### PR TITLE
Add Simple KPI Dashboard and embed portal

### DIFF
--- a/01 demo ecommerce/dashboards/simple_kpi_dashboard.page.aml
+++ b/01 demo ecommerce/dashboards/simple_kpi_dashboard.page.aml
@@ -1,0 +1,138 @@
+Dashboard simple_kpi_dashboard {
+  title: 'Simple KPI Dashboard'
+  description: 'A simple dashboard with 3 KPI widgets: GMV, Total Revenue, and Total Orders.'
+
+  block kpi_gmv: VizBlock {
+    label: 'GMV'
+    viz: MetricKpi {
+      dataset: demo_ecommerce_version_2
+      value: VizFieldFull {
+        ref: r(demo_ecommerce_version_2.gmv)
+        label: 'GMV'
+        format {
+          type: 'number'
+          pattern: 'inherited'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: r(ecommerce_orders.created_at)
+        show_growth_rate: true
+        value {
+          duration: 1
+          granularity: 'year'
+        }
+      }
+      settings {
+        display_mode: 'compare_by_percent'
+        alignment: 'center'
+        label {
+          font_size: 13
+          font_color: '#6B7280'
+        }
+        metric_value {
+          font_size: 28
+          font_color: '#111827'
+        }
+        compare_value {
+          font_size: 13
+        }
+      }
+    }
+  }
+
+  block kpi_revenue: VizBlock {
+    label: 'Total Revenue'
+    viz: MetricKpi {
+      dataset: demo_ecommerce_version_2
+      value: VizFieldFull {
+        ref: r(demo_ecommerce_version_2.revenue)
+        label: 'Total Revenue'
+        format {
+          type: 'number'
+          pattern: 'inherited'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: r(ecommerce_orders.created_at)
+        show_growth_rate: true
+        value {
+          duration: 1
+          granularity: 'year'
+        }
+      }
+      settings {
+        display_mode: 'compare_by_percent'
+        alignment: 'center'
+        label {
+          font_size: 13
+          font_color: '#6B7280'
+        }
+        metric_value {
+          font_size: 28
+          font_color: '#111827'
+        }
+        compare_value {
+          font_size: 13
+        }
+      }
+    }
+  }
+
+  block kpi_orders: VizBlock {
+    label: 'Total Orders'
+    viz: MetricKpi {
+      dataset: demo_ecommerce_version_2
+      value: VizFieldFull {
+        ref: r(demo_ecommerce_version_2.total_orders)
+        label: 'Total Orders'
+        format {
+          type: 'number'
+          pattern: '#,###'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: r(ecommerce_orders.created_at)
+        show_growth_rate: true
+        value {
+          duration: 1
+          granularity: 'year'
+        }
+      }
+      settings {
+        display_mode: 'compare_by_percent'
+        alignment: 'center'
+        label {
+          font_size: 13
+          font_color: '#6B7280'
+        }
+        metric_value {
+          font_size: 28
+          font_color: '#111827'
+        }
+        compare_value {
+          font_size: 13
+        }
+      }
+    }
+  }
+
+  view: CanvasLayout {
+    label: 'Overview'
+    width: 1440
+    height: 400
+
+    block kpi_gmv {
+      position: pos(0, 0, 466, 140)
+    }
+
+    block kpi_revenue {
+      position: pos(487, 0, 466, 140)
+    }
+
+    block kpi_orders {
+      position: pos(974, 0, 466, 140)
+    }
+  }
+
+  theme: holistics_ant
+}

--- a/01 demo ecommerce/dashboards/simple_kpi_portal.embed.aml
+++ b/01 demo ecommerce/dashboards/simple_kpi_portal.embed.aml
@@ -1,0 +1,9 @@
+EmbedPortal simple_kpi_portal {
+  description: 'Embed portal exposing the Simple KPI Dashboard.'
+  objects: [
+    // Dashboards
+    simple_kpi_dashboard,
+    // Datasets
+    demo_ecommerce_version_2,
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a lightweight KPI dashboard and an embed portal to surface it, both under `01 demo ecommerce/dashboards/`.

- **`simple_kpi_dashboard.page.aml`** — a canvas dashboard with three `MetricKpi` widgets laid out in a single row:
  | Widget | Metric | Comparison |
  |--------|--------|-----------|
  | GMV | `demo_ecommerce_version_2.gmv` | YoY % growth |
  | Total Revenue | `demo_ecommerce_version_2.revenue` | YoY % growth |
  | Total Orders | `demo_ecommerce_version_2.total_orders` | YoY % growth |

  Styling and `MetricKpi` configuration mirror the existing `simple_ecommerce_overview` dashboard for consistency.

- **`simple_kpi_portal.embed.aml`** — an `EmbedPortal` (`simple_kpi_portal`) that exposes the dashboard above together with its underlying `demo_ecommerce_version_2` dataset.

## Validation

`holistics aml validate` on both new files passes for their own syntax. The validator currently reports a **pre-existing, unrelated** failure that cascades from `ecommerce_users.model.aml` referencing a `current_user.pii_access` user attribute that isn't defined in the synced org config. This error exists on `master` independently of these files (reproducible by validating `demo_ecommerce_version_2.dataset.aml` alone) and is out of scope for this change. Both new files will validate cleanly once that user attribute is resolved.

## Notes

Scoped strictly to the two new files — the working tree contained many other unrelated modifications that were intentionally left out of this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)