### PR TITLE
Fix dataset label to correct adhoc_dataset_ for clarity

### DIFF
--- a/adhoc/adhoc_dataset.dataset.aml
+++ b/adhoc/adhoc_dataset.dataset.aml
@@ -1,5 +1,5 @@
 Dataset adhoc_dataset {
-  label: 'adhoc_dataset'
+  label: 'adhoc_dataset_'
   data_source_name: 'demodb'
   models: [
     model_d3d33a73_3c8f_4330_9f14_6b5c0194b0e4


### PR DESCRIPTION
## Overview
Corrected the label of the `adhoc_dataset` dataset to `adhoc_dataset_` to improve clarity and prevent potential confusion in dataset identification. This change ensures the dataset label aligns with naming conventions and aids users in distinguishing this dataset within the analytics environment.

## Changes
- Updated label from `'adhoc_dataset'` to `'adhoc_dataset_'` in `adhoc_dataset.dataset.aml` to clarify dataset identity
- No changes to data source, models, or relationships
- No impact on existing metrics or dashboards
- Minor improvement with no breaking changes or migration needed

## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=test_pr_1

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)