### PR TITLE
update the default date filter to today

### DIFF
--- a/demo ecommerce/dashboards/embed_demo_sales.page.aml
+++ b/demo ecommerce/dashboards/embed_demo_sales.page.aml
@@ -315,7 +315,7 @@ ecommerce_users.sign_up_date
     type: 'date'
     default {
       operator: 'matches'
-      value: 'last 2 years'
+      value: 'last 2 years to today'
     }
   }
   block t5: TextBlock {
@@ -672,32 +672,6 @@ ecommerce_users.sign_up_date
         }
       ]
     },
-    FilterInteraction {
-      from: 'f2'
-      to: [
-        CustomMapping {
-          block: [
-            'v3',
-            'v4',
-            'v8',
-            'v12'
-          ]
-          field: ref('ecommerce_users', 'sign_up_date')
-        },
-        CustomMapping {
-          block: [
-            'v5',
-            'v6',
-            'v7'
-          ]
-          field: ref('ecommerce_orders', 'created_at')
-        },
-        CustomMapping {
-          block: 'v11'
-          field: ref('dim_dates', 'date_key')
-        }
-      ]
-    },
     DateDrillInteraction {
       from: 'd1'
       to: [
@@ -721,6 +695,32 @@ ecommerce_users.sign_up_date
         CustomMapping {
           block: 'v8'
           field: ref('ecommerce_users', 'sign_up_date')
+        }
+      ]
+    },
+    FilterInteraction {
+      from: 'f2'
+      to: [
+        CustomMapping {
+          block: [
+            'v3',
+            'v4',
+            'v8',
+            'v12'
+          ]
+          field: ref('ecommerce_users', 'sign_up_date')
+        },
+        CustomMapping {
+          block: [
+            'v5',
+            'v6',
+            'v7'
+          ]
+          field: ref('ecommerce_orders', 'created_at')
+        },
+        CustomMapping {
+          block: 'v11'
+          field: ref('dim_dates', 'date_key')
         }
       ]
     }


### PR DESCRIPTION
## Overview
Update the default date filter for commence dashboards, as the previous filter lacks some data

## Changes
Doesn't change any definition, just update the date filter to add more data (`last 2 years to today`), while the previous filter is `last 2 years` only

## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)