### PR TITLE
Replace age with age_group dimension in ecommerce dataset demographics

### DIFF
--- a/01 demo ecommerce/datasets/demo_ecommerce_version_2.dataset.aml
+++ b/01 demo ecommerce/datasets/demo_ecommerce_version_2.dataset.aml
@@ -692,7 +692,7 @@ Note: this can pair with `total_buyers` or `total_users` for a ratio.
           label: 'User demographics'
           fields: [
             r(ecommerce_users.gender),
-            r(ecommerce_users.age),
+            r(ecommerce_users.age_group),
           ]
         }
       }


### PR DESCRIPTION
## Overview
This PR updates the user demographics fields in the `demo_ecommerce_version_2` dataset by replacing the `age` dimension with `age_group`. This change supports better user segmentation aligned with business needs for cohort retention and targeted analysis.

## Changes
- Modified demographics fields in `demo_ecommerce_version_2.dataset.aml`:
  - Removed `ecommerce_users.age` dimension
  - Added `ecommerce_users.age_group` dimension
- This adjustment improves consistency in user age segmentation across analytics
- ... minor formatting and documentation cleanup


## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=vin-branch2

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)