### PR TITLE
Update label of demo ecommerce dataset for 2025 version

### DIFF
--- a/01 demo ecommerce/datasets/demo_ecommerce_version_2.dataset.aml
+++ b/01 demo ecommerce/datasets/demo_ecommerce_version_2.dataset.aml
@@ -21,7 +21,7 @@ const products_detail = [
 ]
 @tag('Endorsed')
 Dataset demo_ecommerce_version_2 {
-  label: '[Demo] Ecommerce Official (2025)'
+  label: 'Ecommerce Dataset (2025)'
   description: '''
 # Dataset Capabilities
 


### PR DESCRIPTION
## Overview
Updated the label of the `demo_ecommerce_version_2` dataset to reflect the 2025 version. This helps clearly distinguish this dataset as the official ecommerce data model for the upcoming year, improving clarity for users exploring or building on top of this dataset.

## Changes
- Changed dataset label from `'[Demo] Ecommerce Official (2025)'` to `'Ecommerce Dataset (2025)'` in `demo_ecommerce_version_2.dataset.aml` to align with naming conventions and remove the demo tag
- No structural or data logic changes introduced
- Minor cosmetic update to improve dataset identification in the platform


## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=vin-branch2

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)