### PR TITLE
Fix running total metric and label in business users dashboard

### DIFF
--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_advance_board.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_advance_board.block.aml
@@ -1,0 +1,297 @@
+// Groups tab — the Advancement Projector: a brushed-steel magnet board. Each group A–L is a machined
+// lane; the four teams are glossy flag-faced magnet pucks slid along the lane by their Monte-Carlo odds
+// to reach the Round of 32 (position = probability, left = long shot, right = into the knockouts). Tap a
+// puck → a native Popover-API card with that team's full R32→Champion projection (the popover renders in
+// the browser top layer, so it escapes the viz block's overflow:hidden clip). Own bespoke material
+// (brushed steel + magnet discs) — NOT the chalk slate hq_scout uses, NOT the clipboard.
+
+Func wc_advance_board() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Ord'
+          ref: r(wc_teams.group_order)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Grp'
+          ref: r(wc_teams.group_code)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.code)
+        },
+        VizFieldFull {
+          label: 'TeamName'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Color'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'EloRank'
+          ref: r(wc_team_snapshot.elo_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Pct'
+          ref: r(wc_team_snapshot.p_r32_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'R16'
+          ref: r(wc_team_snapshot.p_r16_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'QF'
+          ref: r(wc_team_snapshot.p_qf_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'SF'
+          ref: r(wc_team_snapshot.p_sf_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Fin'
+          ref: r(wc_team_snapshot.p_final_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Chmp'
+          ref: r(wc_team_snapshot.p_champion_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'RunLabel'
+          ref: r(wc_team_snapshot.run_date_label)
+        }
+      ]
+      content: @md
+<style>
+/* THE ADVANCEMENT PROJECTOR — bespoke material: a brushed-steel tactics board bolted to the wall.
+   Twelve machined lanes (groups A–L); each team is a glossy flag-faced magnet puck whose horizontal
+   position IS its odds to reach the Round of 32 (long shot at the rail, locked-in at the gate). Tap a
+   puck for a top-layer Popover card with the full survival ladder. Surface is the only thing bespoke;
+   type uses the SHARED scale (Saira Condensed: eyebrow 10px/700/.2em, 9px engraved, .wc-num tabular). */
+.mb-wrap { width:100%; height:100%; box-sizing:border-box; padding:0;
+  --eng:#e7ecf1; --eng-mut:rgba(220,227,235,.86); --gold:#ffd35c; }
+.mb-plate { position:relative; height:100%; box-sizing:border-box; padding:15px 20px 13px; display:flex;
+  flex-direction:column; border-radius:10px; overflow:hidden;
+  background:
+    linear-gradient(180deg, rgba(255,255,255,.13), rgba(255,255,255,0) 16%, rgba(0,0,0,0) 80%, rgba(0,0,0,.26)),
+    repeating-linear-gradient(0deg, rgba(255,255,255,.035) 0 1px, transparent 1px 3px),
+    linear-gradient(118deg, #6d747c 0%, #494f56 26%, #353a41 52%, #4a5159 74%, #2f343a 100%);
+  box-shadow:0 16px 34px -16px var(--shadow-dir,rgba(0,0,0,.6)), 0 2px 0 rgba(0,0,0,.4),
+    inset 0 1px 0 rgba(255,255,255,.22), inset 0 0 0 1px rgba(0,0,0,.45), inset 0 -3px 10px rgba(0,0,0,.4);
+  animation:mb-plate-in .5s cubic-bezier(.2,.7,.25,1) both; }
+.mb-plate::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:0;
+  background:linear-gradient(108deg, transparent 30%, rgba(255,255,255,.09) 47%, rgba(255,255,255,.02) 53%, transparent 64%); }
+.mb-bolt { position:absolute; width:8px; height:8px; border-radius:50%; z-index:4;
+  background:radial-gradient(circle at 36% 30%, #d6dbe0, #888f96 56%, #4b5258 100%);
+  box-shadow:0 1px 2px rgba(0,0,0,.55), inset 0 0 0 1px rgba(0,0,0,.3); }
+.mb-bolt.tl { top:9px; left:9px; } .mb-bolt.tr { top:9px; right:9px; }
+.mb-bolt.bl { bottom:9px; left:9px; } .mb-bolt.br { bottom:9px; right:9px; }
+/* header */
+.mb-head { position:relative; z-index:2; display:flex; align-items:flex-end; justify-content:space-between;
+  gap:14px; padding:0 4px 10px; margin-bottom:9px; border-bottom:1px solid rgba(0,0,0,.4);
+  box-shadow:0 1px 0 rgba(255,255,255,.1); }
+.mb-tt { display:flex; flex-direction:column; gap:3px; }
+.mb-eye { font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.2em;
+  text-transform:uppercase; color:var(--eng-mut); }
+.mb-eye b { color:var(--gold,#f2c84b); font-weight:700; }
+.mb-title { font-family:var(--font-disp); font-weight:800; font-size:19px; line-height:1; letter-spacing:.02em;
+  text-transform:uppercase; color:var(--eng); text-shadow:0 1px 0 rgba(0,0,0,.55), 0 -1px 0 rgba(255,255,255,.12); }
+.mb-sub { text-align:right; font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.06em;
+  text-transform:uppercase; color:var(--eng-mut); max-width:380px; line-height:1.5; }
+.mb-sub b { color:var(--eng); font-weight:800; }
+/* lanes region (scaffold + pucks share inset math) */
+.mb-lanes { position:relative; z-index:1; flex:1; min-height:0; }
+.mb-scaffold { position:absolute; inset:0; display:flex; flex-direction:column; }
+.mb-lane { flex:1; min-height:0; position:relative; display:flex; align-items:center; }
+.mb-lane + .mb-lane { border-top:1px solid rgba(0,0,0,.32); box-shadow:0 -1px 0 rgba(255,255,255,.05); }
+.mb-rail { width:56px; flex:none; display:flex; align-items:center; justify-content:center; align-self:stretch;
+  background:linear-gradient(118deg, rgba(0,0,0,.22), rgba(0,0,0,.05)); box-shadow:inset -1px 0 0 rgba(0,0,0,.35), inset 1px 0 0 rgba(255,255,255,.06); }
+.mb-grp { font-family:var(--font-disp); font-weight:800; font-size:17px; letter-spacing:.04em; color:var(--eng);
+  text-shadow:0 1px 0 rgba(255,255,255,.14), 0 -1px 1px rgba(0,0,0,.6); }
+.mb-track { position:relative; flex:1; align-self:center; height:11px; margin:0 14px 0 13px; border-radius:6px;
+  background:
+    linear-gradient(90deg, rgba(220,48,26,.62), rgba(216,150,26,.3) 50%, rgba(30,196,98,.66)),
+    linear-gradient(180deg, rgba(0,0,0,.34), rgba(0,0,0,.04) 45%, rgba(255,255,255,.08));
+  box-shadow:inset 0 1px 3px rgba(0,0,0,.5), inset 0 -1px 0 rgba(255,255,255,.08); }
+.mb-gate { width:44px; flex:none; align-self:stretch; position:relative; display:flex; align-items:center; justify-content:center;
+  background:linear-gradient(118deg, rgba(0,0,0,.32), rgba(0,0,0,.1)); box-shadow:inset 1px 0 0 rgba(0,0,0,.4), inset -1px 0 0 rgba(255,255,255,.05); }
+.mb-gate .net { width:19px; height:19px; color:rgba(242,200,75,.72); line-height:0; }
+.mb-grid { position:absolute; top:6px; bottom:6px; left:69px; right:58px; pointer-events:none; }
+.mb-grid i { position:absolute; top:0; bottom:0; width:1px; background:rgba(255,255,255,.06); box-shadow:1px 0 0 rgba(0,0,0,.18); }
+.mb-grid i.g25 { left:25%; } .mb-grid i.g50 { left:50%; } .mb-grid i.g75 { left:75%; }
+/* pucks overlay — left/right insets match rail(56)+margin(13) and gate(44)+margin(14) */
+.mb-pucks { position:absolute; top:0; bottom:0; left:69px; right:58px; }
+.mb-puck { appearance:none; -webkit-appearance:none; border:none; background:none; padding:0; margin:0; font:inherit;
+  position:absolute; transform:translate(-50%,-50%); width:30px; height:30px; cursor:pointer;
+  animation:mb-snap .55s cubic-bezier(.34,1.4,.5,1) both; }
+.mb-disc { position:relative; width:100%; height:100%; border-radius:50%; overflow:hidden; display:block;
+  box-shadow:0 3px 5px -1px rgba(0,0,0,.55), inset 0 0 0 1.5px rgba(0,0,0,.4), 0 0 0 1px rgba(255,255,255,.08); }
+.mb-flag { width:100%; height:100%; object-fit:cover; display:block; }
+/* glossy dome over the flag — keeps the magnet read */
+.mb-disc::after { content:""; position:absolute; inset:0; border-radius:50%; pointer-events:none;
+  background:
+    radial-gradient(circle at 33% 24%, rgba(255,255,255,.6), rgba(255,255,255,0) 44%),
+    radial-gradient(circle at 50% 128%, rgba(0,0,0,.5), rgba(0,0,0,0) 58%);
+  box-shadow:inset 0 1px 1px rgba(255,255,255,.45), inset 0 -3px 5px rgba(0,0,0,.3); }
+.mb-puck:hover { z-index:9; }
+.mb-puck:hover .mb-disc { transform:scale(1.18);
+  box-shadow:0 6px 11px -2px rgba(0,0,0,.6), inset 0 0 0 1.5px rgba(0,0,0,.4), 0 0 0 3px rgba(242,200,75,.5); }
+.mb-disc { transition:transform .16s ease, box-shadow .16s ease; }
+/* ── the Popover-API projection card (top layer, escapes the block's overflow clip) ── */
+.mb-pop { margin:auto; border:none; padding:0; overflow:visible; width:288px;
+  background:
+    repeating-linear-gradient(0deg, rgba(255,255,255,.03) 0 1px, transparent 1px 3px),
+    linear-gradient(150deg, #2b3037, #1a1e23 70%);
+  color:var(--eng); border-radius:11px;
+  box-shadow:0 24px 60px -14px rgba(0,0,0,.7), inset 0 1px 0 rgba(255,255,255,.16), inset 0 0 0 1px rgba(0,0,0,.6); }
+.mb-pop::backdrop { background:rgba(8,11,15,.5); }
+/* anchor the card to the puck that opened it (falls back to viewport-centred where unsupported) */
+@supports (anchor-name: --a) {
+  .mb-pop { margin:7px; inset:auto; position-area:top; position-try-fallbacks:flip-block, flip-inline, flip-block flip-inline; }
+}
+.mb-pop:popover-open { animation:mb-pop-in .22s cubic-bezier(.2,.7,.25,1) both; }
+.pop-in { padding:17px 19px 18px; }
+.pop-h { display:flex; align-items:center; gap:13px; padding-bottom:13px; margin-bottom:13px;
+  border-bottom:1px solid rgba(255,255,255,.1); }
+.pop-disc { position:relative; width:56px; height:38px; flex:none; border-radius:3px; overflow:hidden;
+  box-shadow:0 2px 5px rgba(0,0,0,.5), inset 0 0 0 1px rgba(0,0,0,.5), inset 0 0 0 2px rgba(255,255,255,.1); }
+.pop-disc img { width:100%; height:100%; object-fit:cover; display:block; }
+.pop-disc::after { content:""; position:absolute; inset:0; border-radius:3px; pointer-events:none;
+  background:linear-gradient(180deg, rgba(255,255,255,.22), rgba(255,255,255,0) 42%); }
+.pop-id { display:flex; flex-direction:column; gap:3px; min-width:0; }
+.pop-nm { font-family:var(--font-disp); font-weight:800; font-size:20px; line-height:1; letter-spacing:.01em;
+  text-transform:uppercase; color:#fff; }
+.pop-mt { font-family:var(--font-disp); font-weight:700; font-size:10.5px; letter-spacing:.1em; text-transform:uppercase;
+  color:var(--eng-mut); }
+.pop-sub { font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.08em; text-transform:uppercase;
+  color:var(--eng-mut); margin-bottom:11px; }
+.pop-rl { display:flex; gap:7px; align-items:flex-end; }
+.pop-seg { flex:1; display:flex; flex-direction:column; align-items:center; gap:6px; }
+.pop-seg b { font-family:var(--font-disp); font-weight:800; font-size:13px; color:var(--eng); font-variant-numeric:tabular-nums; }
+.pop-bar { width:11px; height:56px; border-radius:3px; position:relative; overflow:hidden;
+  background:rgba(0,0,0,.4); box-shadow:inset 0 1px 2px rgba(0,0,0,.5); }
+.pop-bar i { position:absolute; left:0; right:0; bottom:0; border-radius:3px;
+  background:linear-gradient(180deg, var(--eng), rgba(205,211,218,.55)); }
+.pop-seg u { font-family:var(--font-disp); font-weight:700; font-size:9.5px; letter-spacing:.06em; text-transform:uppercase;
+  color:var(--eng-mut); text-decoration:none; }
+.pop-seg.win b { color:var(--gold,#f2c84b); }
+.pop-seg.win .pop-bar i { background:linear-gradient(180deg, #f6d978, var(--gold,#f2c84b)); box-shadow:0 0 6px rgba(242,200,75,.5); }
+.pop-seg.win u { color:var(--gold,#f2c84b); }
+/* footer / legend */
+.mb-foot { position:relative; z-index:2; display:flex; align-items:center; justify-content:space-between;
+  gap:14px; margin-top:9px; padding:8px 4px 0; border-top:1px solid rgba(0,0,0,.4); box-shadow:0 -1px 0 rgba(255,255,255,.08);
+  font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.1em; text-transform:uppercase; color:var(--eng-mut); }
+.mb-scale { display:flex; align-items:center; gap:8px; }
+.mb-scale .bar { width:120px; height:5px; border-radius:3px;
+  background:linear-gradient(90deg, rgba(220,48,26,.95), rgba(216,150,26,.85) 50%, rgba(30,196,98,1));
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.3); }
+.mb-foot .sp { color:var(--eng-mut); }
+.mb-foot b { color:var(--eng); font-weight:800; }
+/* motion: the plate drops in, then each lane's magnets snap to the board */
+@keyframes mb-plate-in { from { opacity:0; transform:translateY(13px); } to { opacity:1; transform:none; } }
+@keyframes mb-snap { 0% { opacity:0; transform:translate(calc(-50% - 46px), -50%) scale(.45); }
+  70% { opacity:1; } 100% { opacity:1; transform:translate(-50%, -50%) scale(1); } }
+@keyframes mb-pop-in { from { opacity:0; transform:translateY(8px) scale(.96); } to { opacity:1; transform:none; } }
+@media (prefers-reduced-motion: reduce) {
+  .mb-plate { animation:none !important; opacity:1 !important; transform:none !important; }
+  .mb-puck { animation:none !important; opacity:1 !important; transform:translate(-50%,-50%) !important; }
+  .mb-pop:popover-open { animation:none !important; } }
+</style>
+<div class="mb-wrap">
+<div class="mb-plate">
+<span class="mb-bolt tl"></span><span class="mb-bolt tr"></span><span class="mb-bolt bl"></span><span class="mb-bolt br"></span>
+<div class="mb-head">
+<div class="mb-tt">
+<div class="mb-eye">The advancement <b>projector</b></div>
+<div class="mb-title">Road to the Round of 32</div>
+</div>
+<div class="mb-sub">Each magnet's position = its odds to escape the group<br>Tap a flag for the full projection<br>Elo&rarr;Monte Carlo &middot; 10k sims &middot; run <b>{{ rows[0].`RunLabel`.formatted }}</b></div>
+</div>
+<div class="mb-lanes">
+<div class="mb-scaffold">
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">A</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">B</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">C</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">D</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">E</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">F</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">G</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">H</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">I</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">J</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">K</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+<div class="mb-lane"><span class="mb-rail"><span class="mb-grp">L</span></span><span class="mb-track"></span><span class="mb-gate"><span class="net"><svg viewBox="0 0 24 24" style="margin:0 !important;display:block"><g fill="currentColor"><rect x="4" y="3" width="1.7" height="18" rx=".85"/><rect x="6.6" y="4.2" width="3" height="3"/><rect x="12.6" y="4.2" width="3" height="3"/><rect x="9.6" y="7.2" width="3" height="3"/><rect x="15.6" y="7.2" width="3" height="3"/><rect x="6.6" y="10.2" width="3" height="3"/><rect x="12.6" y="10.2" width="3" height="3"/></g><rect x="6.6" y="4.2" width="12" height="9" fill="none" stroke="currentColor" stroke-width="1" opacity=".55"/></svg></span></span></div>
+</div>
+<div class="mb-grid"><i class="g25"></i><i class="g50"></i><i class="g75"></i></div>
+<div class="mb-pucks">
+{% map(rows) %}
+<button class="mb-puck" type="button" popovertarget="pop-{{ `Team`.raw }}" title="{{ `TeamName`.formatted }} — tap for projection" style="top:calc(({{ `Ord`.raw }} - 0.5) * 8.3333%); left:calc({{ `Pct`.raw }} * 1%); animation-delay:calc({{ `Ord`.raw }} * 0.045s); anchor-name:--mb-{{ `Team`.raw }};"><span class="mb-disc"><img class="mb-flag" src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" /></span></button>
+<div id="pop-{{ `Team`.raw }}" popover class="mb-pop" style="position-anchor:--mb-{{ `Team`.raw }};"><div class="pop-in"><div class="pop-h"><span class="pop-disc"><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" /></span><span class="pop-id"><span class="pop-nm">{{ `TeamName`.formatted }}</span><span class="pop-mt">Group {{ `Grp`.formatted }} &middot; Elo #{{ `EloRank`.formatted }} of 48</span></span></div><div class="pop-sub">Chance of reaching each round</div><div class="pop-rl"><span class="pop-seg"><b class="wc-num">{{ `Pct`.formatted }}</b><span class="pop-bar"><i style="height:calc({{ `Pct`.raw }} * 1%)"></i></span><u>R32</u></span><span class="pop-seg"><b class="wc-num">{{ `R16`.formatted }}</b><span class="pop-bar"><i style="height:calc({{ `R16`.raw }} * 1%)"></i></span><u>R16</u></span><span class="pop-seg"><b class="wc-num">{{ `QF`.formatted }}</b><span class="pop-bar"><i style="height:calc({{ `QF`.raw }} * 1%)"></i></span><u>QF</u></span><span class="pop-seg"><b class="wc-num">{{ `SF`.formatted }}</b><span class="pop-bar"><i style="height:calc({{ `SF`.raw }} * 1%)"></i></span><u>SF</u></span><span class="pop-seg"><b class="wc-num">{{ `Fin`.formatted }}</b><span class="pop-bar"><i style="height:calc({{ `Fin`.raw }} * 1%)"></i></span><u>FIN</u></span><span class="pop-seg win"><b class="wc-num">{{ `Chmp`.formatted }}</b><span class="pop-bar"><i style="height:calc({{ `Chmp`.raw }} * 1%)"></i></span><u>CUP</u></span></div></div></div>
+{% end %}
+</div>
+</div>
+<div class="mb-foot">
+<span class="mb-scale">Long shot<span class="bar"></span>Into the knockouts</span>
+<span class="sp">Top 2 of each group + 8 best thirds advance &middot; <b>32</b> reach the Round of 32</span>
+</div>
+</div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'Ord'
+            direction: 'asc'
+          },
+          SortSetting {
+            key: 'Pct'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 48
+        row_limit: 48
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_contenders.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_contenders.block.aml
@@ -1,0 +1,355 @@
+// Contender Index tab blocks.
+
+Func wc_ci_zone() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">The contender index · who's actually good</p>
+;;
+  }
+}
+
+Func wc_ci_board() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'OddsRank'
+          ref: r(wc_contender_board.odds_rank)
+          uname: 'orank'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Grp'
+          ref: r(wc_teams.group_code)
+        },
+        VizFieldFull {
+          label: 'Spark'
+          ref: r(wc_contender_board.spark_points)
+        },
+        VizFieldFull {
+          label: 'Elo'
+          ref: r(wc_contender_board.elo)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'EloRank'
+          ref: r(wc_contender_board.elo_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'D30'
+          ref: r(wc_contender_board.d30_label)
+        },
+        VizFieldFull {
+          label: 'D30Color'
+          ref: r(wc_contender_board.d30_color)
+        },
+        VizFieldFull {
+          label: 'OddsPct'
+          ref: r(wc_contender_board.p_champion_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'DChamp'
+          ref: r(wc_contender_board.d_champ_label)
+        },
+        VizFieldFull {
+          label: 'DChampColor'
+          ref: r(wc_contender_board.d_champ_color)
+        },
+        VizFieldFull {
+          label: 'RunLabel'
+          ref: r(wc_contender_board.run_label)
+        }
+      ]
+      content: @md
+<style>
+.chk { width:100%; height:100%; box-sizing:border-box; border-radius:7px; padding:12px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0,0,0,.08) 0 2px, transparent 2px 11px),
+    linear-gradient(180deg,#9a6b3c,#7c5026 60%,#6b431f);
+  box-shadow:0 18px 30px -16px rgba(4,18,11,.55), 0 2px 0 rgba(0,0,0,.25), inset 0 1px 0 rgba(255,255,255,.35); }
+.chk-slate { height:100%; box-sizing:border-box; border-radius:3px; padding:16px 18px;
+  display:flex; flex-direction:column;
+  background:
+    radial-gradient(120% 90% at 28% 8%, rgba(255,255,255,.05), transparent 60%),
+    linear-gradient(180deg,#1d3027,#152620);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.07), inset 0 0 30px rgba(0,0,0,.45); }
+.chk-head { display:flex; justify-content:space-between; align-items:baseline; gap:10px;
+  padding-bottom:9px; margin-bottom:9px; border-bottom:1px dashed rgba(238,244,238,.3); }
+.chk-t { font-family:var(--font-disp); font-weight:800; font-size:16px; letter-spacing:.16em;
+  text-transform:uppercase; color:#eef4ee; text-shadow:0 0 1px rgba(255,255,255,.5); }
+.chk-t b { color:var(--gold-2); }
+.chk-s { font-size:10px; color:rgba(238,244,238,.55); letter-spacing:.04em; white-space:nowrap; }
+.cib-row { display:grid; grid-template-columns:26px 30px minmax(0,1fr) 200px 96px 104px;
+  gap:14px; align-items:center; padding:5px 2px; }
+.cib-row + .cib-row { border-top:1px solid rgba(238,244,238,.1); }
+.cib-rk { font-family:var(--font-disp); font-weight:800; font-size:16px; color:rgba(238,244,238,.6); text-align:center; }
+.cib-row:first-of-type .cib-rk { color:var(--gold-2); }
+.chk .cib-row img { width:26px !important; height:18px !important; border-radius:2px !important;
+  margin:0 !important; display:block !important; object-fit:cover; box-shadow:0 1px 3px rgba(0,0,0,.5); }
+.cib-nm { min-width:0; }
+.cib-nm .n { display:block; font-family:var(--font-disp); font-weight:700; font-size:14px; letter-spacing:.04em;
+  text-transform:uppercase; color:#eef4ee; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.cib-nm .g { display:block; font-size:8.5px; text-transform:uppercase; letter-spacing:.14em;
+  color:rgba(238,244,238,.45); margin-top:2px; }
+.cib-spark { width:200px; height:30px; display:block; margin:0 !important; }
+.cib-spark polyline { fill:none; stroke:rgba(238,244,238,.8); stroke-width:1.6; vector-effect:non-scaling-stroke;
+  stroke-linejoin:round; stroke-linecap:round; }
+.cib-cell { text-align:right; line-height:1; }
+.cib-cell .v { display:block; font-family:var(--font-disp); font-weight:800; font-size:16px; color:#eef4ee;
+  font-variant-numeric:tabular-nums; white-space:nowrap; }
+.cib-cell .v b { font-size:.6em; font-weight:700; color:rgba(238,244,238,.5); }
+.cib-cell.gold .v { color:var(--gold-2); text-shadow:0 0 8px rgba(242,200,75,.3); }
+.cib-cell .d { display:block; font-family:var(--font-disp); font-weight:700; font-size:10px;
+  margin-top:3px; white-space:nowrap; }
+.cib-cell .d:empty { display:none; }
+.cib-cell .bl { display:block; font-size:8.5px; color:rgba(238,244,238,.4); letter-spacing:.06em;
+  margin-top:3px; white-space:nowrap; }
+.chk-foot { margin-top:auto; padding-top:9px; border-top:1px dashed rgba(238,244,238,.2);
+  display:flex; justify-content:space-between; gap:10px; font-size:9px; text-transform:uppercase;
+  letter-spacing:.09em; color:rgba(238,244,238,.45); }
+/* the big board deals in (sparklines + rows arrive with it); wc-deal-in keyframe from header_rail */
+.chk-slate { animation:wc-deal-in .5s cubic-bezier(.2,.7,.3,1) backwards; }
+/* each contender's 24-month chalk curve draws itself in, staggered down the board
+   (rows are :nth-child 2..11 — child 1 is .chk-head). dasharray 600 > any path length. */
+.cib-spark polyline { stroke-dasharray:600; animation:spark-draw .9s ease-out .5s both; }
+@keyframes spark-draw { from { stroke-dashoffset:600; } to { stroke-dashoffset:0; } }
+.cib-row:nth-child(2) .cib-spark polyline{animation-delay:.50s} .cib-row:nth-child(3) .cib-spark polyline{animation-delay:.56s}
+.cib-row:nth-child(4) .cib-spark polyline{animation-delay:.62s} .cib-row:nth-child(5) .cib-spark polyline{animation-delay:.68s}
+.cib-row:nth-child(6) .cib-spark polyline{animation-delay:.74s} .cib-row:nth-child(7) .cib-spark polyline{animation-delay:.80s}
+.cib-row:nth-child(8) .cib-spark polyline{animation-delay:.86s} .cib-row:nth-child(9) .cib-spark polyline{animation-delay:.92s}
+.cib-row:nth-child(10) .cib-spark polyline{animation-delay:.98s} .cib-row:nth-child(11) .cib-spark polyline{animation-delay:1.04s}
+@media (prefers-reduced-motion: reduce) {
+  .chk-slate { animation:none !important; opacity:1 !important; transform:none !important; }
+  .cib-spark polyline { animation:none !important; stroke-dashoffset:0 !important; } }
+</style>
+<div class="chk"><div class="chk-slate">
+  <div class="chk-head">
+    <span class="chk-t">The big <b>board</b></span>
+    <span class="chk-s">Top 10 by title odds · {{ rows[0].`RunLabel`.formatted }} · field average 2.1%</span>
+  </div>
+{% map(rows) %}
+  <div class="cib-row">
+    <span class="cib-rk wc-num">{{ `OddsRank`.formatted }}</span>
+    <img src="{{ `Flag`.raw }}" alt="" />
+    <span class="cib-nm"><span class="n">{{ `Team`.formatted }}</span><span class="g">Group {{ `Grp`.formatted }}</span></span>
+    <svg class="cib-spark" viewBox="0 0 100 30" preserveAspectRatio="none" style="margin:0 !important;" aria-hidden="true"><polyline points="{{ `Spark`.raw }}" /></svg>
+    <span class="cib-cell"><span class="v wc-num">{{ `Elo`.formatted }}</span><span class="d wc-num" style="color:{{ `D30Color`.raw }};">{{ `D30`.formatted }}</span><span class="bl wc-num">#{{ `EloRank`.formatted }} by Elo</span></span>
+    <span class="cib-cell gold"><span class="v wc-num">{{ `OddsPct`.formatted }}<b>%</b></span><span class="d wc-num" style="color:{{ `DChampColor`.raw }};">{{ `DChamp`.formatted }}</span><span class="bl">title odds</span></span>
+  </div>
+{% end %}
+  <div class="chk-foot">
+    <span>Chalk curve = 24 months of Elo · same scale per pixel, centred per team</span>
+    <span>Δ vs 30 days ago · odds Δ day-over-day</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'orank'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 10
+        row_limit: 10
+      }
+    }
+  }
+}
+
+Func wc_ci_ladder() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_contender_board.odds_rank)
+        operator: 'less_than'
+        value: 7
+      }
+      rows: [
+        VizFieldFull {
+          label: 'OddsRank'
+          ref: r(wc_contender_board.odds_rank)
+          uname: 'lrank'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'W'
+          ref: r(wc_contender_board.p_champion_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'F'
+          ref: r(wc_contender_board.p_final_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'SF'
+          ref: r(wc_contender_board.p_sf_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'QF'
+          ref: r(wc_contender_board.p_qf_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'R16'
+          ref: r(wc_contender_board.p_r16_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'R32'
+          ref: r(wc_contender_board.p_r32_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md
+<style>
+.chk2 { width:100%; height:100%; box-sizing:border-box; border-radius:7px; padding:12px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0,0,0,.08) 0 2px, transparent 2px 11px),
+    linear-gradient(180deg,#9a6b3c,#7c5026 60%,#6b431f);
+  box-shadow:0 18px 30px -16px rgba(4,18,11,.55), 0 2px 0 rgba(0,0,0,.25), inset 0 1px 0 rgba(255,255,255,.35); }
+.chk2-slate { height:100%; box-sizing:border-box; border-radius:3px; padding:16px 18px;
+  display:flex; flex-direction:column;
+  background:
+    radial-gradient(120% 90% at 28% 8%, rgba(255,255,255,.05), transparent 60%),
+    linear-gradient(180deg,#1d3027,#152620);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.07), inset 0 0 30px rgba(0,0,0,.45); }
+.chk2-head { display:flex; justify-content:space-between; align-items:baseline; gap:10px;
+  padding-bottom:9px; margin-bottom:10px; border-bottom:1px dashed rgba(238,244,238,.3); }
+.chk2-t { font-family:var(--font-disp); font-weight:800; font-size:16px; letter-spacing:.16em;
+  text-transform:uppercase; color:#eef4ee; text-shadow:0 0 1px rgba(255,255,255,.5); }
+.chk2-t b { color:var(--gold-2); }
+.chk2-s { font-size:10px; color:rgba(238,244,238,.55); letter-spacing:.04em; white-space:nowrap; }
+.lad { padding:4px 0 6px; }
+.lad + .lad { border-top:1px solid rgba(238,244,238,.1); }
+.lad-hd { display:flex; align-items:center; gap:8px; margin-bottom:4px; }
+.chk2 .lad-hd img { width:22px !important; height:15px !important; border-radius:2px !important;
+  margin:0 !important; display:block !important; object-fit:cover; box-shadow:0 1px 3px rgba(0,0,0,.5); }
+.lad-hd .n { font-family:var(--font-disp); font-weight:700; font-size:13px; letter-spacing:.05em;
+  text-transform:uppercase; color:#eef4ee; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.lad-hd .w { margin-left:auto; font-family:var(--font-disp); font-weight:800; font-size:14px;
+  color:var(--gold-2); white-space:nowrap; }
+.lad-hd .w small { font-size:.65em; color:rgba(238,244,238,.5); font-weight:700; letter-spacing:.08em; }
+.lad-cols { display:flex; gap:8px; align-items:flex-end; }
+.lad-col { flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; min-width:0; }
+.lad-bar { width:100%; height:36px; display:flex; align-items:flex-end; border-radius:2px;
+  background:rgba(238,244,238,.06); box-shadow:inset 0 0 0 1px rgba(238,244,238,.07); }
+.lad-bar i { display:block; width:100%; border-radius:2px 2px 0 0; background:rgba(238,244,238,.55); }
+.lad-col.win .lad-bar i { background:linear-gradient(180deg, var(--gold-2), var(--gold));
+  box-shadow:0 0 8px rgba(242,200,75,.4); }
+.lad-col .pv { font-family:var(--font-disp); font-weight:800; font-size:10.5px; color:#eef4ee;
+  font-variant-numeric:tabular-nums; }
+.lad-col.win .pv { color:var(--gold-2); }
+.lad-col .pl { font-size:8px; text-transform:uppercase; letter-spacing:.1em; color:rgba(238,244,238,.45); }
+.chk2-foot { margin-top:auto; padding-top:9px; border-top:1px dashed rgba(238,244,238,.2);
+  display:flex; justify-content:space-between; gap:10px; font-size:9px; text-transform:uppercase;
+  letter-spacing:.09em; color:rgba(238,244,238,.45); }
+/* the advance ladder deals in, then each stage's bar grows up (R32→Win) */
+.chk2-slate { animation:wc-deal-in .5s cubic-bezier(.2,.7,.3,1) backwards; }
+.lad-bar i { transform-origin:bottom; animation:bar-rise .55s cubic-bezier(.2,.7,.3,1.05) backwards; }
+@keyframes bar-rise { from { transform:scaleY(0); } to { transform:scaleY(1); } }
+.lad-col:nth-child(1) .lad-bar i{animation-delay:.30s} .lad-col:nth-child(2) .lad-bar i{animation-delay:.37s}
+.lad-col:nth-child(3) .lad-bar i{animation-delay:.44s} .lad-col:nth-child(4) .lad-bar i{animation-delay:.51s}
+.lad-col:nth-child(5) .lad-bar i{animation-delay:.58s} .lad-col:nth-child(6) .lad-bar i{animation-delay:.65s}
+@media (prefers-reduced-motion: reduce) {
+  .chk2-slate, .lad-bar i { animation:none !important; opacity:1 !important; transform:none !important; } }
+</style>
+<div class="chk2"><div class="chk2-slate">
+  <div class="chk2-head">
+    <span class="chk2-t">Road <b>survival</b></span>
+    <span class="chk2-s">P(reach stage) · top 6 contenders</span>
+  </div>
+{% map(rows) %}
+  <div class="lad">
+    <div class="lad-hd"><img src="{{ `Flag`.raw }}" alt="" /><span class="n">{{ `Team`.formatted }}</span><span class="w wc-num">{{ `W`.formatted }}% <small>TITLE</small></span></div>
+    <div class="lad-cols">
+      <div class="lad-col"><div class="lad-bar"><i style="height:{{ `R32`.raw }}%;"></i></div><span class="pv wc-num">{{ `R32`.formatted }}</span><span class="pl">R32</span></div>
+      <div class="lad-col"><div class="lad-bar"><i style="height:{{ `R16`.raw }}%;"></i></div><span class="pv wc-num">{{ `R16`.formatted }}</span><span class="pl">R16</span></div>
+      <div class="lad-col"><div class="lad-bar"><i style="height:{{ `QF`.raw }}%;"></i></div><span class="pv wc-num">{{ `QF`.formatted }}</span><span class="pl">QF</span></div>
+      <div class="lad-col"><div class="lad-bar"><i style="height:{{ `SF`.raw }}%;"></i></div><span class="pv wc-num">{{ `SF`.formatted }}</span><span class="pl">SF</span></div>
+      <div class="lad-col"><div class="lad-bar"><i style="height:{{ `F`.raw }}%;"></i></div><span class="pv wc-num">{{ `F`.formatted }}</span><span class="pl">Final</span></div>
+      <div class="lad-col win"><div class="lad-bar"><i style="height:{{ `W`.raw }}%;"></i></div><span class="pv wc-num">{{ `W`.formatted }}</span><span class="pl">Win</span></div>
+    </div>
+  </div>
+{% end %}
+  <div class="chk2-foot">
+    <span>Every column starts from the group stage</span>
+    <span>Gold = lift the trophy</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'lrank'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 6
+        row_limit: 6
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_group_card.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_group_card.block.aml
@@ -1,0 +1,148 @@
+// Group-stage standings clipboard card. One per group A–L on the Groups tab.
+// Param `grp` drives the standings filter + the "Group X" heading; everything else is identical.
+// Styling/keyframes live in the theme + header_rail block (renders on every tab).
+Func wc_group_card(grp: String) {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_group_standings.group_code)
+        operator: 'is'
+        value: grp
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Rank'
+          ref: r(wc_group_standings.rank)
+          uname: 'rank'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_group_standings.team_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'P'
+          ref: r(wc_group_standings.played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'W'
+          ref: r(wc_group_standings.won)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'D'
+          ref: r(wc_group_standings.drawn)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'L'
+          ref: r(wc_group_standings.lost)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GF'
+          ref: r(wc_group_standings.gf)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GA'
+          ref: r(wc_group_standings.ga)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GD'
+          ref: r(wc_group_standings.gd)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Pts'
+          ref: r(wc_group_standings.pts)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'QualColor'
+          ref: r(wc_group_standings.qual_color)
+        },
+        VizFieldFull {
+          label: 'QualStatus'
+          ref: r(wc_group_standings.qual_status)
+        }
+      ]
+      content: @md
+<div class="cb-wrap"><div class="clipboard cb-x">
+  <div class="cb-head">
+    <span class="cb-grp">Group <b>${grp}</b></span>
+    <span class="cb-sub">Group stage · matchday 1</span>
+  </div>
+  <div class="cb-colhead"><span class="c">#</span><span></span><span>Team</span><span class="c">P</span><span class="c">W</span><span class="c">D</span><span class="c">L</span><span class="c">GF</span><span class="c">GA</span><span class="c">GD</span><span class="c">Pts</span></div>
+{% map(rows) %}
+  <div class="cb-row" style="border-left-color:{{ `QualColor`.raw }};">
+    <span class="cb-rank">{{ `Rank`.formatted }}</span>
+    <img src="{{ `Flag`.raw }}" alt="" />
+    <span class="cb-name" title="{{ `QualStatus`.formatted }}">{{ `Team`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `P`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `W`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `D`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `L`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `GF`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `GA`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `GD`.formatted }}</span>
+    <span class="cb-pts wc-num">{{ `Pts`.formatted }}</span>
+  </div>
+{% end %}
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--qual-adv);"></span>Advance</span>
+    <span class="lg"><span class="dot" style="background:var(--qual-po);"></span>Best-third race</span>
+    <span class="lg"><span class="dot" style="background:var(--qual-out);"></span>Out</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'rank'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 4
+        row_limit: 4
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_groups.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_groups.block.aml
@@ -1,0 +1,150 @@
+// Groups tab furniture (zone labels + best-third board). Group cards = wc_group_card.
+
+Func wc_groups_zone_label() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">Group stage ledger · groups A–L</p>
+;;
+  }
+}
+
+Func wc_advance_zone_label() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">The advancement projector · 48 chase 32 places</p>
+;;
+  }
+}
+
+Func wc_thirds_zone_label() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">The best-thirds race · 8 cross the line</p>
+;;
+  }
+}
+
+Func wc_third_place_board() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Rank'
+          ref: r(wc_third_place_ranking.overall_rank)
+          uname: 'orank'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Grp'
+          ref: r(wc_third_place_ranking.group_code)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_third_place_ranking.team_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'P'
+          ref: r(wc_third_place_ranking.played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GF'
+          ref: r(wc_third_place_ranking.gf)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GD'
+          ref: r(wc_third_place_ranking.gd)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Pts'
+          ref: r(wc_third_place_ranking.pts)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'QualColor'
+          ref: r(wc_third_place_ranking.qual_color)
+        },
+        VizFieldFull {
+          label: 'QualStatus'
+          ref: r(wc_third_place_ranking.qual_status)
+        }
+      ]
+      content: @md
+<div class="cb-wrap"><div class="clipboard cb-tp">
+  <div class="cb-head">
+    <span class="cb-grp">Best <b>thirds</b></span>
+    <span class="cb-sub">Top 8 of 12 advance · Round of 32</span>
+  </div>
+  <div class="cb-colhead"><span class="c">#</span><span class="c">Grp</span><span></span><span>Team</span><span class="c">P</span><span class="c">GF</span><span class="c">GD</span><span class="c">Pts</span><span class="e">Status</span></div>
+  <div class="tp-body">
+{% map(rows) %}
+  <div class="cb-row" style="border-left-color:{{ `QualColor`.raw }};">
+    <span class="cb-rank">{{ `Rank`.formatted }}</span>
+    <span class="tp-grp">{{ `Grp`.formatted }}</span>
+    <img src="{{ `Flag`.raw }}" alt="" />
+    <span class="cb-name">{{ `Team`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `P`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `GF`.formatted }}</span>
+    <span class="cb-n wc-num">{{ `GD`.formatted }}</span>
+    <span class="cb-pts wc-num">{{ `Pts`.formatted }}</span>
+    <span class="tp-st" style="color:{{ `QualColor`.raw }};">{{ `QualStatus`.formatted }}</span>
+  </div>
+{% end %}
+  </div>
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--qual-adv);"></span>In the 8 — advances</span>
+    <span class="lg"><span class="dot" style="background:var(--qual-out);"></span>Below the line</span>
+    <span class="sp">Ranked by Pts, GD, GF across groups</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'orank'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 12
+        row_limit: 12
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_header_rail.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_header_rail.block.aml
@@ -1,0 +1,432 @@
+// ⚠ GLOBAL STYLE HOST — do not split.
+// header_rail renders on EVERY tab, so its <style> is the home for all shared @keyframes
+// (wc-pulse / wc-deal-in / wc-power-on / wc-meter-fill / wc-trophy-glow / wc-pennant-wave /
+// wc-tie-glow) AND cross-tab animation rules (.clipboard, .tie, .wc-pitch .pen, .goal …).
+// Theme custom_css @keyframes are INERT on viz blocks — they must live here. The stadium-fascia
+// header rail (data-driven stage ribbon) is the visible content.
+
+Func wc_header_rail() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_matches.ribbon_order)
+        operator: 'less_than'
+        value: 9
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Ord'
+          ref: r(wc_matches.ribbon_order)
+          uname: 'ord'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Short'
+          ref: r(wc_matches.ribbon_short)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'State'
+          ref: r(worldcup.stage_state)
+        },
+        VizFieldFull {
+          label: 'TPlayed'
+          ref: r(worldcup.tourn_played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'AsOf'
+          ref: r(worldcup.tourn_as_of)
+        },
+        VizFieldFull {
+          label: 'Headline'
+          ref: r(worldcup.live_headline)
+        },
+        VizFieldFull {
+          label: 'LiveClass'
+          ref: r(worldcup.live_class)
+        }
+      ]
+      content: @md
+<style>
+/* the fascia: a broadcast lower-third bar that SEATS the header on the surround (vs floating text).
+   glass fill + a full-width gold underline clipped to the rounded bar = its signature (no floating hairline). */
+.wc-fascia { position:relative; display:flex; align-items:stretch; justify-content:space-between; gap:0;
+  height:100%; box-sizing:border-box; padding:0; border-radius:13px; color:var(--line); overflow:hidden;
+  background:linear-gradient(180deg, rgba(10,28,19,.78), rgba(7,19,13,.5));
+  border:1px solid rgba(255,236,200,.13);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.08), 0 12px 26px -18px rgba(0,0,0,.7);
+  backdrop-filter:blur(3px); -webkit-backdrop-filter:blur(3px);
+  opacity:0; animation:wc-fascia-in .55s ease-out .05s forwards; }
+@keyframes wc-fascia-in { from { opacity:0; transform:translateY(-6px); } to { opacity:1; transform:none; } }
+/* full-width gold broadcast underline — clipped to the rounded corners by the bar's overflow:hidden */
+.wc-fascia::after { content:""; position:absolute; left:0; right:0; bottom:0; height:2.5px; z-index:3;
+  background:linear-gradient(90deg, rgba(200,146,10,.18), var(--gold) 20%, var(--gold-2) 50%, var(--gold) 80%, rgba(200,146,10,.18)); }
+/* three zones share the bar height and are separated by faint inset dividers, so the wide bar reads as
+   a composed broadcast graphic rather than text floating in empty space */
+.wc-brand { display:flex; align-items:center; gap:15px; min-width:0; flex:1 1 0; padding:0 26px; }
+.wc-brand .wc-emblem { height:50px !important; width:auto !important; display:block !important; margin:0 !important;
+  filter:drop-shadow(0 3px 9px rgba(0,0,0,.55)); }
+.wc-brand .t1 { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.03em;
+  font-size:24px; line-height:1; color:#fff; text-shadow:0 2px 10px rgba(0,0,0,.5); }
+.wc-brand .t1 b { color:var(--gold-2); }
+.wc-brand .t2 { font-size:11px; color:rgba(234,255,242,.74); margin-top:7px; letter-spacing:.03em; }
+.wc-brand .t2 .sep { opacity:.4; padding:0 7px; }
+/* stage-progress ribbon — "the road to the final" as a connected node chain. The current stage borrows
+   the concept's active-tab look (gold pill, dark ink, lifted + glow); future stages stay dim. */
+/* segmented stepper: chips are DIRECT flex children of .wc-stages (same structure as the working knockout
+   bracket), forced to align-self:center so none can drop. .wc-stages hugs its content (flex:0 0 auto) and is
+   centred between equal-width brand/meta zones → sits at the BAR's centre. The rail is .wc-stages::before,
+   inset to the side padding so it runs first→last chip, hidden under the end plates, showing in the gaps. */
+.wc-stages { position:relative; display:flex; align-items:center; flex:0 0 auto; justify-content:center;
+  gap:30px; min-width:0; padding:0 26px;
+  border-left:1px solid rgba(255,236,200,.1); border-right:1px solid rgba(255,236,200,.1);
+  box-shadow:inset 1px 0 0 rgba(0,0,0,.2), inset -1px 0 0 rgba(0,0,0,.2); }
+.wc-stages::before { content:""; position:absolute; top:50%; left:26px; right:26px; height:2px; z-index:0;
+  transform:translateY(-50%); background:rgba(234,255,242,.24); }
+.wc-stage { position:relative; z-index:1; flex:0 0 auto; align-self:center;
+  display:inline-flex; align-items:center; gap:8px; padding:7px 13px; border-radius:9px; line-height:1; white-space:nowrap;
+  background:linear-gradient(180deg, rgba(13,30,20,.95), rgba(8,19,13,.95));
+  box-shadow:inset 0 0 0 1px rgba(255,236,200,.08);
+  font-family:var(--font-disp); font-weight:700; text-transform:uppercase; letter-spacing:.12em;
+  font-size:11.5px; color:rgba(234,255,242,.5); }
+.wc-stage .d { width:7px; height:7px; border-radius:50%; background:rgba(234,255,242,.32); flex:none; }
+/* completed stages: brighter ink + a gold node; upcoming stays the dim base defined above */
+.wc-stage.done { color:rgba(234,255,242,.74); }
+.wc-stage.done .d { background:var(--gold); box-shadow:0 0 6px rgba(242,200,75,.5); }
+.wc-stage.now { color:#22160a; background:linear-gradient(180deg, var(--gold-2), var(--gold)); transform:translateY(-1px);
+  box-shadow:0 -1px 12px -3px rgba(242,200,75,.6), inset 0 1px 0 rgba(255,255,255,.55), 0 3px 6px rgba(0,0,0,.3); }
+.wc-stage.now .d { background:#3a2a06; box-shadow:none; }
+/* meta status dot: pulsing red when any match is live, steady gold when idle */
+.wc-dot { display:inline-block; width:8px; height:8px; border-radius:50%; vertical-align:middle; margin-right:6px; }
+.wc-dot.live { background:var(--live); animation:wc-pulse 1.8s infinite; }
+.wc-dot.idle { background:var(--gold-2); }
+/* meta */
+.wc-meta { display:flex; flex-direction:column; justify-content:center; align-items:flex-end; text-align:right; flex:1 1 0; min-width:0; padding:0 26px; }
+.wc-meta .m1 { font-family:var(--font-disp); font-size:13px; font-weight:700; letter-spacing:.04em;
+  color:rgba(234,255,242,.95); text-transform:uppercase; }
+.wc-meta .m2 { font-size:10.5px; color:rgba(234,255,242,.62); margin-top:5px; }
+@media (prefers-reduced-motion: reduce) { .wc-fascia { animation:none; opacity:1; } .wc-dot.live, .wc-pulse { animation:none !important; } }
+/* ── GLOBAL motion (keyframes + cross-tab rules) ──────────────────────────
+   IMPORTANT: @keyframes defined in the theme custom_css are NOT applied to viz
+   blocks — only @keyframes defined in a page block <style> work. header_rail
+   renders on every tab, so ALL shared keyframes + cross-tab animation rules
+   live here. (The theme keeps the static tokens/material styling, which DO
+   apply; its copies of these keyframes are dead and can be removed.) */
+@keyframes wc-pulse { 0%{box-shadow:0 0 0 0 rgba(230,29,37,.5);} 70%{box-shadow:0 0 0 8px rgba(230,29,37,0);} 100%{box-shadow:0 0 0 0 rgba(230,29,37,0);} }
+@keyframes wc-deal-in { from { opacity:0; transform:translateY(14px) scale(.985); } to { opacity:1; transform:none; } }
+@keyframes wc-power-on { 0% { filter:brightness(2.4) saturate(.4); } 18% { filter:brightness(.4); } 34% { filter:brightness(2); } 52% { filter:brightness(.7); } 100% { filter:brightness(1); } }
+@keyframes wc-meter-fill { from { transform:scaleX(0); } to { transform:scaleX(1); } }
+@keyframes wc-trophy-glow {
+  0%,100% { filter:drop-shadow(0 0 12px rgba(242,200,75,.65)) drop-shadow(0 0 24px rgba(242,200,75,.32)) drop-shadow(0 6px 12px rgba(0,0,0,.55)); }
+  50% { filter:drop-shadow(0 0 22px rgba(242,200,75,.95)) drop-shadow(0 0 38px rgba(242,200,75,.5)) drop-shadow(0 6px 12px rgba(0,0,0,.55)); } }
+@keyframes wc-pennant-wave {
+  0% { transform:rotate(-4deg) skewX(5deg); }
+  30% { transform:rotate(7deg) skewX(-11deg); }
+  55% { transform:rotate(1deg) skewX(-3deg); }
+  80% { transform:rotate(5deg) skewX(-8deg); }
+  100% { transform:rotate(-4deg) skewX(5deg); } }
+@keyframes wc-tie-glow {
+  0%,100% { box-shadow:0 9px 18px -10px rgba(120,85,15,.5), 0 0 9px -1px rgba(242,200,75,.45), inset 0 1px 0 rgba(255,255,255,.55); }
+  50% { box-shadow:0 9px 18px -10px rgba(120,85,15,.5), 0 0 14px 0 rgba(242,200,75,.85), inset 0 1px 0 rgba(255,255,255,.55); } }
+/* Players-tab pack-reveal backdrop atmosphere — dust motes rising through the spotlight, the
+   floodlight bloom breathing, the gantry rigs twinkling. Keyframes host here (page-block scope). */
+@keyframes pkr-drift {
+  0% { transform:translate(0,14px) scale(.85); opacity:0; }
+  18% { opacity:.7; } 82% { opacity:.5; }
+  100% { transform:translate(16px,-48px) scale(1.08); opacity:0; } }
+@keyframes pkr-flare {
+  0%,100% { opacity:.8; transform:translateX(-50%) scale(1); }
+  50% { opacity:1; transform:translateX(-50%) scale(1.045); } }
+@keyframes pkr-twinkle { 0%,100% { opacity:.5; } 50% { opacity:1; } }
+@keyframes gp-pop { 0% { transform:scale(0); opacity:0; } 60% { transform:scale(1.25); } 100% { transform:scale(1); opacity:1; } }
+.clipboard { animation:cb-drop .55s cubic-bezier(.2,.74,.3,1.05) backwards; transform-origin:top center;
+  transition:transform .2s cubic-bezier(.2,.7,.3,1.05), box-shadow .2s ease; }
+@keyframes cb-drop {
+  0% { opacity:0; transform:perspective(950px) rotateX(-15deg); }
+  62% { opacity:1; transform:perspective(950px) rotateX(3deg); }
+  100% { transform:perspective(950px) rotateX(0deg); } }
+.clipboard:hover { transform:translateY(-3px);
+  box-shadow:0 24px 36px -16px var(--shadow-dir), 0 2px 0 rgba(0,0,0,.12), inset 0 1px 0 rgba(255,255,255,.75); }
+/* knockout ties cascade down the funnel (per-round --rd inline on each .kbr); final tie idle shimmer.
+   Keyframes wc-deal-in / wc-tie-glow / wc-pennant-wave / wc-trophy-glow live early in the theme and
+   survive the truncation, so page rules can reference them; goal-in / trophy-pop / cb-drop are defined here. */
+.tie { animation:wc-deal-in .46s cubic-bezier(.2,.7,.3,1) var(--rd,0s) backwards;
+  transition:transform .18s cubic-bezier(.2,.7,.3,1.05), box-shadow .18s ease, border-color .18s ease; }
+.tie:hover { transform:translateY(-2px); border-color:rgba(12,36,24,.3); box-shadow:0 14px 24px -12px var(--shadow-dir); }
+.tie-final { animation:wc-deal-in .5s cubic-bezier(.2,.7,.25,1.1) var(--rd,0s) backwards, wc-tie-glow 3.6s ease-in-out 1.1s infinite; }
+.tie-final:hover { transform:translateY(-2px); }
+/* corner pennants — flag on a pole at each pitch corner; the SHAPE lives here so it actually renders */
+.wc-pitch .pen { position:absolute; z-index:2; width:2px; height:26px; pointer-events:none; border-radius:1px;
+  background:linear-gradient(180deg, rgba(255,255,255,.92), rgba(255,255,255,.45)); }
+.wc-pitch .pen::before { content:""; position:absolute; top:0; left:2px; width:17px; height:11px;
+  background:linear-gradient(135deg, var(--gold-2), var(--gold)); box-shadow:0 1px 2px rgba(0,0,0,.3);
+  clip-path:polygon(0 0, 100% 50%, 0 100%); transform-origin:left center;
+  animation:wc-pennant-wave 2.8s ease-in-out infinite; }
+.wc-pitch .pen.tl { left:34px; top:10px; }
+.wc-pitch .pen.tr { right:34px; top:10px; }
+.wc-pitch .pen.bl { left:34px; bottom:10px; }
+.wc-pitch .pen.br { right:34px; bottom:10px; }
+.wc-pitch .pen.tr::before, .wc-pitch .pen.br::before { left:auto; right:2px; clip-path:polygon(100% 0, 0 50%, 100% 100%); transform-origin:right center; }
+.wc-pitch .pen.tr::before { animation-delay:-1.2s; }
+.wc-pitch .pen.bl::before { animation-delay:-.6s; }
+.wc-pitch .pen.br::before { animation-delay:-1.8s; }
+/* goal frame rises, trophy pops then breathes a gold glow */
+.goal { animation:goal-in .6s ease-out .85s backwards; }
+@keyframes goal-in { from { opacity:0; transform:translateY(16px); } to { opacity:1; transform:none; } }
+.goal img { animation:trophy-pop .55s cubic-bezier(.2,.7,.25,1.3) .95s backwards, wc-trophy-glow 3.8s ease-in-out 1.7s infinite; }
+@keyframes trophy-pop { 0% { opacity:0; transform:scale(.6); } 100% { opacity:1; transform:scale(1); } }
+@media (prefers-reduced-motion: reduce) {
+  .clipboard, .tie, .tie-final, .goal, .goal img { animation:none !important; opacity:1 !important; transform:none !important; }
+  .clipboard:hover, .tie:hover, .tie-final:hover { transform:none !important; }
+  .wc-pitch .pen::before { animation:none !important; } }
+
+/* ── SHARED PLAYER-PROFILE POPOVER (pp-*) ─────────────────────────────────────
+   The reusable player card-back: opened from the Team HQ squad stickers and the
+   Players-tab FUT cards. Native Popover API → renders in the browser top layer,
+   so it escapes every viz block's overflow:hidden clip; anchored to the trigger
+   via CSS anchor positioning (falls back to viewport-centred). Markup is emitted
+   per-player inside each block's map; this is just the shared skin. */
+button.stk { appearance:none; -webkit-appearance:none; border:none; font:inherit; color:inherit; text-align:inherit; }
+.pp-card { margin:auto; border:none; padding:0 0 18px; overflow:hidden; width:392px;
+  font-family:var(--font-disp); color:#e7ecf1;
+  background:repeating-linear-gradient(0deg, rgba(255,255,255,.03) 0 1px, transparent 1px 3px), linear-gradient(155deg,#2c323a,#171b20 74%);
+  border-radius:16px;
+  box-shadow:0 34px 74px -16px rgba(0,0,0,.74), inset 0 1px 0 rgba(255,255,255,.16), inset 0 0 0 1px rgba(0,0,0,.6); }
+.pp-card::backdrop { background:rgba(8,11,15,.55); }
+@supports (anchor-name: --a) {
+  .pp-card { margin:8px; inset:auto; position-area:top; position-try-fallbacks:flip-block, flip-inline, flip-block flip-inline; } }
+.pp-card:popover-open { animation:pp-in .22s cubic-bezier(.2,.7,.25,1) both; }
+@keyframes pp-in { from { opacity:0; transform:translateY(9px) scale(.97); } to { opacity:1; transform:none; } }
+.pp-top { position:relative; display:flex; gap:16px; padding:18px 20px 16px; overflow:hidden; border-radius:16px 16px 0 0; }
+.pp-top::before { content:""; position:absolute; inset:0; opacity:.22; pointer-events:none;
+  background:linear-gradient(118deg, var(--ppc,#1d5c3f), transparent 66%); }
+/* avatar: the figure is zoomed + top-anchored so the head/torso fills the frame (FIFA art floats small in its source canvas) */
+.pp-fig { position:relative; width:92px; height:92px; flex:none; border-radius:16px; overflow:hidden;
+  background:radial-gradient(120% 110% at 50% 8%, rgba(255,255,255,.16), rgba(0,0,0,.34));
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.16), 0 4px 10px rgba(0,0,0,.4); }
+.pp-fig img { width:100%; height:100%; object-fit:cover; object-position:center top;
+  transform:scale(1.7); transform-origin:center top; display:block; margin:0 !important; }
+.pp-id { position:relative; min-width:0; display:flex; flex-direction:column; justify-content:center; gap:7px; }
+.pp-nm { font-weight:800; font-size:23px; line-height:.98; letter-spacing:.01em; text-transform:uppercase; color:#fff; }
+.pp-sub { display:flex; align-items:center; gap:8px; font-weight:700; font-size:11px; letter-spacing:.1em; text-transform:uppercase; color:rgba(225,231,238,.9); }
+.pp-sub img { width:23px; height:15px; border-radius:2px; object-fit:cover; display:block; margin:0 !important; box-shadow:0 1px 2px rgba(0,0,0,.45); }
+.pp-chips { display:flex; flex-wrap:wrap; gap:6px; }
+.pp-chip { display:inline-flex; align-items:baseline; gap:6px; font-weight:800; font-size:11px; letter-spacing:.02em;
+  text-transform:uppercase; color:#eef2f6; background:rgba(255,255,255,.08); border-radius:6px; padding:5px 10px;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.05); }
+.pp-chip::before { font-size:7.5px; font-weight:800; letter-spacing:.13em; color:var(--gold,#ffd35c); opacity:.92; }
+.cl-age::before { content:"AGE"; }
+.cl-pos::before { content:"POS"; }
+.cl-club::before { content:"CLUB"; }
+.cl-ht::before { content:"HT"; }
+.pp-chip:empty { display:none; }
+.pp-stats { display:grid; grid-template-columns:repeat(6,1fr); gap:1px; margin:16px 20px 0; background:rgba(0,0,0,.42);
+  border-radius:10px; overflow:hidden; box-shadow:inset 0 0 0 1px rgba(0,0,0,.5); }
+.pp-stat { background:linear-gradient(180deg, rgba(255,255,255,.055), rgba(0,0,0,.12)); padding:12px 2px 10px; text-align:center; }
+.pp-stat b { display:block; font-weight:800; font-size:23px; line-height:1; color:#fff; font-variant-numeric:tabular-nums; }
+.pp-stat i { display:block; font-style:normal; font-weight:700; font-size:8.5px; letter-spacing:.07em; text-transform:uppercase; color:rgba(225,231,238,.62); margin-top:5px; }
+.pp-stat.hl b { color:var(--gold,#ffd35c); }
+.pp-gl { list-style:none !important; margin:14px 20px 0; padding:0 !important; display:flex; flex-direction:column; gap:4px; max-height:136px; overflow:auto; }
+.pp-gl:empty { display:none; }
+.pp-gl::before { content:"Goals"; font-weight:800; font-size:9px; letter-spacing:.14em; text-transform:uppercase;
+  color:rgba(225,231,238,.55); margin-bottom:4px; }
+.pp-gl li { list-style:none !important; margin:0 !important; font-weight:700; font-size:12px; letter-spacing:.02em; color:rgba(225,231,238,.9);
+  padding:6px 11px; border-radius:6px; background:rgba(255,255,255,.05); }
+.pp-gl li::marker { content:"" !important; }
+.pp-gl li b { color:var(--gold,#ffd35c); font-variant-numeric:tabular-nums; margin-right:6px; }
+/* goal-mouth placement map — a front-on net with a gold dot per placed goal. The dots come from
+   wc_player_stats.goal_placement_svg (null → empty <g>), so the whole section hides for players
+   with no coord-bearing goal via :has() — no empty frame for the ~96% who haven't placed one yet. */
+.pp-goal { margin:15px 20px 0; }
+.pp-goal::before { content:"Where they score"; display:block; font-weight:800; font-size:9px; letter-spacing:.14em;
+  text-transform:uppercase; color:rgba(225,231,238,.55); margin-bottom:7px; }
+/* the goal sits in a spotlit case: a cool top-down bloom + a lit inner edge, like a stadium net at night */
+.pp-goal-box { border-radius:9px; padding:11px 13px 7px; overflow:hidden;
+  background:radial-gradient(80% 98% at 50% -8%, rgba(150,184,224,.16), transparent 58%), linear-gradient(180deg, rgba(23,29,37,.62), rgba(7,10,14,.58));
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.45), inset 0 0 28px -8px rgba(150,184,224,.24); }
+.pp-net { display:block; width:100%; height:auto; margin:0 !important; }
+/* back-net depth panel (the goal has a roof going back) — kept faint */
+.pp-net .pp-depth { fill:rgba(7,11,15,.4); stroke:rgba(226,233,242,.16); stroke-width:.7; stroke-linejoin:round; }
+.pp-net .ground { stroke:rgba(226,233,242,.32); stroke-width:1.2; stroke-linecap:round; }
+/* placement dots: gold core + pale rim + glow, popping in when the card opens */
+.pp-net .gp { fill:var(--gold,#ffd35c); stroke:rgba(255,243,209,.9); stroke-width:.6; transform-box:fill-box; transform-origin:center;
+  filter:drop-shadow(0 0 4px rgba(242,200,75,.9)); }
+.pp-card:popover-open .pp-net .gp { animation:gp-pop .42s cubic-bezier(.2,.7,.25,1.5) both; }
+.pp-goal:has(.pp-dots:empty) { display:none; }
+@media (prefers-reduced-motion: reduce) { .pp-card:popover-open { animation:none !important; } }
+
+/* ── SHARED FUT CARD MATERIAL (.fut*) ─────────────────────────────────────────
+   The gold-foil shield used by BOTH the Tournament boot podium and the Players
+   gallery. Lives here (global host) so the two are pixel-identical — one source.
+   Layout-specific rules (.bp-row podium positioning, .fut-wall grid) stay in
+   their own blocks; this is just the card itself. */
+.fut { position:relative; width:176px; height:232px; flex:none; border-radius:18px; color:#4a3608;
+  --rest:perspective(900px) translateY(0) rotateY(0deg) scale(1); transform:var(--rest); isolation:isolate;
+  transition:transform .26s cubic-bezier(.2,.7,.3,1.05), filter .26s ease;
+  clip-path:path('M 0 34 C 0 18 10 8 26 7 L 64 7 C 74 7 80 2 88 2 C 96 2 102 7 112 7 L 150 7 C 166 8 176 18 176 34 L 176 168 C 176 192 168 204 146 214 C 124 223 102 230 88 230 C 74 230 52 223 30 214 C 8 204 0 192 0 168 Z');
+  background:
+    radial-gradient(130% 70% at 50% -10%, #fcf0c4, transparent 55%),
+    linear-gradient(120deg, transparent 36%, rgba(255,255,255,.28) 46%, transparent 58%),
+    linear-gradient(180deg, #f0dc9e 0%, #e3c068 52%, #c99b36 100%);
+  filter:drop-shadow(0 10px 12px rgba(7,30,18,.4)); }
+.fut::before { content:""; position:absolute; inset:0; pointer-events:none; opacity:.14;
+  background:linear-gradient(115deg, transparent 38%, var(--teamc) 50%, transparent 67%); }
+.fut .fut-frame { position:absolute !important; inset:0 !important; width:100% !important; height:100% !important;
+  pointer-events:none; display:block !important; margin:0 !important; }
+.fut-medal { position:absolute; top:7px; left:50%; transform:translateX(-50%); z-index:3; width:24px; height:24px;
+  border-radius:50%; display:flex; align-items:center; justify-content:center; font-family:var(--font-disp);
+  font-weight:800; font-size:12px; color:#f9edc6; background:radial-gradient(120% 120% at 32% 28%, #8a6516, #5d430c);
+  box-shadow:inset 0 1px 1px rgba(255,255,255,.35), 0 1px 3px rgba(74,54,8,.45); }
+.fut-body { position:absolute; inset:0; display:flex; flex-direction:column; padding:16px 16px 14px; }
+.fut-top { position:relative; flex:1; min-height:0; }
+.fut-rate { position:absolute; left:0; top:0; bottom:0; z-index:2; display:flex; flex-direction:column;
+  align-items:center; justify-content:center; width:40px; line-height:1; padding-bottom:12px; }
+.fut-rate .n { font-family:var(--font-disp); font-weight:800; font-size:34px; text-shadow:0 1px 0 rgba(255,255,255,.45); }
+.fut-rate .u { font-family:var(--font-disp); font-weight:700; font-size:7.5px; letter-spacing:.14em;
+  text-transform:uppercase; opacity:.78; margin-top:4px; }
+.fut-rate .fut-flag { width:25px !important; height:17px !important; border-radius:2px !important; object-fit:cover;
+  display:block !important; margin:10px 0 0 !important; box-shadow:0 1px 2px rgba(0,0,0,.3); }
+.fut-ph { position:absolute; right:-4px; top:4px; bottom:0; width:72%; overflow:hidden; }
+.fut-ph img { width:100% !important; height:100% !important; object-fit:cover; object-position:top center;
+  transform:scale(2.2); transform-origin:top center; display:block !important; margin:0 !important; }
+.fut-ph img[src=""], .fut-ph img:not([src]) { display:none !important; }
+.fut-name { position:relative; font-family:var(--font-disp); font-weight:800; text-transform:uppercase;
+  font-size:14px; letter-spacing:.03em; text-align:center; line-height:1.1; padding:7px 6px 6px; margin:0 4px;
+  border-bottom:1px solid rgba(120,85,20,.4); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.fut-meta { font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.13em;
+  text-transform:uppercase; text-align:center; opacity:.82; padding-top:6px; }
+.fut-meta b { font-size:11px; font-weight:800; }
+.fut.t2 { color:#39424a;
+  background:
+    radial-gradient(130% 70% at 50% -10%, #ffffff, transparent 55%),
+    linear-gradient(120deg, transparent 36%, rgba(255,255,255,.45) 46%, transparent 58%),
+    linear-gradient(180deg, #f2f5f7 0%, #cfd6db 52%, #a7b1b9 100%); }
+.fut.t2 .fut-frame path { stroke:#7e8a92; }
+.fut.t2 .fut-name { border-bottom-color:rgba(70,85,95,.4); }
+.fut.t2 .fut-medal { color:#eef3f6; background:radial-gradient(120% 120% at 32% 28%, #5d6970, #39444b);
+  box-shadow:inset 0 1px 1px rgba(255,255,255,.4), 0 1px 3px rgba(40,50,57,.45); }
+.fut.t3 { color:#46301a;
+  background:
+    radial-gradient(130% 70% at 50% -10%, #f6e3cf, transparent 55%),
+    linear-gradient(120deg, transparent 36%, rgba(255,255,255,.3) 46%, transparent 58%),
+    linear-gradient(180deg, #e9cdaf 0%, #cd9f6e 52%, #a87146 100%); }
+.fut.t3 .fut-frame path { stroke:#7e5226; }
+.fut.t3 .fut-name { border-bottom-color:rgba(110,70,30,.45); }
+.fut.t3 .fut-medal { color:#f3e2cd; background:radial-gradient(120% 120% at 32% 28%, #6e4a20, #46300f);
+  box-shadow:inset 0 1px 1px rgba(255,255,255,.35), 0 1px 3px rgba(60,40,15,.45); }
+.fut { animation:fut-deal .55s cubic-bezier(.2,.74,.3,1.16) backwards; }
+@keyframes fut-deal {
+  0% { opacity:0; transform:perspective(900px) translateY(34px) rotateY(-26deg) scale(.9); }
+  100% { opacity:1; transform:var(--rest); } }
+.fut::after { content:""; position:absolute; inset:0; z-index:4; pointer-events:none; opacity:0;
+  background:linear-gradient(115deg, transparent 32%, rgba(255,255,255,.5) 47%, transparent 63%);
+  transform:translateX(-120%); }
+.fut:hover { transform:perspective(900px) translateY(-10px) rotateY(0deg) scale(1.06); z-index:6;
+  filter:drop-shadow(0 22px 22px rgba(7,30,18,.5)) drop-shadow(0 0 28px rgba(242,200,75,.6)); }
+.fut:hover::after { opacity:1; animation:fut-foil .6s ease-out; }
+@keyframes fut-foil { from { transform:translateX(-120%); } to { transform:translateX(120%); } }
+@media (prefers-reduced-motion: reduce) {
+  .fut { animation:none !important; opacity:1 !important; transform:var(--rest) !important; }
+  .fut:hover { transform:var(--rest) !important; }
+  .fut::after { display:none !important; } }
+/* ── RACE LADDER (rl-*) — the Players-tab "Race for the Golden Boot / Playmaker".
+   A matte broadcast TIMING-BOARD, not the foil .fut card: each contender owns a lane
+   and the lane itself FILLS toward the leader (the SQL-resolved %), so the board reads
+   as a live race rather than a chart. Shared by both ladders — they differ ONLY in the
+   metric and the lane-light hue (boot = gold, play = ice), which the accent tokens carry.
+   No edge stripe; the material is the engraved plate + the lit lanes themselves. */
+.rl { position:relative; height:100%; box-sizing:border-box; display:flex; flex-direction:column;
+  font-family:var(--font-disp); color:var(--line); border-radius:15px; overflow:hidden; padding:18px 20px 16px;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,255,255,.016) 0 2px, transparent 2px 6px),
+    linear-gradient(168deg, #232a31, #13171c 80%);
+  box-shadow:0 26px 52px -22px rgba(0,0,0,.72), inset 0 1px 0 rgba(255,255,255,.08), inset 0 0 0 1px rgba(0,0,0,.5);
+  opacity:0; animation:wc-deal-in .5s cubic-bezier(.2,.7,.3,1) .05s forwards; }
+.rl.boot { --ac:#f2c84b; --ac-soft:rgba(242,200,75,.34); --ac-dim:rgba(242,200,75,.05); --ac-edge:rgba(255,224,140,.95); --ac-glow:rgba(242,200,75,.5); }
+.rl.play { --ac:#86d9ec; --ac-soft:rgba(120,210,232,.32); --ac-dim:rgba(120,210,232,.05); --ac-edge:rgba(190,242,252,.92); --ac-glow:rgba(120,210,232,.5); }
+/* header plate: an engraved title bar seated above the lanes, closed by an accent hairline */
+.rl-head { display:flex; align-items:center; gap:13px; padding:0 2px 14px; margin-bottom:13px; position:relative; }
+.rl-head::after { content:""; position:absolute; left:0; right:0; bottom:0; height:2px;
+  background:linear-gradient(90deg, var(--ac-edge), transparent 78%); opacity:.8; }
+.rl-mark { width:38px; height:38px; flex:none; border-radius:11px; display:flex; align-items:center; justify-content:center;
+  background:radial-gradient(120% 120% at 32% 24%, rgba(255,255,255,.16), rgba(0,0,0,.32));
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.12), 0 3px 8px rgba(0,0,0,.4); }
+.rl-mark svg { width:21px; height:21px; display:block; margin:0 !important; stroke:var(--ac); }
+.rl-ttl { display:flex; flex-direction:column; gap:4px; min-width:0; }
+.rl-ttl .a { font-weight:800; font-size:18px; line-height:1; letter-spacing:.03em; text-transform:uppercase; color:#fff; }
+.rl-ttl .b { font-weight:700; font-size:9.5px; letter-spacing:.16em; text-transform:uppercase; color:rgba(225,231,238,.55); }
+.rl-ttl .b em { font-style:normal; color:var(--ac); }
+/* the lanes: equal-share the remaining height so the board always fills its block cleanly */
+.rl-list { display:flex; flex-direction:column; gap:7px; flex:1; min-height:0; }
+.rl-row { position:relative; display:grid; grid-template-columns:30px 28px 1fr auto; align-items:center; gap:11px;
+  flex:1; min-height:0; padding:0 14px 0 9px; border-radius:9px; overflow:hidden;
+  background:linear-gradient(180deg, rgba(255,255,255,.03), rgba(0,0,0,.17));
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.4);
+  animation:wc-deal-in .42s cubic-bezier(.2,.7,.3,1) backwards; }
+/* the lane fill — a translucent wash growing left→right to the leader-relative width, with a lit leading edge */
+.rl-fill { position:absolute; left:0; top:0; bottom:0; width:max(9%, var(--w,0%)); z-index:0; border-radius:9px 0 0 9px;
+  background:linear-gradient(90deg, var(--ac-dim), var(--ac-soft)); box-shadow:inset -2px 0 0 var(--ac-edge);
+  transform-origin:left center; animation:wc-meter-fill .85s cubic-bezier(.2,.7,.25,1) .3s backwards; }
+.rl-rank, .rl-flag, .rl-id, .rl-val { position:relative; z-index:1; }
+.rl-rank { width:24px; height:24px; border-radius:50%; display:flex; align-items:center; justify-content:center;
+  font-weight:800; font-size:11.5px; font-variant-numeric:tabular-nums; color:rgba(225,231,238,.62);
+  background:radial-gradient(120% 120% at 32% 28%, #3a434c, #232a31); box-shadow:inset 0 0 0 1px rgba(0,0,0,.4); }
+.rl-row.r1 .rl-rank { color:#3a2a06; background:radial-gradient(120% 120% at 32% 24%, #ffe08c, #e0a82a);
+  box-shadow:inset 0 1px 1px rgba(255,255,255,.55), 0 1px 4px var(--ac-glow); }
+.rl-row.r2 .rl-rank { color:#1f262c; background:radial-gradient(120% 120% at 32% 24%, #f1f5f8, #aeb8c0); box-shadow:inset 0 1px 1px rgba(255,255,255,.5); }
+.rl-row.r3 .rl-rank { color:#33240f; background:radial-gradient(120% 120% at 32% 24%, #f0cba0, #c08a52); box-shadow:inset 0 1px 1px rgba(255,255,255,.4); }
+.rl-flag { width:26px; height:18px; border-radius:3px; object-fit:cover; display:block; margin:0 !important; box-shadow:0 1px 2px rgba(0,0,0,.5), inset 0 0 0 1px rgba(255,255,255,.12); }
+.rl-id { min-width:0; display:flex; flex-direction:column; gap:2px; }
+.rl-id .n { font-weight:800; font-size:13.5px; letter-spacing:.01em; color:#fff; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.rl-id .s { font-weight:700; font-size:9px; letter-spacing:.09em; text-transform:uppercase; color:rgba(225,231,238,.5); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.rl-val { font-weight:800; font-size:22px; line-height:1; font-variant-numeric:tabular-nums; color:#fff; text-align:right; padding-left:8px; }
+.rl-row.r1 .rl-val { color:var(--ac); text-shadow:0 0 12px var(--ac-glow); }
+.rl-list .rl-row:nth-child(1){animation-delay:.34s} .rl-list .rl-row:nth-child(2){animation-delay:.40s}
+.rl-list .rl-row:nth-child(3){animation-delay:.46s} .rl-list .rl-row:nth-child(4){animation-delay:.52s}
+.rl-list .rl-row:nth-child(5){animation-delay:.58s} .rl-list .rl-row:nth-child(6){animation-delay:.64s}
+.rl-list .rl-row:nth-child(7){animation-delay:.70s} .rl-list .rl-row:nth-child(n+8){animation-delay:.76s}
+@media (prefers-reduced-motion: reduce) {
+  .rl, .rl-row { animation:none !important; opacity:1 !important; }
+  .rl-fill { animation:none !important; } }
+</style>
+<div class="wc-fascia">
+  <div class="wc-brand">
+    <img class="wc-emblem" style="margin:0 !important" src="https://upload.wikimedia.org/wikipedia/en/thumb/1/17/2026_FIFA_World_Cup_emblem.svg/500px-2026_FIFA_World_Cup_emblem.svg.png" alt="FIFA World Cup 26 emblem" />
+    <div>
+      <div class="t1">FIFA World <b>Cup 26</b></div>
+      <div class="t2">Canada · Mexico · USA<span class="sep">·</span>48 teams<span class="sep">·</span>104 matches</div>
+    </div>
+  </div>
+  <div class="wc-stages">
+{% map(rows) %}
+  <div class="wc-stage {{ values.`State`.raw }}"><i class="d"></i>{{ `Short`.formatted }}</div>
+{% end %}
+  </div>
+  <div class="wc-meta">
+    <div class="m1"><span class="wc-dot {{ rows[0].values.`LiveClass`.raw }}"></span> {{ rows[0].values.`Headline`.formatted }}</div>
+    <div class="m2">{{ rows[0].values.`TPlayed`.formatted }} of 104 played · as of {{ rows[0].values.`AsOf`.formatted }}</div>
+  </div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'ord'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 6
+        row_limit: 6
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hist_editions.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hist_editions.block.aml
@@ -1,0 +1,231 @@
+// History — edition comparison: how the tournament has changed, goals per match 1930 → 2026.
+// CRAFTED MarkdownViz (not a native chart): static surface → stays on the History wall's bronze-plaque
+// material. Vertical aged-bronze columns on an engraved plate (timeline left→right), the live 2026
+// edition in bright gold, a dashed line at the all-time average. Bar heights + average are window
+// measures computed INLINE (no dataset metric). Each column is a Popover-API trigger: tapping it opens
+// a detail card (goals/match + matches + goals) in the browser TOP LAYER — so it escapes the plate's
+// overflow:hidden clip and is anchored to its own column (the advance-board technique). Replaces the
+// native chart's built-in tooltip, which we gave up by going crafted.
+
+Func wc_hist_zone_editions() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">How the tournament has changed · goals per match, every edition</p>
+;;
+  }
+}
+
+Func wc_hist_editions() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      calculation gpm_val {
+        label: 'Goals per match'
+        formula: @aql max(wc_edition_compare.goals_per_match) ;;
+        calc_type: 'measure'
+        data_type: 'number'
+      }
+      calculation gpm_bar_pct {
+        label: 'Bar pct'
+        formula: @aql 100 * safe_divide(max(wc_edition_compare.goals_per_match), window_max(max(wc_edition_compare.goals_per_match))) ;;
+        calc_type: 'measure'
+        data_type: 'number'
+      }
+      calculation gpm_avg_pct {
+        label: 'Avg pct'
+        formula: @aql 100 * safe_divide(window_avg(max(wc_edition_compare.goals_per_match)), window_max(max(wc_edition_compare.goals_per_match))) ;;
+        calc_type: 'measure'
+        data_type: 'number'
+      }
+      calculation gpm_field_avg {
+        label: 'Field avg'
+        formula: @aql window_avg(max(wc_edition_compare.goals_per_match)) ;;
+        calc_type: 'measure'
+        data_type: 'number'
+      }
+      calculation ed_matches {
+        label: 'Matches'
+        formula: @aql max(wc_edition_compare.matches) ;;
+        calc_type: 'measure'
+        data_type: 'number'
+      }
+      calculation ed_goals {
+        label: 'Goals'
+        formula: @aql max(wc_edition_compare.goals) ;;
+        calc_type: 'measure'
+        data_type: 'number'
+      }
+      calculation cur_flag {
+        label: 'Current flag'
+        formula: @aql case(when: max(wc_edition_compare.edition) == 2026, then: 'cur', else: 'base') ;;
+        calc_type: 'measure'
+        data_type: 'text'
+      }
+      rows: [
+        VizFieldFull {
+          label: 'EdSort'
+          ref: r(wc_edition_compare.edition)
+          uname: 'edsort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Ed'
+          ref: r(wc_edition_compare.edition_label)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'Gpm'
+          ref: 'gpm_val'
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'BarPct'
+          ref: 'gpm_bar_pct'
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'AvgPct'
+          ref: 'gpm_avg_pct'
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'FieldAvg'
+          ref: 'gpm_field_avg'
+          format {
+            type: 'number'
+            pattern: '#,##0.00'
+          }
+        },
+        VizFieldFull {
+          label: 'Matches'
+          ref: 'ed_matches'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: 'ed_goals'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'CurFlag'
+          ref: 'cur_flag'
+        }
+      ]
+      content: @md
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@600;700;800&display=swap');
+/* edition vitrine — same bronze-plaque material as the Hall / Roll / Pedigree plaques (walnut frame +
+   engraved bronze plate + Cinzel), hosting a column timeline. Base columns are dark aged-bronze so the
+   bright-gold current edition stands out; each column is a Popover-API trigger for its detail card. */
+.hed-wrap { width:100%; box-sizing:border-box; padding:2px; }
+.hed-frame { position:relative; border-radius:13px; padding:22px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0,0,0,.13) 0 1px, transparent 1px 7px, rgba(255,212,150,.045) 7px 8px, transparent 8px 14px),
+    linear-gradient(90deg, #3a2817, #4c3722 17%, #32220f 39%, #4a3320 61%, #2c1c0c 83%, #3f2c19),
+    linear-gradient(180deg,#43301d,#2a1b0c);
+  box-shadow:0 30px 48px -22px rgba(4,18,11,.72), 0 2px 0 rgba(0,0,0,.45),
+    inset 0 2px 0 rgba(255,224,164,.24), inset 0 -5px 8px rgba(0,0,0,.6), inset 0 0 0 1px rgba(0,0,0,.45); }
+.hed-frame::before, .hed-frame::after { content:""; position:absolute; top:6px; width:10px; height:10px; border-radius:50%;
+  background:radial-gradient(120% 120% at 34% 28%, #e4cf94, #6e5526); box-shadow:0 1px 2px rgba(0,0,0,.55), inset 0 -1px 1px rgba(60,40,10,.6); }
+.hed-frame::before { left:6px; } .hed-frame::after { right:6px; }
+.hed-plate { position:relative; overflow:hidden; border-radius:7px; padding:18px 26px 16px;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,250,225,.05) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg,#cdaa6a,#b89252 44%,#9c7836);
+  box-shadow:inset 0 0 0 1px rgba(255,240,200,.3), inset 0 2px 7px rgba(255,245,215,.32),
+    inset 0 -12px 26px rgba(60,40,12,.38),
+    0 0 0 2px #241708, 0 0 0 4px rgba(214,176,108,.55), 0 0 0 5px rgba(0,0,0,.35), 0 4px 11px rgba(0,0,0,.55); }
+.hed-cap { display:flex; align-items:center; justify-content:center; gap:16px; margin-bottom:6px; }
+.hed-cap .lr { flex:none; width:60px; height:1.5px; background:linear-gradient(90deg, transparent, rgba(74,52,16,.7)); }
+.hed-cap .lr.r { background:linear-gradient(90deg, rgba(74,52,16,.7), transparent); }
+.hed-title { font-family:'Cinzel',serif; font-weight:800; font-size:23px; letter-spacing:.18em; text-transform:uppercase;
+  color:#46330f; text-shadow:0 1px 0 rgba(255,247,218,.6); white-space:nowrap; }
+.hed-sub { text-align:center; font-family:var(--font-body); font-size:11px; letter-spacing:.14em; text-transform:uppercase;
+  color:rgba(70,50,16,.66); margin:0; }
+.hed-plot { position:relative; display:flex; align-items:flex-end; gap:5px; height:200px; margin:16px 0 26px; }
+.hed-col { position:relative; flex:1; height:100%; display:flex; align-items:flex-end; justify-content:center; }
+/* the bar IS the popover trigger (a reset button) */
+.hed-bar { appearance:none; -webkit-appearance:none; border:0; margin:0; padding:0; font:inherit; cursor:pointer;
+  interest-delay-start:0.1s; interest-delay-end:0.25s;
+  display:block; width:62%; min-height:2px; border-radius:3px 3px 0 0;
+  background:linear-gradient(180deg,#8a7038,#5e4a23 55%,#43341a);
+  box-shadow:inset 0 1px 0 rgba(255,240,200,.22), inset 0 -3px 4px rgba(30,20,6,.45), 0 1px 2px rgba(40,26,8,.4);
+  transition:filter .15s; transform-origin:bottom; animation:hed-rise .6s cubic-bezier(.2,.7,.3,1) backwards; }
+.hed-bar:hover { filter:brightness(1.22); }
+.hed-col[data-cur="cur"] .hed-bar { background:linear-gradient(180deg,#ffe79a,#f2c84b 50%,#d8a72f);
+  box-shadow:inset 0 1px 0 rgba(255,255,235,.75), 0 0 15px rgba(242,200,75,.6), 0 1px 2px rgba(40,26,8,.4); }
+@keyframes hed-rise { from { transform:scaleY(0); } to { transform:scaleY(1); } }
+/* readable year labels (Saira Condensed is narrow, so 12px fits the column width) */
+.hed-yr { position:absolute; top:100%; left:-3px; right:-3px; margin-top:6px; text-align:center;
+  font-family:var(--font-disp); font-weight:700; font-size:12px; letter-spacing:.01em; color:rgba(60,42,14,.78); }
+.hed-col[data-cur="cur"] .hed-yr { color:#6e4f14; font-weight:800; }
+/* dashed all-time-average rule across the plot */
+.hed-avg { position:absolute; left:0; right:0; z-index:4; height:0; border-top:2px dashed rgba(40,26,8,.55); }
+.hed-avg b { position:absolute; right:2px; top:-15px; font-family:'Cinzel',serif; font-weight:700; font-size:12px;
+  color:#43300d; background:rgba(205,170,106,.9); padding:0 5px; border-radius:3px; box-shadow:0 1px 2px rgba(40,26,8,.3); }
+/* Popover-API detail card — renders in the TOP LAYER (escapes the plate clip), anchored above its column.
+   Base rule is the un-anchored UA fallback (viewport-centred); the @supports block does the anchoring. */
+.hed-pop { margin:auto; border:1px solid rgba(214,176,108,.45); border-radius:8px; padding:8px 12px;
+  background:linear-gradient(180deg,#3a2817,#211506); color:#efdcae; text-align:center; white-space:nowrap;
+  font-family:var(--font-body); box-shadow:0 14px 30px -8px rgba(0,0,0,.72); }
+@supports (anchor-name:--a) {
+  .hed-pop { margin:0; inset:auto; position-area:top; position-try-fallbacks:flip-block; }
+}
+.hed-pop .yr { font-family:'Cinzel',serif; font-weight:700; font-size:14px; color:#ffe79a; margin-right:6px; }
+.hed-pop .big { font-family:var(--font-disp); font-weight:800; font-size:16px; color:#fff; }
+.hed-pop .mt { display:block; font-size:10px; letter-spacing:.04em; color:rgba(239,220,174,.8); margin-top:3px; }
+.hed-pop:popover-open { animation:hed-pop-in .16s ease-out; }
+@keyframes hed-pop-in { from { opacity:0; transform:translateY(4px); } to { opacity:1; transform:none; } }
+.hed-foot { margin-top:6px; padding-top:12px; border-top:1px solid rgba(74,52,16,.28);
+  display:flex; justify-content:space-between; gap:10px;
+  font-family:var(--font-body); font-size:10px; letter-spacing:.05em; text-transform:uppercase; color:rgba(70,50,16,.58); }
+.hed-foot b { color:#7a5a16; font-weight:700; }
+@media (prefers-reduced-motion: reduce) { .hed-bar { animation:none; } .hed-pop:popover-open { animation:none; } }
+</style>
+<div class="hed-wrap"><div class="hed-frame"><div class="hed-plate">
+<div class="hed-cap"><span class="lr"></span><span class="hed-title">Goals Per Match</span><span class="lr r"></span></div>
+<div class="hed-sub">Every edition · 1930 → 2026 · hover a column for detail</div>
+<div class="hed-plot"><span class="hed-avg" style="bottom:{{ rows[0].values.`AvgPct`.raw }}%;"><b class="wc-num">{{ rows[0].values.`FieldAvg`.formatted }}</b></span>
+{% map(rows) %}
+<div class="hed-col" data-cur="{{ values.`CurFlag`.formatted }}"><button class="hed-bar" type="button" interestfor="edp{{ `Ed`.raw }}" interesttarget="edp{{ `Ed`.raw }}" popovertarget="edp{{ `Ed`.raw }}" style="height:{{ values.`BarPct`.raw }}%;anchor-name:--ed{{ `Ed`.raw }};"></button><span class="hed-yr wc-num">{{ `Ed`.formatted }}</span><div id="edp{{ `Ed`.raw }}" popover class="hed-pop" style="position-anchor:--ed{{ `Ed`.raw }};"><span class="yr wc-num">{{ `Ed`.formatted }}</span><span class="big wc-num">{{ values.`Gpm`.formatted }}</span> goals/match<span class="mt wc-num">{{ values.`Matches`.formatted }} matches · {{ values.`Goals`.formatted }} goals</span></div></div>
+{% end %}
+</div>
+<div class="hed-foot"><span>Dashed line = all-time average, <b class="wc-num">{{ rows[0].values.`FieldAvg`.formatted }}</b> per match</span><span>This <b>2026</b> edition in gold · the 1950s were the high-water mark</span></div>
+</div></div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'edsort'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 30
+        row_limit: 30
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_history.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_history.block.aml
@@ -1,0 +1,597 @@
+// History tab blocks (honours wall).
+
+Func wc_hist_wall() {
+  TextBlock {
+    content: @md
+<style>
+/* dark green-stained wood paneling: fine vertical grain over wide plank seams (dark groove + thin
+   highlight) on a cool green-wood base, with a soft overhead light pool. The bronze board hangs on it
+   like an honours board on a club wall. */
+.hist-wall { position:relative; width:100%; height:100%; border-radius:14px; overflow:hidden;
+  background:
+    radial-gradient(64% 50% at 50% 40%, rgba(242,200,75,.075), transparent 72%),
+    repeating-linear-gradient(90deg, transparent 0 196px, rgba(0,0,0,.3) 196px 198px, rgba(255,236,200,.03) 198px 199px, transparent 199px 200px),
+    repeating-linear-gradient(90deg, rgba(0,0,0,.1) 0 1px, transparent 1px 8px, rgba(255,232,192,.018) 8px 9px, transparent 9px 16px),
+    linear-gradient(180deg, #1b2a22 0%, #122019 52%, #0c1610 100%);
+  box-shadow: inset 0 0 0 2px rgba(0,0,0,.3); }
+/* gentle ambient vignette so the board sits in a soft pool of light, not a fake cone */
+.hist-wall .glow { position:absolute; inset:0; pointer-events:none;
+  background: radial-gradient(118% 86% at 50% 46%, transparent 60%, rgba(3,10,7,.5) 100%); }
+</style>
+<div class="hist-wall"><i class="glow"></i></div>
+;;
+  }
+}
+
+Func wc_hist_zone() {
+  TextBlock {
+    content: @md
+<style>
+.hist-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="hist-zone-label">The archive · 1930–2022 · who owns the World Cup</p>
+;;
+  }
+}
+
+Func wc_hist_champions() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_team_aliases.entity_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_team_aliases.entity_flag)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'Titles'
+          ref: r(worldcup.wc_titles)
+          uname: 'titles'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Finals'
+          ref: r(worldcup.wc_finals_reached)
+          uname: 'finals'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Semis'
+          ref: r(worldcup.wc_semis_reached)
+          uname: 'semis'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Apps'
+          ref: r(worldcup.wc_appearances)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Years'
+          ref: r(worldcup.hist_title_years)
+        }
+      ]
+      content: @md
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&display=swap');
+/* engraved text = dark bronze ink + a 1px light highlight on the lower edge (debossed into metal). */
+.hof-wrap { width:100%; box-sizing:border-box; padding:2px; }
+/* walnut frame: fine grain threads (dark + light) + vertical plank-tone figure + a top-down shade, with a
+   carved bevel (bright top inner edge, dark lower edge). Grain is high-contrast so the wood reads at a glance. */
+.hof { position:relative; border-radius:13px; padding:22px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0,0,0,.13) 0 1px, transparent 1px 7px, rgba(255,212,150,.045) 7px 8px, transparent 8px 14px),
+    linear-gradient(90deg, #3a2817, #4c3722 17%, #32220f 39%, #4a3320 61%, #2c1c0c 83%, #3f2c19),
+    linear-gradient(180deg,#43301d,#2a1b0c);
+  box-shadow:0 30px 48px -22px rgba(4,18,11,.72), 0 2px 0 rgba(0,0,0,.45),
+    inset 0 2px 0 rgba(255,224,164,.24), inset 0 -5px 8px rgba(0,0,0,.6), inset 0 0 0 1px rgba(0,0,0,.45); }
+/* brass corner screws on the walnut frame */
+.hof::before, .hof::after { content:""; position:absolute; top:6px; width:10px; height:10px; border-radius:50%;
+  background:radial-gradient(120% 120% at 34% 28%, #e4cf94, #6e5526); box-shadow:0 1px 2px rgba(0,0,0,.55), inset 0 -1px 1px rgba(60,40,10,.6); }
+.hof::before { left:6px; } .hof::after { right:6px; }
+.hof-plate { position:relative; overflow:hidden; border-radius:7px; padding:18px 26px 16px;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,250,225,.05) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg,#cdaa6a,#b89252 44%,#9c7836);
+  box-shadow:inset 0 0 0 1px rgba(255,240,200,.3), inset 0 2px 7px rgba(255,245,215,.32),
+    inset 0 -12px 26px rgba(60,40,12,.38),
+    0 0 0 2px #241708, 0 0 0 4px rgba(214,176,108,.55), 0 0 0 5px rgba(0,0,0,.35), 0 4px 11px rgba(0,0,0,.55); }
+/* sheen-sweep: a single diagonal glint travels across the bronze on load — light catching polished metal */
+.hof-plate::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:4;
+  background:linear-gradient(105deg, transparent 40%, rgba(255,252,232,.4) 49%, rgba(255,252,232,.12) 53%, transparent 62%);
+  transform:translateX(-130%); animation:hof-sheen 1.5s cubic-bezier(.4,0,.2,1) .35s 1 forwards; }
+@keyframes hof-sheen { to { transform:translateX(130%); } }
+.hof-cap { display:flex; align-items:center; justify-content:center; gap:16px; margin-bottom:16px; }
+.hof-cap .lr { flex:none; width:60px; height:1.5px; background:linear-gradient(90deg, transparent, rgba(74,52,16,.7)); }
+.hof-cap .lr.r { background:linear-gradient(90deg, rgba(74,52,16,.7), transparent); }
+.hof-title { font-family:'Cinzel',serif; font-weight:800; font-size:27px; letter-spacing:.2em; text-transform:uppercase;
+  color:#46330f; text-shadow:0 1px 0 rgba(255,247,218,.6); white-space:nowrap; }
+.hof-sub { text-align:center; font-family:var(--font-body); font-size:11px; letter-spacing:.16em; text-transform:uppercase;
+  color:rgba(70,50,16,.66); margin:-10px 0 16px; }
+.hof-colhead, .hof-row { display:grid; grid-template-columns:46px 58px 256px minmax(0,1fr) 72px 72px 80px;
+  gap:16px; align-items:center; }
+.hof-colhead { padding:0 6px 9px; font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.13em;
+  text-transform:uppercase; color:rgba(70,50,16,.62); border-bottom:1px solid rgba(74,52,16,.32);
+  box-shadow:0 1px 0 rgba(255,247,218,.4); }
+.hof-colhead .c { text-align:center; }
+.hof-list { counter-reset:hof; }
+/* engrave-in: rows settle onto the plaque top→bottom, like names being struck one by one */
+.hof-row { counter-increment:hof; padding:11px 6px; border-top:1px solid rgba(74,52,16,.22);
+  box-shadow:inset 0 1px 0 rgba(255,247,218,.34);
+  opacity:0; animation:hof-engrave .5s ease-out forwards; }
+.hof-row:first-child { border-top:0; box-shadow:none; }
+.hof-row:nth-child(1){animation-delay:.30s} .hof-row:nth-child(2){animation-delay:.40s}
+.hof-row:nth-child(3){animation-delay:.50s} .hof-row:nth-child(4){animation-delay:.60s}
+.hof-row:nth-child(5){animation-delay:.70s} .hof-row:nth-child(6){animation-delay:.80s}
+.hof-row:nth-child(7){animation-delay:.90s} .hof-row:nth-child(8){animation-delay:1.0s}
+@keyframes hof-engrave { from { opacity:0; transform:translateY(9px); } to { opacity:1; transform:none; } }
+@media (prefers-reduced-motion: reduce) {
+  .hof-row { opacity:1; animation:none; }
+  .hof-plate::after { animation:none; display:none; }
+}
+.hof-rk { font-family:'Cinzel',serif; font-weight:700; font-size:21px; text-align:center; color:rgba(70,50,16,.7);
+  text-shadow:0 1px 0 rgba(255,247,218,.5); }
+.hof-rk::before { content:counter(hof); }
+.hof-row:first-child .hof-rk { color:#7a5a16; }
+.hof .hof-row img { width:42px !important; height:28px !important; border-radius:2px !important; margin:0 !important;
+  display:block !important; object-fit:cover; box-shadow:0 0 0 1px rgba(74,52,16,.5), 0 2px 4px rgba(40,26,8,.5); }
+.hof .hof-row img[src=""], .hof .hof-row img:not([src]) { display:none !important; }
+.hof-nm { min-width:0; }
+.hof-nm .n { display:block; font-family:'Cinzel',serif; font-weight:700; font-size:23px; letter-spacing:.03em;
+  text-transform:uppercase; color:#3c2a0c; text-shadow:0 1px 0 rgba(255,247,218,.55);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hof-nm .y { display:block; font-family:var(--font-body); font-size:10.5px; letter-spacing:.05em;
+  color:rgba(70,50,16,.62); margin-top:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+/* the trophy shelf: a recessed bronze channel spanning the column; each title is a cup, so the
+   ribbon length IS the title count — the rows descend like a chart, and the empty channel to the
+   right reads as shelf, not dead space. Cup count comes from --n (inline), width = n × tile. */
+.hof-shelf { position:relative; height:42px; border-radius:5px; display:flex; align-items:center;
+  gap:14px; padding:0 14px; overflow:hidden;
+  background:linear-gradient(180deg, rgba(60,40,12,.2), rgba(60,40,12,.06));
+  box-shadow:inset 0 2px 3px rgba(40,26,8,.4), inset 0 -1px 0 rgba(255,247,218,.28); }
+.hof-shelf .ct { flex:none; font-family:'Cinzel',serif; font-weight:800; font-size:32px; line-height:1; color:#43300d;
+  text-shadow:0 1px 0 rgba(255,247,218,.6), 0 -1px 1px rgba(60,40,10,.22); }
+.hof-shelf .cups { flex:none; height:30px; width:calc(var(--n) * 34px);
+  background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 28 24'><g fill='%236e5113'><path d='M8 3h12v2.5c0 3.6-2.7 6.5-6 6.5S8 9.1 8 5.5V3z'/><path d='M5 4h3v2H7c0 1.3.6 2.3 1.5 2.9C6 9 5 7.1 5 5V4z'/><path d='M23 4h-3v2h1c0 1.3-.6 2.3-1.5 2.9C22 9 23 7.1 23 5V4z'/><rect x='13' y='12' width='2' height='3'/><path d='M10 16h8l-1-2H11z'/><rect x='9' y='16' width='10' height='2.2' rx='1'/></g></svg>") repeat-x left center;
+  background-size:34px 30px; filter:drop-shadow(0 1px 0 rgba(255,247,218,.4)); }
+.hof-stat { text-align:center; line-height:1; }
+.hof-stat .v { display:block; font-family:'Cinzel',serif; font-weight:700; font-size:25px; color:#43300d;
+  text-shadow:0 1px 0 rgba(255,247,218,.5); }
+.hof-foot { margin-top:15px; padding-top:12px; border-top:1px solid rgba(74,52,16,.28);
+  display:flex; justify-content:space-between; gap:10px;
+  font-family:var(--font-body); font-size:10px; letter-spacing:.05em; text-transform:uppercase; color:rgba(70,50,16,.58); }
+</style>
+<div class="hof-wrap"><div class="hof"><div class="hof-plate">
+  <div class="hof-cap"><span class="lr"></span><span class="hof-title">Hall of Champions</span><span class="lr r"></span></div>
+  <div class="hof-sub">Every nation to lift the trophy · 1930–2022</div>
+  <div class="hof-colhead"><span class="c">#</span><span></span><span>Nation</span><span>Titles won</span><span class="c">Finals</span><span class="c">Semis</span><span class="c">Apps</span></div>
+  <div class="hof-list">
+{% map(rows) %}
+  <div class="hof-row">
+    <span class="hof-rk wc-num"></span>
+    <img src="{{ `Flag`.raw }}" alt="" />
+    <span class="hof-nm"><span class="n">{{ `Team`.formatted }}</span><span class="y wc-num">Won {{ values.`Years`.raw }}</span></span>
+    <span class="hof-shelf"><span class="ct wc-num">{{ values.`Titles`.formatted }}</span><span class="cups" style="--n:{{ values.`Titles`.raw }};"></span></span>
+    <span class="hof-stat"><span class="v wc-num">{{ values.`Finals`.formatted }}</span></span>
+    <span class="hof-stat"><span class="v wc-num">{{ values.`Semis`.formatted }}</span></span>
+    <span class="hof-stat"><span class="v wc-num">{{ values.`Apps`.formatted }}</span></span>
+  </div>
+{% end %}
+  </div>
+  <div class="hof-foot">
+    <span>Engraved by titles · West Germany counts as Germany</span>
+    <span>22 editions played · 8 nations have ever lifted it</span>
+  </div>
+</div></div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'titles'
+            direction: 'desc'
+          },
+          SortSetting {
+            key: 'finals'
+            direction: 'desc'
+          },
+          SortSetting {
+            key: 'semis'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 8
+        row_limit: 8
+      }
+    }
+  }
+}
+
+Func wc_hist_roll() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Yr'
+          ref: r(wc_history_finals.year)
+          uname: 'yr'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Edition'
+          ref: r(wc_history_finals.year_text)
+        },
+        VizFieldFull {
+          label: 'Host'
+          ref: r(wc_history_finals.host_name)
+        },
+        VizFieldFull {
+          label: 'Champ'
+          ref: r(wc_history_finals.champ_name)
+        },
+        VizFieldFull {
+          label: 'CFlag'
+          ref: r(wc_history_finals.champ_flag)
+        },
+        VizFieldFull {
+          label: 'Score'
+          ref: r(wc_history_finals.score_label)
+        },
+        VizFieldFull {
+          label: 'Runner'
+          ref: r(wc_history_finals.runner_name)
+        },
+        VizFieldFull {
+          label: 'RFlag'
+          ref: r(wc_history_finals.runner_flag)
+        }
+      ]
+      content: @md
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&display=swap');
+.roll-wrap { width:100%; box-sizing:border-box; padding:2px; }
+/* walnut frame — same grain/bevel/corner-screw language as the Hall plaque */
+.roll { position:relative; border-radius:13px; padding:22px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0,0,0,.13) 0 1px, transparent 1px 7px, rgba(255,212,150,.045) 7px 8px, transparent 8px 14px),
+    linear-gradient(90deg, #3a2817, #4c3722 17%, #32220f 39%, #4a3320 61%, #2c1c0c 83%, #3f2c19),
+    linear-gradient(180deg,#43301d,#2a1b0c);
+  box-shadow:0 30px 48px -22px rgba(4,18,11,.72), 0 2px 0 rgba(0,0,0,.45),
+    inset 0 2px 0 rgba(255,224,164,.24), inset 0 -5px 8px rgba(0,0,0,.6), inset 0 0 0 1px rgba(0,0,0,.45); }
+.roll::before, .roll::after { content:""; position:absolute; top:6px; width:10px; height:10px; border-radius:50%;
+  background:radial-gradient(120% 120% at 34% 28%, #e4cf94, #6e5526); box-shadow:0 1px 2px rgba(0,0,0,.55), inset 0 -1px 1px rgba(60,40,10,.6); }
+.roll::before { left:6px; } .roll::after { right:6px; }
+.roll-plate { position:relative; overflow:hidden; border-radius:7px; padding:18px 26px 16px;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,250,225,.05) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg,#cdaa6a,#b89252 44%,#9c7836);
+  box-shadow:inset 0 0 0 1px rgba(255,240,200,.3), inset 0 2px 7px rgba(255,245,215,.32),
+    inset 0 -12px 26px rgba(60,40,12,.38),
+    0 0 0 2px #241708, 0 0 0 4px rgba(214,176,108,.55), 0 0 0 5px rgba(0,0,0,.35), 0 4px 11px rgba(0,0,0,.55); }
+.roll-plate::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:4;
+  background:linear-gradient(105deg, transparent 40%, rgba(255,252,232,.4) 49%, rgba(255,252,232,.12) 53%, transparent 62%);
+  transform:translateX(-130%); animation:roll-sheen 1.6s cubic-bezier(.4,0,.2,1) .35s 1 forwards; }
+@keyframes roll-sheen { to { transform:translateX(130%); } }
+.roll-cap { display:flex; align-items:center; justify-content:center; gap:16px; margin-bottom:14px; }
+.roll-cap .lr { flex:none; width:60px; height:1.5px; background:linear-gradient(90deg, transparent, rgba(74,52,16,.7)); }
+.roll-cap .lr.r { background:linear-gradient(90deg, rgba(74,52,16,.7), transparent); }
+.roll-title { font-family:'Cinzel',serif; font-weight:800; font-size:25px; letter-spacing:.2em; text-transform:uppercase;
+  color:#46330f; text-shadow:0 1px 0 rgba(255,247,218,.6); white-space:nowrap; }
+.roll-sub { text-align:center; font-family:var(--font-body); font-size:11px; letter-spacing:.16em; text-transform:uppercase;
+  color:rgba(70,50,16,.66); margin:-8px 0 14px; }
+.roll-colhead, .roll-row { display:grid; grid-template-columns:210px minmax(0,1fr) 150px minmax(0,1fr);
+  gap:18px; align-items:center; }
+.roll-colhead { padding:0 6px 8px; font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.13em;
+  text-transform:uppercase; color:rgba(70,50,16,.62); border-bottom:1px solid rgba(74,52,16,.32);
+  box-shadow:0 1px 0 rgba(255,247,218,.4); }
+.roll-colhead .c { text-align:center; }
+.roll-colhead .e { text-align:right; }
+/* engrave-in: finals settle onto the plaque oldest→newest, like a roll being struck line by line */
+.roll-row { padding:8.5px 6px; border-top:1px solid rgba(74,52,16,.2); box-shadow:inset 0 1px 0 rgba(255,247,218,.3);
+  opacity:0; animation:roll-engrave .5s ease-out forwards; }
+.roll-row:first-child { border-top:0; box-shadow:none; }
+.roll-row:nth-child(1){animation-delay:.30s} .roll-row:nth-child(2){animation-delay:.33s}
+.roll-row:nth-child(3){animation-delay:.36s} .roll-row:nth-child(4){animation-delay:.39s}
+.roll-row:nth-child(5){animation-delay:.42s} .roll-row:nth-child(6){animation-delay:.45s}
+.roll-row:nth-child(7){animation-delay:.48s} .roll-row:nth-child(8){animation-delay:.51s}
+.roll-row:nth-child(9){animation-delay:.54s} .roll-row:nth-child(10){animation-delay:.57s}
+.roll-row:nth-child(11){animation-delay:.60s} .roll-row:nth-child(12){animation-delay:.63s}
+.roll-row:nth-child(13){animation-delay:.66s} .roll-row:nth-child(14){animation-delay:.69s}
+.roll-row:nth-child(15){animation-delay:.72s} .roll-row:nth-child(16){animation-delay:.75s}
+.roll-row:nth-child(17){animation-delay:.78s} .roll-row:nth-child(18){animation-delay:.81s}
+.roll-row:nth-child(19){animation-delay:.84s} .roll-row:nth-child(20){animation-delay:.87s}
+.roll-row:nth-child(21){animation-delay:.90s} .roll-row:nth-child(22){animation-delay:.93s}
+@keyframes roll-engrave { from { opacity:0; transform:translateY(7px); } to { opacity:1; transform:none; } }
+@media (prefers-reduced-motion: reduce) {
+  .roll-row { opacity:1; animation:none; }
+  .roll-plate::after { animation:none; display:none; }
+}
+.roll-ed { line-height:1.05; }
+.roll-ed .y { font-family:'Cinzel',serif; font-weight:700; font-size:20px; color:#3c2a0c; text-shadow:0 1px 0 rgba(255,247,218,.55); }
+.roll-ed .h { display:block; font-family:var(--font-body); font-size:10px; letter-spacing:.05em; text-transform:uppercase;
+  color:rgba(70,50,16,.6); margin-top:2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.roll-side { display:flex; align-items:center; gap:10px; min-width:0; }
+.roll-side.win { font-weight:700; }
+.roll-side.lose { justify-content:flex-end; text-align:right; }
+.roll .roll-side img { width:34px !important; height:23px !important; border-radius:2px !important; margin:0 !important;
+  display:block !important; flex:none; object-fit:cover; box-shadow:0 0 0 1px rgba(74,52,16,.5), 0 2px 4px rgba(40,26,8,.5); }
+.roll .roll-side img[src=""], .roll .roll-side img:not([src]) { display:none !important; }
+.roll-side .nm { font-family:'Cinzel',serif; letter-spacing:.02em; text-transform:uppercase; white-space:nowrap;
+  overflow:hidden; text-overflow:ellipsis; min-width:0; }
+.roll-side.win .nm { font-weight:700; font-size:17px; color:#7a5a16; text-shadow:0 1px 0 rgba(255,247,218,.6); }
+.roll-side.lose .nm { font-weight:600; font-size:14px; color:rgba(60,42,12,.78); }
+/* scoreline cartouche — a small recessed bronze plate, the engraved final result */
+.roll-score { justify-self:center; font-family:'Cinzel',serif; font-weight:700; font-size:16px; color:#43300d;
+  text-shadow:0 1px 0 rgba(255,247,218,.5); padding:3px 12px; border-radius:5px; white-space:nowrap;
+  background:linear-gradient(180deg, rgba(60,40,12,.16), rgba(60,40,12,.04));
+  box-shadow:inset 0 1px 2px rgba(40,26,8,.35), inset 0 -1px 0 rgba(255,247,218,.3); }
+.roll-foot { margin-top:14px; padding-top:12px; border-top:1px solid rgba(74,52,16,.28);
+  display:flex; justify-content:space-between; gap:10px;
+  font-family:var(--font-body); font-size:10px; letter-spacing:.05em; text-transform:uppercase; color:rgba(70,50,16,.58); }
+</style>
+<div class="roll-wrap"><div class="roll"><div class="roll-plate">
+  <div class="roll-cap"><span class="lr"></span><span class="roll-title">Roll of Champions</span><span class="lr r"></span></div>
+  <div class="roll-sub">Every final · 1930–2022</div>
+  <div class="roll-colhead"><span>Edition · Host</span><span>Champion</span><span class="c">Final</span><span class="e">Runner-up</span></div>
+  <div class="roll-list">
+{% map(rows) %}
+  <div class="roll-row">
+    <span class="roll-ed"><span class="y wc-num">{{ `Edition`.formatted }}</span><span class="h">{{ `Host`.formatted }}</span></span>
+    <span class="roll-side win"><img src="{{ `CFlag`.raw }}" alt="" /><span class="nm">{{ `Champ`.formatted }}</span></span>
+    <span class="roll-score wc-num">{{ `Score`.formatted }}</span>
+    <span class="roll-side lose"><span class="nm">{{ `Runner`.formatted }}</span><img src="{{ `RFlag`.raw }}" alt="" /></span>
+  </div>
+{% end %}
+  </div>
+  <div class="roll-foot">
+    <span>Engraved oldest → newest · gold = lifted the trophy</span>
+    <span>1950 decided by the final pool — Uruguay's win over Brazil stands as the final</span>
+  </div>
+</div></div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'yr'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 22
+        row_limit: 22
+      }
+    }
+  }
+}
+
+Func wc_hist_pedigree() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_team_aliases.entity_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_team_aliases.entity_flag)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'Ped'
+          ref: r(worldcup.pedigree_score)
+          uname: 'ped'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Titles'
+          ref: r(worldcup.wc_titles)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Finals'
+          ref: r(worldcup.wc_finals_reached)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Semis'
+          ref: r(worldcup.wc_semis_reached)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Apps'
+          ref: r(worldcup.wc_appearances)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'BarPct'
+          ref: r(worldcup.pedigree_bar_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'AvgPct'
+          ref: r(worldcup.pedigree_avg_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'FieldAvg'
+          ref: r(worldcup.pedigree_field_avg)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        }
+      ]
+      content: @md
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;800&display=swap');
+.ped-wrap { width:100%; box-sizing:border-box; padding:2px; }
+.ped { position:relative; border-radius:13px; padding:22px;
+  background:
+    repeating-linear-gradient(90deg, rgba(0,0,0,.13) 0 1px, transparent 1px 7px, rgba(255,212,150,.045) 7px 8px, transparent 8px 14px),
+    linear-gradient(90deg, #3a2817, #4c3722 17%, #32220f 39%, #4a3320 61%, #2c1c0c 83%, #3f2c19),
+    linear-gradient(180deg,#43301d,#2a1b0c);
+  box-shadow:0 30px 48px -22px rgba(4,18,11,.72), 0 2px 0 rgba(0,0,0,.45),
+    inset 0 2px 0 rgba(255,224,164,.24), inset 0 -5px 8px rgba(0,0,0,.6), inset 0 0 0 1px rgba(0,0,0,.45); }
+.ped::before, .ped::after { content:""; position:absolute; top:6px; width:10px; height:10px; border-radius:50%;
+  background:radial-gradient(120% 120% at 34% 28%, #e4cf94, #6e5526); box-shadow:0 1px 2px rgba(0,0,0,.55), inset 0 -1px 1px rgba(60,40,10,.6); }
+.ped::before { left:6px; } .ped::after { right:6px; }
+.ped-plate { position:relative; overflow:hidden; border-radius:7px; padding:18px 26px 16px;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,250,225,.05) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg,#cdaa6a,#b89252 44%,#9c7836);
+  box-shadow:inset 0 0 0 1px rgba(255,240,200,.3), inset 0 2px 7px rgba(255,245,215,.32),
+    inset 0 -12px 26px rgba(60,40,12,.38),
+    0 0 0 2px #241708, 0 0 0 4px rgba(214,176,108,.55), 0 0 0 5px rgba(0,0,0,.35), 0 4px 11px rgba(0,0,0,.55); }
+.ped-plate::after { content:""; position:absolute; inset:0; pointer-events:none; z-index:4;
+  background:linear-gradient(105deg, transparent 40%, rgba(255,252,232,.4) 49%, rgba(255,252,232,.12) 53%, transparent 62%);
+  transform:translateX(-130%); animation:ped-sheen 1.6s cubic-bezier(.4,0,.2,1) .35s 1 forwards; }
+@keyframes ped-sheen { to { transform:translateX(130%); } }
+.ped-cap { display:flex; align-items:center; justify-content:center; gap:16px; margin-bottom:14px; }
+.ped-cap .lr { flex:none; width:60px; height:1.5px; background:linear-gradient(90deg, transparent, rgba(74,52,16,.7)); }
+.ped-cap .lr.r { background:linear-gradient(90deg, rgba(74,52,16,.7), transparent); }
+.ped-title { font-family:'Cinzel',serif; font-weight:800; font-size:25px; letter-spacing:.2em; text-transform:uppercase;
+  color:#46330f; text-shadow:0 1px 0 rgba(255,247,218,.6); white-space:nowrap; }
+.ped-sub { text-align:center; font-family:var(--font-body); font-size:11px; letter-spacing:.16em; text-transform:uppercase;
+  color:rgba(70,50,16,.66); margin:-8px 0 14px; }
+.ped-colhead, .ped-row { display:grid; grid-template-columns:44px 56px 230px minmax(0,1fr) 58px;
+  gap:16px; align-items:center; }
+.ped-colhead { padding:0 6px 8px; font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.13em;
+  text-transform:uppercase; color:rgba(70,50,16,.62); border-bottom:1px solid rgba(74,52,16,.32);
+  box-shadow:0 1px 0 rgba(255,247,218,.4); }
+.ped-colhead .c { text-align:center; }
+.ped-colhead .e { text-align:right; }
+.ped-list { counter-reset:ped; }
+.ped-row { counter-increment:ped; padding:9px 6px; border-top:1px solid rgba(74,52,16,.22);
+  box-shadow:inset 0 1px 0 rgba(255,247,218,.32);
+  opacity:0; animation:ped-engrave .5s ease-out forwards; }
+.ped-row:first-child { border-top:0; box-shadow:none; }
+.ped-row:nth-child(1){animation-delay:.30s} .ped-row:nth-child(2){animation-delay:.37s}
+.ped-row:nth-child(3){animation-delay:.44s} .ped-row:nth-child(4){animation-delay:.51s}
+.ped-row:nth-child(5){animation-delay:.58s} .ped-row:nth-child(6){animation-delay:.65s}
+.ped-row:nth-child(7){animation-delay:.72s} .ped-row:nth-child(8){animation-delay:.79s}
+.ped-row:nth-child(9){animation-delay:.86s} .ped-row:nth-child(10){animation-delay:.93s}
+.ped-row:nth-child(11){animation-delay:1.0s} .ped-row:nth-child(12){animation-delay:1.07s}
+@keyframes ped-engrave { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:none; } }
+@media (prefers-reduced-motion: reduce) {
+  .ped-row { opacity:1; animation:none; }
+  .ped-plate::after { animation:none; display:none; }
+}
+.ped-rk { font-family:'Cinzel',serif; font-weight:700; font-size:20px; text-align:center; color:rgba(70,50,16,.7);
+  text-shadow:0 1px 0 rgba(255,247,218,.5); }
+.ped-rk::before { content:counter(ped); }
+.ped-row:first-child .ped-rk { color:#7a5a16; }
+.ped .ped-row img { width:40px !important; height:27px !important; border-radius:2px !important; margin:0 !important;
+  display:block !important; object-fit:cover; box-shadow:0 0 0 1px rgba(74,52,16,.5), 0 2px 4px rgba(40,26,8,.5); }
+.ped .ped-row img[src=""], .ped .ped-row img:not([src]) { display:none !important; }
+.ped-nm { min-width:0; }
+.ped-nm .n { display:block; font-family:'Cinzel',serif; font-weight:700; font-size:19px; letter-spacing:.02em;
+  text-transform:uppercase; color:#3c2a0c; text-shadow:0 1px 0 rgba(255,247,218,.55);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.ped-nm .br { display:block; font-family:var(--font-body); font-size:10px; letter-spacing:.03em;
+  color:rgba(70,50,16,.62); margin-top:3px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.ped-nm .br b { color:#7a5a16; font-weight:700; }
+/* pedigree meter: a recessed bronze channel; the gold fill length is the score relative to the leader,
+   the engraved notch marks the field-average baseline — every nation read against the typical WC nation. */
+.ped-meter-wrap { display:flex; align-items:center; gap:12px; min-width:0; }
+.ped-meter { position:relative; flex:1; height:16px; border-radius:4px; overflow:hidden; min-width:40px;
+  background:linear-gradient(180deg, rgba(60,40,12,.24), rgba(60,40,12,.08));
+  box-shadow:inset 0 2px 3px rgba(40,26,8,.4), inset 0 -1px 0 rgba(255,247,218,.26); }
+.ped-meter i { position:absolute; left:0; top:0; bottom:0; border-radius:4px 2px 2px 4px;
+  background:linear-gradient(180deg,#e9cf86,#caa251 52%,#a87f33);
+  box-shadow:inset 0 1px 0 rgba(255,247,218,.55), inset 0 -2px 3px rgba(90,62,18,.5); }
+.ped-meter .base { position:absolute; top:-2px; bottom:-2px; width:2px; z-index:3;
+  background:repeating-linear-gradient(180deg, rgba(40,26,8,.85) 0 2px, transparent 2px 4px); }
+.ped-sc { font-family:'Cinzel',serif; font-weight:800; font-size:21px; text-align:right; color:#43300d;
+  text-shadow:0 1px 0 rgba(255,247,218,.5); }
+.ped-row:first-child .ped-sc { color:#7a5a16; }
+.ped-foot { margin-top:14px; padding-top:12px; border-top:1px solid rgba(74,52,16,.28);
+  display:flex; justify-content:space-between; gap:10px;
+  font-family:var(--font-body); font-size:10px; letter-spacing:.05em; text-transform:uppercase; color:rgba(70,50,16,.58); }
+.ped-foot .base-key { display:inline-block; width:2px; height:10px; vertical-align:-1px; margin-right:5px;
+  background:repeating-linear-gradient(180deg, rgba(40,26,8,.85) 0 2px, transparent 2px 4px); }
+</style>
+<div class="ped-wrap"><div class="ped"><div class="ped-plate">
+  <div class="ped-cap"><span class="lr"></span><span class="ped-title">All-time Pedigree</span><span class="lr r"></span></div>
+  <div class="ped-sub">Weighted prestige · 1930–2022</div>
+  <div class="ped-colhead"><span class="c">#</span><span></span><span>Nation</span><span>Pedigree score</span><span class="e">Pts</span></div>
+  <div class="ped-list">
+{% map(rows) %}
+  <div class="ped-row">
+    <span class="ped-rk wc-num"></span>
+    <img src="{{ `Flag`.raw }}" alt="" />
+    <span class="ped-nm"><span class="n">{{ `Team`.formatted }}</span><span class="br"><b class="wc-num">{{ values.`Titles`.formatted }}</b> titles · <b class="wc-num">{{ values.`Finals`.formatted }}</b> finals · <b class="wc-num">{{ values.`Semis`.formatted }}</b> semis · <b class="wc-num">{{ values.`Apps`.formatted }}</b> apps</span></span>
+    <span class="ped-meter-wrap"><span class="ped-meter"><i style="width:{{ values.`BarPct`.raw }}%;"></i><span class="base" style="left:{{ values.`AvgPct`.raw }}%;"></span></span></span>
+    <span class="ped-sc wc-num">{{ values.`Ped`.formatted }}</span>
+  </div>
+{% end %}
+  </div>
+  <div class="ped-foot">
+    <span><span class="base-key"></span>Baseline = field-average pedigree ({{ rows[0].values.`FieldAvg`.formatted }})</span>
+    <span>8·title · 4·final · 2·semi · 1·appearance · West Germany counts as Germany</span>
+  </div>
+</div></div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'ped'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 12
+        row_limit: 12
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_pulse.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_pulse.block.aml
@@ -1,0 +1,228 @@
+// Team HQ — tournament pulse: current campaign stat chips + form strip with real scorelines.
+
+Func wc_hq_pulse() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'KO'
+          ref: r(wc_team_match_results.kickoff_utc)
+          uname: 'fko'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Res'
+          ref: r(wc_team_match_results.result)
+        },
+        VizFieldFull {
+          label: 'ResColor'
+          ref: r(wc_team_match_results.result_color)
+        },
+        VizFieldFull {
+          label: 'FGF'
+          ref: r(wc_team_match_results.gf)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'FGA'
+          ref: r(wc_team_match_results.ga)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Opp'
+          ref: r(wc_team_match_results.opponent_code)
+        },
+        VizFieldFull {
+          label: 'TeamColor'
+          ref: r(wc_teams.color_hex)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'P'
+          ref: r(worldcup.team_matches_played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'W'
+          ref: r(worldcup.matches_won)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'D'
+          ref: r(worldcup.matches_drawn)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'L'
+          ref: r(worldcup.matches_lost)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GF'
+          ref: r(worldcup.goals_for)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GA'
+          ref: r(worldcup.goals_against)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GD'
+          ref: r(worldcup.goal_difference)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Pts'
+          ref: r(worldcup.points)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'WR'
+          ref: r(worldcup.win_rate)
+          format {
+            type: 'number'
+            pattern: '#,##0%'
+          }
+        },
+        VizFieldFull {
+          label: 'CS'
+          ref: r(worldcup.clean_sheets)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md
+<style>
+/* old-ground scoreboard: a board PAINTED in the selected team's kit colour, with the
+   campaign tallies hung as dark enamel number plates (screw heads, alternating hang).
+   Translation of the mockup's stat chips into this page's material language — distinct
+   from clipboard paper, LED glass, split-flap, chalkboard, sticker and broadcast glass. */
+/* height:auto, NOT 100% — the board hugs its content and the block's scroll-safety
+   headroom stays as transparent turf below it, never as empty paint inside it */
+.pulse { width:100%; box-sizing:border-box; border-radius:12px; overflow:hidden;
+  display:flex; flex-direction:column; gap:11px; padding:14px 20px 13px; color:#fff;
+  background:
+    repeating-linear-gradient(90deg, rgba(255,255,255,.03) 0 3px, transparent 3px 8px),
+    radial-gradient(120% 90% at 50% -20%, rgba(255,255,255,.12), transparent 55%),
+    linear-gradient(180deg,
+      color-mix(in srgb, var(--teamc, #1d5c3f) 58%, black 42%),
+      color-mix(in srgb, var(--teamc, #1d5c3f) 42%, black 58%));
+  border:1px solid rgba(0,0,0,.4);
+  box-shadow:0 18px 32px -16px rgba(4,18,11,.65), inset 0 0 0 2px rgba(255,255,255,.09),
+    inset 0 2px 0 rgba(255,255,255,.14), inset 0 -3px 8px rgba(0,0,0,.35); }
+.pulse-head { display:flex; justify-content:space-between; align-items:baseline; gap:10px;
+  padding-bottom:9px; border-bottom:1px solid rgba(255,255,255,.2); }
+.ph-t { font-family:var(--font-disp); font-weight:800; font-size:16px; letter-spacing:.07em;
+  text-transform:uppercase; text-shadow:0 1px 4px rgba(0,0,0,.45); white-space:nowrap; }
+.ph-t b { color:var(--gold-2); }
+.ph-s { font-size:10px; text-transform:uppercase; letter-spacing:.12em; color:rgba(255,255,255,.68);
+  white-space:nowrap; }
+.pl-rail { display:grid; grid-template-columns:repeat(8, minmax(0,1fr)); gap:10px; }
+.pl-plate { text-align:center; min-width:0; }
+.pl-tile { position:relative; display:block; padding:9px 4px 7px; border-radius:6px;
+  background:linear-gradient(180deg,#262d31,#14181b 62%,#1b2125);
+  box-shadow:0 5px 9px -3px rgba(0,0,0,.6), inset 0 1px 0 rgba(255,255,255,.16),
+    inset 0 0 0 1px rgba(0,0,0,.55);
+  transform:rotate(-.5deg); }
+.pl-plate:nth-child(even) .pl-tile { transform:rotate(.5deg); }
+/* screw heads pinning each plate to the board */
+.pl-tile::before, .pl-tile::after { content:""; position:absolute; top:4px; width:5px; height:5px;
+  border-radius:50%; background:radial-gradient(circle at 35% 30%, #aeb6ba, #4e565a);
+  box-shadow:inset 0 -1px 1px rgba(0,0,0,.6); }
+.pl-tile::before { left: 5px; }
+.pl-tile::after { right: 5px; }
+.pl-tile .cv { display:block; font-family:var(--font-disp); font-weight:800; font-size:28px;
+  line-height:1; color:#f4f7f8; text-shadow:0 2px 2px rgba(0,0,0,.7);
+  font-variant-numeric:tabular-nums; white-space:nowrap; }
+.pl-tile .cv:empty::after { content:"0"; }
+.pl-plate.gold .pl-tile .cv { color:var(--gold-2); }
+.pl-plate .cl { display:block; font-size:8.5px; text-transform:uppercase; letter-spacing:.11em;
+  color:rgba(255,255,255,.72); margin-top:6px; white-space:nowrap; text-shadow:0 1px 2px rgba(0,0,0,.5); }
+.pf-form { display:flex; align-items:center; gap:9px; flex-wrap:wrap;
+  padding-top:9px; border-top:1px solid rgba(255,255,255,.2); }
+.pf-form .fl { font-family:var(--font-disp); font-weight:700; font-size:10px; line-height:24px;
+  text-transform:uppercase; letter-spacing:.14em; color:rgba(255,255,255,.68); }
+.pf-r { display:inline-flex; align-items:center; gap:6px; font-size:11px; line-height:1; font-weight:600;
+  height:24px; padding:0 9px 0 4px; border-radius:6px; color:#eef2f3;
+  background:linear-gradient(180deg,#262d31,#171b1e);
+  box-shadow:0 3px 6px -2px rgba(0,0,0,.55), inset 0 1px 0 rgba(255,255,255,.14),
+    inset 0 0 0 1px rgba(0,0,0,.5); white-space:nowrap; }
+.pf-r .o { width:16px; height:16px; border-radius:50%; display:inline-flex; align-items:center;
+  justify-content:center; font-family:var(--font-disp); font-weight:800; font-size:9px; color:#fff;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.25); }
+.pf-r small { color:rgba(255,255,255,.55); font-weight:500; }
+</style>
+<div class="pulse" style="--teamc:{{ rows[0].`TeamColor`.raw }};">
+  <div class="pulse-head">
+    <span class="ph-t">This <b>tournament</b></span>
+    <span class="ph-s">Group stage tallies · form oldest → newest</span>
+  </div>
+  <div class="pl-rail">
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`P`.formatted }}</span></span><span class="cl">Played</span></span>
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`W`.formatted }}-{{ rows[0].values.`D`.formatted }}-{{ rows[0].values.`L`.formatted }}</span></span><span class="cl">W-D-L</span></span>
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`GF`.formatted }}</span></span><span class="cl">Goals for</span></span>
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`GA`.formatted }}</span></span><span class="cl">Goals against</span></span>
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`GD`.formatted }}</span></span><span class="cl">Goal diff</span></span>
+    <span class="pl-plate gold"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`Pts`.formatted }}</span></span><span class="cl">Points</span></span>
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`WR`.formatted }}</span></span><span class="cl">Win rate</span></span>
+    <span class="pl-plate"><span class="pl-tile"><span class="cv wc-num">{{ rows[0].values.`CS`.formatted }}</span></span><span class="cl">Clean sheets</span></span>
+  </div>
+  <div class="pf-form">
+    <span class="fl">Form</span>
+{% map(rows) %}
+  <span class="pf-r"><span class="o" style="background:{{ `ResColor`.raw }};">{{ `Res`.formatted }}</span><span class="wc-num">{{ `FGF`.formatted }}–{{ `FGA`.formatted }}</span><small>{{ `Opp`.formatted }}</small></span>
+{% end %}
+  </div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'fko'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 8
+        row_limit: 8
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_rating.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_rating.block.aml
@@ -1,0 +1,153 @@
+// Team HQ — Elo rating trajectory: a native LineChart on a crafted "rating monitor" chrome.
+// Showcases the date-drill control (DateDrillBlock → snapshot_date granularity) + period-over-period
+// (added later). Two stacked blocks (frame TextBlock = material, no dataset; chart VizBlock = data),
+// same pattern as the Match Center momentum monitor. The chart is scoped to the Nation filter via
+// wc_team_ratings → wc_teams (so it follows the selected team); disabled on the Match filter.
+// Dark screen on purpose: native chart ticks/grid render light, so they need a dark backdrop to read.
+
+Func wc_hq_zone_rating() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">Rating trajectory · two years of Elo</p>
+;;
+  }
+}
+
+Func wc_hq_rating_frame() {
+  TextBlock {
+    content: @md
+<style>
+/* rating monitor — a navy analytics console (its own material): a deep screen the native Elo trace
+   plots onto, with a gold graticule glow, a brushed header rail + status LED, and corner reticle
+   ticks. Dark so the native chart's light ticks + white grid read; gold accent (rating), distinct
+   from the green momentum oscilloscope and from the LED nameplate / clipboard / sticker materials. */
+.rt-wrap { width:100%; height:100%; box-sizing:border-box; padding:0 2px; }
+.rt-card { position:relative; width:100%; height:100%; box-sizing:border-box; border-radius:13px;
+  background:linear-gradient(180deg,#1a2336,#121a2a 55%,#0c1320); border:1px solid #0a1018;
+  box-shadow:0 18px 32px -16px rgba(4,12,28,.7), 0 2px 0 rgba(0,0,0,.35),
+    inset 0 1px 0 rgba(255,255,255,.10), inset 0 -3px 8px rgba(0,0,0,.45);
+  padding:11px 14px 9px; display:flex; flex-direction:column; }
+.rt-head { display:flex; align-items:center; gap:9px; padding:0 2px 8px; }
+.rt-led { width:8px; height:8px; border-radius:50%; flex:none;
+  background:radial-gradient(circle at 35% 30%, #ffe79a, var(--gold)); box-shadow:0 0 8px rgba(242,200,75,.8); }
+.rt-title { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.16em;
+  font-size:14px; line-height:1; color:rgba(234,240,255,.9); }
+.rt-title b { color:var(--gold-2); }
+.rt-sub { font-size:9px; text-transform:uppercase; letter-spacing:.1em; color:rgba(210,222,245,.5); white-space:nowrap; }
+/* deep screen — the native chart (white grid + light ticks + gold trace) draws onto this */
+.rt-screen { position:relative; flex:1; border-radius:8px; overflow:hidden;
+  background:radial-gradient(120% 120% at 50% -10%, rgba(242,200,75,.08), transparent 55%), #0a1120;
+  box-shadow:inset 0 0 0 1px rgba(242,200,75,.14), inset 0 0 40px rgba(0,0,0,.55); }
+/* corner reticle accents (not a full grid — the native chart supplies that) */
+.rt-screen::before, .rt-screen::after { content:""; position:absolute; width:14px; height:14px; pointer-events:none;
+  border-color:rgba(242,200,75,.4); }
+.rt-screen::before { top:7px; left:7px; border-top:1.5px solid rgba(242,200,75,.4); border-left:1.5px solid rgba(242,200,75,.4); border-top-left-radius:3px; }
+.rt-screen::after { bottom:7px; right:7px; border-bottom:1.5px solid rgba(242,200,75,.4); border-right:1.5px solid rgba(242,200,75,.4); border-bottom-right-radius:3px; }
+.rt-foot { display:flex; gap:9px; padding:7px 2px 0; font-size:8px; text-transform:uppercase;
+  letter-spacing:.05em; color:rgba(210,222,245,.42); }
+.rt-foot .sp { margin-left:auto; font-style:italic; opacity:.9; text-transform:none; letter-spacing:.02em; }
+</style>
+<div class="rt-wrap"><div class="rt-card">
+  <div class="rt-head"><span class="rt-led"></span><span class="rt-title">Rating <b>trajectory</b></span><span class="rt-sub">Elo · monthly since 2024</span></div>
+  <div class="rt-screen"></div>
+  <div class="rt-foot"><span>Higher = stronger</span><span class="sp">Set the granularity top-right · scoped to the selected nation</span></div>
+</div></div>
+;;
+  }
+}
+
+Func wc_hq_rating_chart() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: LineChart {
+      dataset: worldcup
+      x_axis: VizFieldFull {
+        label: 'Snapshot'
+        ref: r(wc_team_ratings.snapshot_date)
+        transformation: 'datetrunc month'
+        format {
+          type: 'date'
+          pattern: 'LLL yyyy'
+        }
+      }
+      y_axis {
+        series {
+          field: VizFieldFull {
+            label: 'Elo'
+            ref: r(wc_team_ratings.elo)
+            aggregation: 'avg'
+            format {
+              type: 'number'
+              pattern: '#,##0'
+            }
+          }
+          settings {
+            color: '#f2c84b'
+            line_interpolation: 'smooth'
+          }
+        }
+      }
+      settings {
+        legend_label: 'hidden'
+        show_data_points: true
+        sort: LineFamilySort {
+          type: 'xaxis'
+          direction: 'asc'
+        }
+        row_limit: 500
+      }
+    }
+  }
+}
+
+// Period comparison done cleanly (no confusing overlay): a "30-day movement" readout parked in the
+// monitor header — signed Elo + rank deltas from wc_team_rating_movement (labels/colour pre-built in
+// SQL). Now vs ~a month ago; scoped to the Nation filter via wc_team_rating_movement → wc_teams.
+Func wc_hq_rating_move() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'EloD'
+          ref: r(wc_team_rating_movement.delta_30d_label)
+        },
+        VizFieldFull {
+          label: 'EloDColor'
+          ref: r(wc_team_rating_movement.delta_30d_color)
+        },
+        VizFieldFull {
+          label: 'RankD'
+          ref: r(wc_team_rating_movement.rank_delta_label)
+        }
+      ]
+      content: @md
+<style>
+.rtm { display:flex; gap:18px; justify-content:flex-end; align-items:center; height:100%; padding:0 4px; }
+.rtm-chip { display:flex; flex-direction:column; align-items:flex-end; line-height:1.05; }
+.rtm-k { font-family:var(--font-disp); font-weight:700; font-size:8px; letter-spacing:.14em;
+  text-transform:uppercase; color:rgba(210,222,245,.5); margin-bottom:3px; white-space:nowrap; }
+.rtm-v { font-family:var(--font-disp); font-weight:800; font-size:15px; font-variant-numeric:tabular-nums; white-space:nowrap; }
+</style>
+<div class="rtm">
+{% map(rows) %}
+  <div class="rtm-chip"><span class="rtm-k">Elo · 30d</span><span class="rtm-v" style="color:{{ `EloDColor`.raw }};">{{ `EloD`.formatted }}</span></div>
+  <div class="rtm-chip"><span class="rtm-k">Rank · 30d</span><span class="rtm-v" style="color:rgba(234,240,255,.92);">{{ `RankD`.formatted }}</span></div>
+{% end %}
+</div>
+;;
+      settings {
+        row_limit: 1
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_scout.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_scout.block.aml
@@ -1,0 +1,261 @@
+// Team HQ — scouting dossier: rating verdict + 'The Road Ahead' advance-probability chart.
+
+Func wc_hq_scout() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'TeamName'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'TeamColor'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'RunLabel'
+          ref: r(wc_team_snapshot.run_date_label)
+        },
+        VizFieldFull {
+          label: 'EloRank'
+          ref: r(wc_team_snapshot.elo_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'R32pct'
+          ref: r(wc_team_snapshot.p_r32_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'R16pct'
+          ref: r(wc_team_snapshot.p_r16_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'QFpct'
+          ref: r(wc_team_snapshot.p_qf_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'SFpct'
+          ref: r(wc_team_snapshot.p_sf_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'FINpct'
+          ref: r(wc_team_snapshot.p_final_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'CHpct'
+          ref: r(wc_team_snapshot.p_champion_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'Verdict'
+          ref: r(worldcup.scout_form_verdict)
+        },
+        VizFieldFull {
+          label: 'Class'
+          ref: r(worldcup.scout_class)
+        },
+        VizFieldFull {
+          label: 'Outlook'
+          ref: r(worldcup.scout_outlook)
+        }
+      ]
+      content: @md
+<style>
+/* THE GAFFER'S BOARD — a bespoke material unique to this block: a mounted tactics chalkboard
+   (matte slate in an aluminium frame), the scout's pre-match read written in chalk. NOT a panel,
+   NOT the clipboard — its own object. The scouting brief is chalked on the left, the verdict is
+   CIRCLED in gold chalk (a coach ringing the conclusion), and the road ahead is a chalk projection
+   plotted on the board. Type uses the SHARED scale (Saira Condensed: eyebrow 10px/700/.2em, value
+   14px/800, 9px labels, .wc-num tabular) rendered as chalk — same treatment the LED blocks use on
+   dark. Surface is the only thing bespoke; the typography matches the rest of the dashboard. */
+.tboard { width:100%; height:100%; box-sizing:border-box; padding:13px 13px 19px; display:flex;
+  --chalk:#e9efe6; --chalk-mut:rgba(233,239,230,.62); --chalk-faint:rgba(233,239,230,.4);
+  --chalk-rule:rgba(233,239,230,.17); }
+/* aluminium frame holding the slate */
+.tb-frame { position:relative; flex:1; display:flex; border-radius:9px; padding:7px;
+  background:linear-gradient(180deg,#414c47,#272f2b 55%,#1d2521);
+  box-shadow:0 13px 26px -13px var(--shadow-dir), 0 2px 0 rgba(0,0,0,.34),
+    inset 0 1px 0 rgba(255,255,255,.16), inset 0 -2px 4px rgba(0,0,0,.4);
+  animation:tb-in .5s cubic-bezier(.2,.7,.25,1) both; }
+/* mounting screws, one per corner — the board is bolted to the wall */
+.tb-frame::before, .tb-frame::after { content:""; position:absolute; top:7px; width:5px; height:5px;
+  z-index:3; border-radius:50%; background:radial-gradient(circle at 35% 30%, #c7cfca, #6c756f 70%, #444b46);
+  box-shadow:0 1px 1px rgba(0,0,0,.5); }
+.tb-frame::before { left:7px; } .tb-frame::after { right:7px; }
+/* matte slate with a faint chalk grid + soft top light */
+.tb-slate { position:relative; flex:1; display:flex; border-radius:4px; overflow:hidden;
+  background:
+    radial-gradient(135% 120% at 50% -12%, rgba(233,239,230,.05), transparent 52%),
+    repeating-linear-gradient(0deg, var(--chalk-rule) 0 1px, transparent 1px 27px),
+    repeating-linear-gradient(90deg, var(--chalk-rule) 0 1px, transparent 1px 27px),
+    linear-gradient(162deg,#213a2e,#15241d 70%);
+  background-blend-mode:normal, soft-light, soft-light, normal;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.45), inset 0 2px 16px rgba(0,0,0,.5); }
+/* ── LEFT: the chalked brief ── */
+.tb-l { position:relative; z-index:1; width:38%; flex:none; box-sizing:border-box;
+  padding:17px 20px 17px 22px; display:flex; flex-direction:column; justify-content:space-between; }
+.tb-head { display:flex; align-items:baseline; justify-content:space-between; gap:12px;
+  margin-bottom:12px; padding-bottom:9px; border-bottom:1px solid var(--chalk-rule); }
+.tb-eye { font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.2em;
+  text-transform:uppercase; color:var(--chalk-mut); }
+.tb-eye b { color:var(--gold-2); font-weight:700; }
+.tb-tab { display:inline-flex; align-items:center; gap:6px; white-space:nowrap; color:var(--chalk);
+  font-family:var(--font-disp); font-weight:800; font-size:11px; letter-spacing:.1em; text-transform:uppercase; }
+.tb-tab .kc { width:9px; height:9px; border-radius:2px; flex:none; background:var(--teamc,#1d5c3f);
+  box-shadow:0 0 0 1px rgba(0,0,0,.45), inset 0 0 0 1px rgba(255,255,255,.25); }
+.tb-read { display:flex; flex-direction:column; }
+.tb-f { display:flex; align-items:baseline; gap:14px; padding:8px 0; border-bottom:1px solid var(--chalk-rule); }
+.tb-f .k { flex:0 0 64px; font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.15em;
+  text-transform:uppercase; color:var(--chalk-mut); }
+.tb-f .v { flex:1; min-width:0; font-family:var(--font-disp); font-weight:800; font-size:14px; letter-spacing:.01em;
+  text-transform:uppercase; color:var(--chalk); }
+.tb-f .v .mut { color:var(--chalk-faint); font-weight:700; font-size:.78em; }
+/* VERDICT — kicker OUTSIDE, the word CIRCLED in gold chalk (one element ringed). */
+.tb-verdict { display:flex; flex-direction:column; align-items:center; gap:9px; padding-top:14px; }
+.tb-vk { font-family:var(--font-disp); font-weight:700; font-size:8.5px; letter-spacing:.34em;
+  text-transform:uppercase; color:var(--chalk-mut); padding-left:.34em; }
+.tb-ring { position:relative; display:inline-block; padding:9px 24px; }
+.tb-ring svg { position:absolute; inset:0; width:100%; height:100%; overflow:visible;
+  transform:rotate(-3deg); }
+.tb-ring ellipse { fill:none; stroke:var(--gold-2); stroke-width:2; vector-effect:non-scaling-stroke;
+  stroke-linecap:round; filter:drop-shadow(0 0 3px rgba(242,200,75,.35));
+  stroke-dasharray:400; stroke-dashoffset:0; animation:tb-draw .7s cubic-bezier(.45,.05,.25,1) .5s backwards; }
+.tb-vval { position:relative; text-align:center; font-family:var(--font-disp); font-weight:800; font-size:22px;
+  line-height:1; letter-spacing:.03em; text-transform:uppercase; color:var(--chalk); }
+/* chalk-dashed divider between brief and plot */
+.tb-div { width:0; align-self:stretch; margin:16px 3px; flex:none;
+  border-left:1px dashed var(--chalk-rule); }
+/* ── RIGHT: the road ahead, chalked ── */
+.tb-r { position:relative; z-index:1; flex:1; min-width:0; box-sizing:border-box;
+  padding:16px 22px 13px 18px; display:flex; flex-direction:column; }
+.tb-rh { display:flex; justify-content:flex-start; align-items:center; gap:9px; padding-right:28px; }
+.tb-rh .t { font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.18em;
+  text-transform:uppercase; color:var(--chalk-mut); }
+.tb-rh .tp { width:16px; height:16px; flex:none; color:var(--gold-2); line-height:0;
+  filter:drop-shadow(0 0 4px rgba(242,200,75,.3)); }
+.tb-rsub { font-size:9px; letter-spacing:.04em; text-transform:uppercase; color:var(--chalk-faint); margin:3px 0 9px; }
+.tb-pcts, .tb-rounds { display:grid; grid-template-columns:repeat(6, 1fr); }
+.tb-pcts { margin-bottom:4px; }
+.tb-pcts span { text-align:center; font-family:var(--font-disp); font-weight:800; font-size:15px; color:var(--chalk);
+  font-variant-numeric:tabular-nums; }
+.tb-pcts span b { font-size:.5em; color:var(--chalk-faint); font-weight:700; margin-left:1px; }
+.tb-pcts span.win { color:var(--gold-2); }
+.tb-ridge { position:relative; flex:1; min-height:50px; }
+.tb-rsvg { position:absolute; inset:0; width:100%; height:100%; display:block; overflow:visible; }
+.tb-rfill { fill:var(--chalk); fill-opacity:.06; }
+.tb-rline { fill:none; stroke:var(--chalk); stroke-width:2; vector-effect:non-scaling-stroke;
+  stroke-linejoin:round; stroke-linecap:round; filter:drop-shadow(0 0 2px rgba(233,239,230,.35)); }
+.tb-dot { position:absolute; width:6px; height:6px; border-radius:50%; transform:translate(-50%, 50%);
+  background:var(--chalk); box-shadow:0 0 0 2px rgba(21,36,29,.9); }
+.tb-dot.win { width:9px; height:9px; background:var(--gold-2);
+  box-shadow:0 0 0 2px rgba(21,36,29,.9), 0 0 10px rgba(242,200,75,.55); }
+.tb-rounds { margin-top:7px; padding-top:8px; border-top:1px solid var(--chalk-rule); }
+.tb-rounds span { text-align:center; font-family:var(--font-disp); font-size:8.5px; text-transform:uppercase;
+  letter-spacing:.05em; color:var(--chalk-mut); font-weight:700; }
+.tb-rounds span.win { color:var(--gold-2); }
+/* ── motion ── board settles, the verdict ring is drawn, the curve chalks across, %s fade ── */
+@keyframes tb-in { from { opacity:0; transform:translateY(12px); } to { opacity:1; transform:none; } }
+@keyframes tb-draw { from { stroke-dashoffset:400; } to { stroke-dashoffset:0; } }
+.tb-ridge { animation:tb-chalk .8s cubic-bezier(.32,.6,.3,1) .62s backwards; }
+@keyframes tb-chalk { from { clip-path:inset(0 100% 0 0); } to { clip-path:inset(0 -14% 0 0); } }
+.tb-pcts span { animation:tb-fade .4s ease backwards; }
+.tb-pcts span:nth-child(1) { animation-delay:.78s; } .tb-pcts span:nth-child(2) { animation-delay:.86s; }
+.tb-pcts span:nth-child(3) { animation-delay:.94s; } .tb-pcts span:nth-child(4) { animation-delay:1.02s; }
+.tb-pcts span:nth-child(5) { animation-delay:1.1s; } .tb-pcts span:nth-child(6) { animation-delay:1.18s; }
+@keyframes tb-fade { from { opacity:0; transform:translateY(-4px); } to { opacity:1; transform:none; } }
+@media (prefers-reduced-motion: reduce) {
+  .tb-frame, .tb-ridge, .tb-pcts span { animation:none !important; opacity:1 !important;
+    transform:none !important; clip-path:none !important; }
+  .tb-ring ellipse { animation:none !important; stroke-dashoffset:0 !important; } }
+</style>
+<div class="tboard" style="--teamc:{{ rows[0].`TeamColor`.raw }};">
+  <div class="tb-frame">
+    <div class="tb-slate">
+      <div class="tb-l">
+        <div class="tb-head">
+          <div class="tb-eye">Scouting <b>report</b></div>
+          <div class="tb-tab"><span class="kc"></span>{{ rows[0].`TeamName`.formatted }}</div>
+        </div>
+        <div class="tb-read">
+          <div class="tb-f"><span class="k">Rating</span><span class="v">{{ rows[0].values.`Class`.formatted }} <span class="mut">· #{{ rows[0].`EloRank`.formatted }} of 48</span></span></div>
+          <div class="tb-f"><span class="k">Outlook</span><span class="v">{{ rows[0].values.`Outlook`.formatted }}</span></div>
+        </div>
+        <div class="tb-verdict">
+          <div class="tb-vk">The verdict</div>
+          <div class="tb-ring"><svg viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true" style="margin:0 !important"><ellipse cx="50" cy="50" rx="47" ry="42"></ellipse></svg><div class="tb-vval">{{ rows[0].values.`Verdict`.formatted }}</div></div>
+        </div>
+      </div>
+      <span class="tb-div"></span>
+      <div class="tb-r">
+        <div class="tb-rh"><span class="t">The road ahead</span><span class="tp"><svg viewBox="0 0 24 24" fill="currentColor" style="margin:0 !important;display:block"><path d="M6 4V3h12v1h3v4a3 3 0 0 1-3.4 2.97A6.01 6.01 0 0 1 13 14.9V17h3v2H8v-2h3v-2.1A6.01 6.01 0 0 1 6.4 10.97 3 3 0 0 1 3 8V4h3zm0 2H5v2a1 1 0 0 0 1 .9V6zm13 0h-1v2.9A1 1 0 0 0 19 8V6z"/></svg></span></div>
+        <div class="tb-rsub">Chance of reaching each round · Elo→MC, 10k sims · run {{ rows[0].`RunLabel`.formatted }}</div>
+        <div class="tb-pcts">
+          <span class="wc-num">{{ rows[0].`R32pct`.formatted }}<b>%</b></span>
+          <span class="wc-num">{{ rows[0].`R16pct`.formatted }}<b>%</b></span>
+          <span class="wc-num">{{ rows[0].`QFpct`.formatted }}<b>%</b></span>
+          <span class="wc-num">{{ rows[0].`SFpct`.formatted }}<b>%</b></span>
+          <span class="wc-num">{{ rows[0].`FINpct`.formatted }}<b>%</b></span>
+          <span class="wc-num win">{{ rows[0].`CHpct`.formatted }}<b>%</b></span>
+        </div>
+        <div class="tb-ridge">
+          <svg class="tb-rsvg" viewBox="0 0 100 100" preserveAspectRatio="none" style="margin:0 !important">
+            <g transform="translate(0,100) scale(1,-1)">
+              <polygon class="tb-rfill" points="0,0 0,{{ rows[0].`R32pct`.raw }} 8.333,{{ rows[0].`R32pct`.raw }} 25,{{ rows[0].`R16pct`.raw }} 41.667,{{ rows[0].`QFpct`.raw }} 58.333,{{ rows[0].`SFpct`.raw }} 75,{{ rows[0].`FINpct`.raw }} 91.667,{{ rows[0].`CHpct`.raw }} 100,{{ rows[0].`CHpct`.raw }} 100,0"></polygon>
+              <polyline class="tb-rline" points="0,{{ rows[0].`R32pct`.raw }} 8.333,{{ rows[0].`R32pct`.raw }} 25,{{ rows[0].`R16pct`.raw }} 41.667,{{ rows[0].`QFpct`.raw }} 58.333,{{ rows[0].`SFpct`.raw }} 75,{{ rows[0].`FINpct`.raw }} 91.667,{{ rows[0].`CHpct`.raw }} 100,{{ rows[0].`CHpct`.raw }}"></polyline>
+            </g>
+          </svg>
+          <span class="tb-dot" style="left:8.333%; bottom:calc({{ rows[0].`R32pct`.raw }} * 1%);"></span>
+          <span class="tb-dot" style="left:25%; bottom:calc({{ rows[0].`R16pct`.raw }} * 1%);"></span>
+          <span class="tb-dot" style="left:41.667%; bottom:calc({{ rows[0].`QFpct`.raw }} * 1%);"></span>
+          <span class="tb-dot" style="left:58.333%; bottom:calc({{ rows[0].`SFpct`.raw }} * 1%);"></span>
+          <span class="tb-dot" style="left:75%; bottom:calc({{ rows[0].`FINpct`.raw }} * 1%);"></span>
+          <span class="tb-dot win" style="left:91.667%; bottom:calc({{ rows[0].`CHpct`.raw }} * 1%);"></span>
+        </div>
+        <div class="tb-rounds">
+          <span>Last 32</span>
+          <span>Last 16</span>
+          <span>Quarters</span>
+          <span>Semis</span>
+          <span>Final</span>
+          <span class="win">Champions</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+;;
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_knockout.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_knockout.block.aml
@@ -1,0 +1,273 @@
+// Knockout bracket rounds (Tournament tab). .kbr/.tie/.goal styling lives in theme wc_pitch_day;
+// the cascade keyframes live in header_rail. Each round sets its own --rd cascade delay.
+//
+// wc_knockout_round covers the three identical middle rounds (R16, QF, SF) — they differ only by
+// stage code, heading, cascade delay and row cap. R32 (shows all 16 ties, aggregate-aware) and the
+// Final (trophy meta + .tie-final markup) are kept as their own funcs because their bodies differ.
+Func wc_knockout_round(stage: String, title: String, rd: String, n: Number) {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_matches.stage)
+        operator: 'is'
+        value: stage
+      }
+      rows: [
+        VizFieldFull {
+          label: 'MatchNum'
+          ref: r(wc_matches.match_num)
+          uname: 'mnum'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeFlag'
+          ref: r(wc_home_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayFlag'
+          ref: r(wc_away_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'HomeScore'
+          ref: r(wc_matches.home_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'AwayScore'
+          ref: r(wc_matches.away_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'KODay'
+          ref: r(wc_matches.kickoff_day)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_matches.city)
+        }
+      ]
+      content: @md <style>/* knockout round — .kbr/.tie/.goal styles live in theme wc_pitch_day */</style>
+<div class="kbr" style="--rd:${rd}">
+<div class="kbr-h">${title}</div>
+<div class="kbr-row">
+{% map(rows) %}
+  <article class="tie">
+    <div class="tie-meta"><span>{{ `KODay`.formatted }}</span><span>{{ `City`.formatted }}</span></div>
+    <div class="tie-row"><img src="{{ `HomeFlag`.raw }}" alt="" /><span class="nm">{{ `Home`.formatted }}</span><span class="g wc-num">{{ `HomeScore`.formatted }}</span></div>
+    <div class="tie-row"><img src="{{ `AwayFlag`.raw }}" alt="" /><span class="nm">{{ `Away`.formatted }}</span><span class="g wc-num">{{ `AwayScore`.formatted }}</span></div>
+  </article>
+{% end %}
+</div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'mnum'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: n
+        row_limit: n
+      }
+    }
+  }
+}
+
+// Round of 32 — shows all 16 ties (aggregate-aware, no row cap).
+Func wc_knockout_r32() {
+  VizBlock {
+    label: 'MatchNum, Home and 7 more'
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_matches.stage)
+        operator: 'is'
+        value: 'r32'
+      }
+      rows: [
+        VizFieldFull {
+          label: 'MatchNum'
+          ref: r(wc_matches.match_num)
+          uname: 'mnum'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeFlag'
+          ref: r(wc_home_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayFlag'
+          ref: r(wc_away_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'HomeScore'
+          ref: r(wc_matches.home_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'AwayScore'
+          ref: r(wc_matches.away_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'KODay'
+          ref: r(wc_matches.kickoff_day)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_matches.city)
+        }
+      ]
+      content: @md <style>/* knockout round — .kbr/.tie/.goal styles live in theme wc_pitch_day */</style>
+<div class="kbr" style="--rd:.15s">
+<div class="kbr-h">Round of 32</div>
+<div class="kbr-row">
+{% map(rows) %}
+  <article class="tie">
+    <div class="tie-meta"><span>{{ `KODay`.formatted }}</span><span>{{ `City`.formatted }}</span></div>
+    <div class="tie-row"><img src="{{ `HomeFlag`.raw }}" alt="" /><span class="nm">{{ `Home`.formatted }}</span><span class="g wc-num">{{ `HomeScore`.formatted }}</span></div>
+    <div class="tie-row"><img src="{{ `AwayFlag`.raw }}" alt="" /><span class="nm">{{ `Away`.formatted }}</span><span class="g wc-num">{{ `AwayScore`.formatted }}</span></div>
+  </article>
+{% end %}
+</div>
+</div> ;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'mnum'
+            direction: 'asc'
+          }
+        ]
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+}
+
+// The Final — single tie with trophy meta + gold-foil .tie-final treatment.
+Func wc_knockout_final() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_matches.stage)
+        operator: 'is'
+        value: 'final'
+      }
+      rows: [
+        VizFieldFull {
+          label: 'MatchNum'
+          ref: r(wc_matches.match_num)
+          uname: 'mnum'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeFlag'
+          ref: r(wc_home_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayFlag'
+          ref: r(wc_away_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'HomeScore'
+          ref: r(wc_matches.home_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'AwayScore'
+          ref: r(wc_matches.away_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'KODay'
+          ref: r(wc_matches.kickoff_day)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_matches.city)
+        }
+      ]
+      content: @md <style>/* knockout round — .kbr/.tie/.goal styles live in theme wc_pitch_day */</style>
+<div class="kbr" style="--rd:.67s">
+<div class="kbr-h">Final</div>
+<div class="kbr-row">
+{% map(rows) %}
+  <article class="tie tie-final">
+    <div class="tie-meta"><span class="kt"><svg viewBox="0 0 24 24" fill="none" aria-hidden="true" style="width:12px;height:12px;margin:0 !important;"><path d="M7 4h10v3a5 5 0 0 1-10 0V4z" stroke="currentColor" stroke-width="1.6"/><path d="M7 5H4v2a3 3 0 0 0 3 3M17 5h3v2a3 3 0 0 1-3 3M9 16h6M12 12v4M9 20h6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>The Final</span><span>{{ `KODay`.formatted }} · {{ `City`.formatted }}</span></div>
+    <div class="tie-row"><img src="{{ `HomeFlag`.raw }}" alt="" /><span class="nm">{{ `Home`.formatted }}</span><span class="g wc-num">{{ `HomeScore`.formatted }}</span></div>
+    <div class="tie-row"><img src="{{ `AwayFlag`.raw }}" alt="" /><span class="nm">{{ `Away`.formatted }}</span><span class="g wc-num">{{ `AwayScore`.formatted }}</span></div>
+  </article>
+{% end %}
+</div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'mnum'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 1
+        row_limit: 1
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_match_center.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_match_center.block.aml
@@ -1,0 +1,1245 @@
+// Match Center tab blocks. Match filter (mc_match_filter) stays inline in the page.
+
+Func wc_mc_filter_hint() {
+  TextBlock {
+    content: @md
+<style>
+.mc-hint { font-size:10.5px; line-height:1.5; color:rgba(234,255,242,.62); padding:2px 4px; }
+.mc-hint b { color:rgba(234,255,242,.85); font-weight:600; }
+</style>
+<div class="mc-hint"><b>Pick a match</b> — scoreboard, ticker, team sheets and the odds board all re-arm. Ticker and sheets fill at kickoff; odds refresh with the nightly sim run.</div>
+;;
+  }
+}
+
+Func wc_mc_scoreboard() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeFlag'
+          ref: r(wc_home_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'HomeColor'
+          ref: r(wc_home_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayFlag'
+          ref: r(wc_away_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'AwayColor'
+          ref: r(wc_away_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'StatusText'
+          ref: r(wc_matches.status_label)
+        },
+        VizFieldFull {
+          label: 'StatusColor'
+          ref: r(wc_matches.status_color)
+        },
+        VizFieldFull {
+          label: 'StageLabel'
+          ref: r(wc_matches.stage_label)
+        },
+        VizFieldFull {
+          label: 'FeaturedSort'
+          ref: r(wc_matches.featured_sort)
+          uname: 'mc_featured'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Display'
+          ref: r(wc_matches.featured_display)
+        },
+        VizFieldFull {
+          label: 'DisplaySub'
+          ref: r(wc_matches.featured_display_sub)
+        },
+        VizFieldFull {
+          label: 'KODay'
+          ref: r(wc_matches.kickoff_day)
+        },
+        VizFieldFull {
+          label: 'KOTime'
+          ref: r(wc_matches.kickoff_time)
+        },
+        VizFieldFull {
+          label: 'Venue'
+          ref: r(wc_matches.venue)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_matches.city)
+        },
+        VizFieldFull {
+          label: 'Att'
+          ref: r(wc_matches.attendance)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md
+<style>
+.sb { display:flex; justify-content:center; padding:8px 10px 16px; }
+.sb-bezel { position:relative; width:100%; border-radius:14px; padding:10px;
+  background:linear-gradient(180deg, var(--board-bezel-a), var(--board-bezel-b));
+  box-shadow:0 14px 26px -14px rgba(0,0,0,.6), 0 3px 0 rgba(0,0,0,.35),
+    inset 0 1px 0 rgba(255,255,255,.55), inset 0 -2px 5px rgba(0,0,0,.22); }
+.sb-screen { position:relative; border-radius:8px; overflow:hidden; padding:12px 26px 13px;
+  background:radial-gradient(120% 140% at 50% -20%, rgba(120,255,180,.18), transparent 55%), var(--board-bg);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.08), inset 0 0 40px rgba(0,0,0,.6); }
+.sb-screen::after { content:""; position:absolute; inset:0; pointer-events:none; opacity:.5;
+  background:repeating-linear-gradient(180deg, rgba(255,255,255,.05) 0 1px, transparent 1px 3px); }
+.sb-head { position:relative; display:flex; align-items:center; justify-content:space-between; gap:10px; margin-bottom:8px; }
+.sb-stage { display:inline-flex; align-items:center; gap:8px; font-family:var(--font-disp); font-weight:700;
+  text-transform:uppercase; letter-spacing:.14em; font-size:11px; color:rgba(234,255,242,.78); }
+.sb-badge { font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.07em;
+  text-transform:uppercase; padding:3px 9px; border-radius:999px; color:#fff; box-shadow:0 1px 2px rgba(0,0,0,.3); }
+.sb-ko { font-size:11px; color:rgba(234,255,242,.72); letter-spacing:.02em; white-space:nowrap; }
+.sb-row { position:relative; display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:18px; }
+.sb-team { display:flex; align-items:center; gap:14px; min-width:0; }
+.sb-team.away { flex-direction:row-reverse; }
+.sb-team .sb-kit { flex:none; width:6px; height:44px; border-radius:3px; box-shadow:0 0 12px rgba(255,255,255,.18); }
+.sb-screen .sb-team img { width:62px !important; height:42px !important; border-radius:3px !important; margin:0 !important;
+  display:block !important; object-fit:cover; flex:none; box-shadow:0 6px 16px -6px rgba(0,0,0,.6); }
+.sb-screen .sb-team img[src=""], .sb-screen .sb-team img:not([src]) { display:none !important; }
+.sb-name { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.03em;
+  font-size:34px; line-height:1; color:var(--board-ink); text-shadow:0 0 14px var(--board-glow);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sb-team.away .sb-name { text-align:right; }
+.sb-name:empty::after { content:"TBD"; opacity:.5; font-style:italic; }
+.sb-mid { text-align:center; min-width:170px; }
+.sb-score { font-family:var(--font-disp); font-weight:800; font-size:54px; line-height:.95; color:var(--gold-2);
+  text-shadow:0 0 16px var(--board-glow), 0 2px 0 rgba(0,0,0,.45); white-space:nowrap; }
+.sb-sub { font-size:9.5px; text-transform:uppercase; letter-spacing:.16em; color:rgba(234,255,242,.6); margin-top:5px; }
+.sb-venue { position:relative; text-align:center; font-size:11px; color:rgba(234,255,242,.66); margin-top:9px;
+  padding-top:8px; border-top:1px solid rgba(234,255,242,.14); }
+.sb-att:empty { display:none; }
+.sb-att::before { content:" · "; }
+.sb-att::after { content:" in the stands"; }
+/* scoreboard powers on like the jumbotron (wc-power-on keyframe from header_rail) */
+.sb-screen { animation:wc-power-on .6s ease-out .2s 1; }
+@media (prefers-reduced-motion: reduce) { .sb-screen { animation:none !important; } }
+</style>
+<div class="sb"><div class="sb-bezel"><div class="sb-screen">
+{% map(rows) %}
+  <div class="sb-head">
+    <span class="sb-stage"><span class="sb-badge" style="background:{{ `StatusColor`.raw }};">{{ `StatusText`.formatted }}</span>{{ `StageLabel`.formatted }} · match center</span>
+    <span class="sb-ko">{{ `KODay`.formatted }} · {{ `KOTime`.formatted }} UTC</span>
+  </div>
+  <div class="sb-row">
+    <div class="sb-team home"><span class="sb-kit" style="background:{{ `HomeColor`.raw }};"></span><img src="{{ `HomeFlag`.raw }}" alt="" /><span class="sb-name">{{ `Home`.formatted }}</span></div>
+    <div class="sb-mid"><div class="sb-score wc-num">{{ `Display`.formatted }}</div><div class="sb-sub">{{ `DisplaySub`.formatted }}</div></div>
+    <div class="sb-team away"><span class="sb-kit" style="background:{{ `AwayColor`.raw }};"></span><img src="{{ `AwayFlag`.raw }}" alt="" /><span class="sb-name">{{ `Away`.formatted }}</span></div>
+  </div>
+  <div class="sb-venue">{{ `Venue`.formatted }} · {{ `City`.formatted }}<span class="sb-att wc-num">{{ `Att`.formatted }}</span></div>
+{% end %}
+</div></div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'mc_featured'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 1
+        row_limit: 1
+      }
+    }
+  }
+}
+
+Func wc_mc_zone_ticker() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">Starting XI · how it unfolded</p>
+;;
+  }
+}
+
+Func wc_mc_zone_odds() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">The odds board · what the sim says</p>
+;;
+  }
+}
+
+Func wc_mc_timeline() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_events.is_key_event)
+        operator: 'is'
+        value: true
+      }
+      rows: [
+        VizFieldFull {
+          label: 'TS'
+          ref: r(wc_events.ts)
+          uname: 'ets'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Minute'
+          ref: r(wc_events.match_minute)
+        },
+        VizFieldFull {
+          label: 'Side'
+          ref: r(wc_events.side)
+        },
+        VizFieldFull {
+          label: 'Kind'
+          ref: r(wc_events.event_kind)
+        },
+        VizFieldFull {
+          label: 'MS'
+          ref: r(wc_events.milestone_label)
+        },
+        VizFieldFull {
+          label: 'MSScore'
+          ref: r(wc_events.milestone_score)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Desc'
+          ref: r(wc_events.description)
+        },
+        VizFieldFull {
+          label: 'ScoreChip'
+          ref: r(wc_events.score_chip)
+        }
+      ]
+      content: @md
+<style>
+/* ticker hierarchy: goals = gold hero cards, red cards = alert slips, bookings/subs = quiet
+   slips. Kit colour rides the card's spine-side edge; structural rows are dark referee-board
+   chips sitting on the spine. All variants are driven by Side/Kind classes — no conditionals. */
+.tl-body { position:relative; padding:4px 0 2px; }
+/* spine starts/ends at the first/last marker's midline, not the clipboard edge */
+.tl-body::before { content:""; position:absolute; left:50%; top:22px; bottom:22px; width:2px;
+  background:var(--panel-line); transform:translateX(-50%); }
+.tl-row { position:relative; display:grid; grid-template-columns:1fr 64px 1fr; align-items:center; }
+.tl-row + .tl-row { margin-top:7px; }
+.tl-spine { grid-column:2; grid-row:1; display:flex; justify-content:center; }
+/* one station-stop chip per event: minute INSIDE an opaque pill, so it covers the line and
+   its midline == the card's midline (single child + grid align-items:center) */
+.tl-stop { display:inline-flex; align-items:center; justify-content:center; min-width:42px;
+  padding:3px 9px; border-radius:999px; background:#fbfdfb; border:1px solid var(--panel-line);
+  font-family:var(--font-disp); font-weight:800; font-size:11px; line-height:1.2; color:var(--panel-ink);
+  box-shadow:0 1px 3px rgba(0,0,0,.14); white-space:nowrap; }
+.tl-row.k-yellow .tl-stop { border-color:var(--draw); }
+.tl-row.k-red .tl-stop { border-color:var(--loss); color:#7e1f18; }
+.tl-card { grid-row:1; display:flex; align-items:center; gap:8px; min-width:0; padding:6px 10px;
+  background:linear-gradient(180deg,#fbfdfb,#f0f5f1); border:1px solid var(--panel-line); border-radius:9px;
+  box-shadow:0 6px 14px -10px var(--shadow-dir); }
+.tl-row.home .tl-card { grid-column:1; justify-self:end; flex-direction:row-reverse; }
+.tl-row.away .tl-card { grid-column:3; justify-self:start; }
+.tl .tl-card img { width:20px !important; height:14px !important; border-radius:2px !important; margin:0 !important;
+  display:block !important; object-fit:cover; flex:none; box-shadow:0 1px 2px rgba(0,0,0,.25); }
+/* crafted CSS glyphs (no emoji, no mockup SVGs — paths blur at 14px, CSS shapes stay crisp):
+   every card carries all four, the row's Kind class shows one; .show forces one on (legend) */
+.tl-ico { flex:none; display:inline-flex; align-items:center; justify-content:center;
+  width:16px; height:16px; }
+/* glyph–label alignment: flex centres the text's LINE BOX, and inherited line-height
+   (~1.45) makes that box taller than the capitals, floating icons off the visual midline.
+   line-height:1 collapses the box to the glyphs, so centring becomes optical. */
+.tl .cb-foot { align-items:center; }
+.tl .cb-foot .lg { display:inline-flex; align-items:center; line-height:1; }
+.tl .cb-foot .sp { line-height:1.3; }
+/* every glyph lives in an IDENTICAL 16×16 centred box — shapes are drawn inside it, so
+   icons and labels share one midline everywhere (cards, legend) regardless of shape size */
+.ick { position:relative; flex:none; width:16px; height:16px; display:none;
+  align-items:center; justify-content:center; gap:2px; }
+.ick.show { display:inline-flex; }
+.tl-row.k-goal .tl-ico .ick-ball,
+.tl-row.k-yellow .tl-ico .ick-card.yellow,
+.tl-row.k-red .tl-ico .ick-card.red,
+.tl-row.k-sub .tl-ico .ick-sub { display:inline-flex; }
+/* football: verified truncated-icosahedron glyph (see SVG in markup).
+   margin:0 !important beats MarkdownViz's built-in svg margin-top (same fight as img). */
+.ick-ball svg { display:block; width:15px; height:15px; margin:0 !important; }
+/* referee cards: tilted enamel rectangle drawn inside the box */
+.ick-card::before { content:""; width:9px; height:12px; border-radius:2px; transform:rotate(8deg);
+  background:linear-gradient(160deg, #f7ce53, #d99412);
+  box-shadow:0 1px 2px rgba(0,0,0,.3), inset 0 1px 0 rgba(255,255,255,.4); }
+.ick-card.red::before { background:linear-gradient(160deg, #f0655c, #c52e24); }
+/* substitution: the conventional pair — green on, red off */
+.ick-sub::before { content:""; width:0; height:0; border-left:3.5px solid transparent;
+  border-right:3.5px solid transparent; border-bottom:8px solid #1FA36B; }
+.ick-sub::after { content:""; width:0; height:0; border-left:3.5px solid transparent;
+  border-right:3.5px solid transparent; border-top:8px solid #E5362B; }
+.tl-desc { font-size:11px; line-height:1.35; color:var(--panel-ink); min-width:0; }
+.tl-chip { flex:none; font-family:var(--font-disp); font-weight:800; font-size:12px; color:var(--gold-2);
+  background:linear-gradient(180deg,#16352a,#0c2418); border-radius:6px; padding:2px 8px;
+  box-shadow:0 1px 3px rgba(0,0,0,.3), inset 0 1px 0 rgba(255,255,255,.12); }
+.tl-chip:empty { display:none; }
+/* goals: the hero moment — gold foil card, bold line, glowing spine marker */
+.tl-row.k-goal .tl-card { background:
+    linear-gradient(120deg, transparent 38%, rgba(255,255,255,.35) 47%, transparent 58%),
+    linear-gradient(180deg,#f8ecc0,#ecd592);
+  border-color:rgba(163,121,32,.5); padding:9px 12px;
+  box-shadow:0 10px 20px -10px rgba(120,85,15,.55), inset 0 1px 0 rgba(255,255,255,.55); }
+.tl-row.k-goal .tl-desc { font-weight:700; font-size:12px; color:#4a3608; }
+.tl-row.k-goal .tl-stop { background:linear-gradient(180deg, var(--gold-2), var(--gold));
+  border-color:rgba(163,121,32,.6); color:#3c2c06; font-size:12px;
+  box-shadow:0 0 12px rgba(242,200,75,.6), 0 1px 2px rgba(0,0,0,.2); }
+/* red card: alert slip */
+.tl-row.k-red .tl-card { background:linear-gradient(180deg,#fdf2f1,#f8e2df); border-color:rgba(229,54,43,.45); }
+.tl-row.k-red .tl-desc { font-weight:700; color:#7e1f18; }
+/* structural rows: dark fourth-official board chip on the spine — no full-width rule */
+.tl-ms { display:none; }
+.tl-row.mid { display:block; padding:6px 0; }
+.tl-row.mid .tl-spine, .tl-row.mid .tl-card { display:none; }
+.tl-row.mid .tl-ms { display:flex; justify-content:center; }
+.tl-ms-pill { display:inline-flex; align-items:baseline; gap:7px;
+  font-family:var(--font-disp); font-weight:800; font-size:10px; letter-spacing:.16em; text-transform:uppercase;
+  color:#eafff2; background:linear-gradient(180deg,#1a3c2e,#0c2418); border-radius:999px; padding:4px 15px;
+  box-shadow:0 3px 8px -3px rgba(7,30,18,.6), inset 0 1px 0 rgba(255,255,255,.14); }
+.tl-ms-pill .m { color:var(--gold-2); }
+.tl-ms-pill .sc:empty { display:none; }
+.tl-ms-pill .sc::before { content:"· "; opacity:.55; }
+/* ── motion: the ticker comes to life after the board hinges in — the spine
+   draws top→down, then each event pops in along it in minute order. */
+.tl-body::before { transform-origin:50% 0; animation:tl-spine .5s ease-out .45s backwards; }
+@keyframes tl-spine { from { transform:translateX(-50%) scaleY(0); } to { transform:translateX(-50%) scaleY(1); } }
+.tl-row { animation:tl-pop .4s cubic-bezier(.2,.7,.3,1.05) backwards; }
+@keyframes tl-pop { from { opacity:0; transform:translateY(9px); } to { opacity:1; transform:none; } }
+.tl-body .tl-row:nth-child(1){animation-delay:.50s} .tl-body .tl-row:nth-child(2){animation-delay:.55s}
+.tl-body .tl-row:nth-child(3){animation-delay:.60s} .tl-body .tl-row:nth-child(4){animation-delay:.65s}
+.tl-body .tl-row:nth-child(5){animation-delay:.70s} .tl-body .tl-row:nth-child(6){animation-delay:.75s}
+.tl-body .tl-row:nth-child(7){animation-delay:.80s} .tl-body .tl-row:nth-child(8){animation-delay:.85s}
+.tl-body .tl-row:nth-child(9){animation-delay:.90s} .tl-body .tl-row:nth-child(10){animation-delay:.95s}
+.tl-body .tl-row:nth-child(n+11){animation-delay:1s}
+@media (prefers-reduced-motion: reduce) {
+  .tl-body::before { animation:none !important; transform:translateX(-50%) !important; }
+  .tl-row { animation:none !important; opacity:1 !important; transform:none !important; } }
+</style>
+<div class="cb-wrap"><div class="clipboard tl">
+  <div class="cb-head">
+    <span class="cb-grp">Match <b>ticker</b></span>
+    <span class="cb-sub">Home left · away right · match minutes</span>
+  </div>
+  <div class="tl-body">
+{% map(rows) %}
+  <div class="tl-row {{ `Side`.formatted }} k-{{ `Kind`.formatted }}">
+    <div class="tl-ms"><span class="tl-ms-pill">{{ `MS`.formatted }} <span class="m wc-num">{{ `Minute`.formatted }}</span> <span class="sc wc-num">{{ `MSScore`.formatted }}</span></span></div>
+    <div class="tl-spine"><span class="tl-stop wc-num">{{ `Minute`.formatted }}</span></div>
+    <div class="tl-card"><span class="tl-ico"><span class="ick ick-ball"><svg viewBox="0 0 24 24" style="margin:0 !important;" aria-hidden="true"><circle cx="12" cy="12" r="9.8" fill="#f6f9f6" stroke="#22302a" stroke-width="1.6"/><path d="M12 7.6 7.82 10.64 9.41 15.56 14.59 15.56 16.18 10.64Z" fill="#22302a"/><path d="M12 7.6 12 5M7.82 10.64 5.34 9.84M9.41 15.56 7.89 17.66M14.59 15.56 16.11 17.66M16.18 10.64 18.66 9.84" stroke="#22302a" stroke-width="1.4" stroke-linecap="round" fill="none"/><path d="M14.62 2.87 9.38 2.87 12 4.8Z" fill="#22302a"/><path d="M4.12 6.69 2.51 11.67 5.15 9.78Z" fill="#22302a"/><path d="M4.51 17.85 8.75 20.93 7.77 17.82Z" fill="#22302a"/><path d="M15.25 20.93 19.49 17.85 16.23 17.82Z" fill="#22302a"/><path d="M21.49 11.67 19.88 6.69 18.85 9.78Z" fill="#22302a"/></svg></span><span class="ick ick-card yellow"></span><span class="ick ick-card red"></span><span class="ick ick-sub"></span></span><img src="{{ `Flag`.raw }}" alt="" /><span class="tl-desc">{{ `Desc`.formatted }}</span><span class="tl-chip wc-num">{{ `ScoreChip`.formatted }}</span></div>
+  </div>
+{% end %}
+  </div>
+  <div class="cb-foot">
+    <span class="lg"><span class="ick ick-ball show"><svg viewBox="0 0 24 24" style="margin:0 !important;" aria-hidden="true"><circle cx="12" cy="12" r="9.8" fill="#f6f9f6" stroke="#22302a" stroke-width="1.6"/><path d="M12 7.6 7.82 10.64 9.41 15.56 14.59 15.56 16.18 10.64Z" fill="#22302a"/><path d="M12 7.6 12 5M7.82 10.64 5.34 9.84M9.41 15.56 7.89 17.66M14.59 15.56 16.11 17.66M16.18 10.64 18.66 9.84" stroke="#22302a" stroke-width="1.4" stroke-linecap="round" fill="none"/><path d="M14.62 2.87 9.38 2.87 12 4.8Z" fill="#22302a"/><path d="M4.12 6.69 2.51 11.67 5.15 9.78Z" fill="#22302a"/><path d="M4.51 17.85 8.75 20.93 7.77 17.82Z" fill="#22302a"/><path d="M15.25 20.93 19.49 17.85 16.23 17.82Z" fill="#22302a"/><path d="M21.49 11.67 19.88 6.69 18.85 9.78Z" fill="#22302a"/></svg></span>Goal</span>
+    <span class="lg"><span class="ick ick-card yellow show"></span>Booking</span>
+    <span class="lg"><span class="ick ick-card red show"></span>Sent off</span>
+    <span class="lg"><span class="ick ick-sub show"></span>Substitution</span>
+    <span class="sp">A quiet stretch between whistles is a quiet match, not missing data</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'ets'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 40
+        row_limit: 40
+      }
+    }
+  }
+}
+
+Func wc_mc_lineup_home() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_lineups.side)
+        operator: 'is'
+        value: 'home'
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'Kit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Formation'
+          ref: r(wc_matches.home_formation)
+        },
+        VizFieldFull {
+          label: 'Num'
+          ref: r(wc_players.shirt_number)
+          uname: 'shirt'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Name'
+          ref: r(wc_players.name)
+        },
+        VizFieldFull {
+          label: 'Pos'
+          ref: r(wc_players.position_group)
+        },
+        VizFieldFull {
+          label: 'PosSort'
+          ref: r(wc_players.position)
+          uname: 'psort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Role'
+          ref: r(wc_lineups.role)
+        },
+        VizFieldFull {
+          label: 'RoleSort'
+          ref: r(wc_lineups.role_sort)
+          uname: 'rsort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Cap'
+          ref: r(wc_lineups.captain_tag)
+        },
+        VizFieldFull { label: 'Pid' ref: r(wc_lineups.fifa_player_id) },
+        VizFieldFull { label: 'Flag' ref: r(wc_teams.flag_url) },
+        VizFieldFull { label: 'Photo' ref: r(wc_player_stats.picture_url) },
+        VizFieldFull { label: 'Goals' ref: r(wc_player_stats.goals) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Assists' ref: r(wc_player_stats.assists) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Apps' ref: r(wc_player_stats.apps) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Starts' ref: r(wc_player_stats.starts) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Yellows' ref: r(wc_player_stats.yellows) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Reds' ref: r(wc_player_stats.reds) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Age' ref: r(wc_player_bio.age) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Club' ref: r(wc_player_bio.club) },
+        VizFieldFull { label: 'PosDetail' ref: r(wc_player_bio.position_detail) },
+        VizFieldFull { label: 'Height' ref: r(wc_player_bio.height) },
+        VizFieldFull { label: 'Log' ref: r(wc_player_stats.goal_log_html) },
+        VizFieldFull { label: 'GoalSvg' ref: r(wc_player_stats.goal_placement_svg) }
+      ]
+      content: @md
+<style>
+.lp-row + .lp-row { border-top:1px solid var(--panel-line); }
+/* the row is now a popover trigger — the grid moves onto the button so each player opens their profile */
+.lp-hit { display:grid; grid-template-columns:26px minmax(0,1fr) 18px 26px; gap:7px; align-items:center;
+  width:100%; padding:4px 4px; appearance:none; -webkit-appearance:none; border:none; background:none;
+  font:inherit; color:inherit; text-align:left; cursor:pointer; border-radius:6px; transition:background .14s ease; }
+.lp-hit:hover, .lp-hit:focus-visible { background:rgba(12,36,24,.07); outline:none; }
+.lp-num { width:24px; height:24px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--font-disp); font-weight:800; font-size:11px; color:#fff;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.4), 0 1px 2px rgba(0,0,0,.3); }
+.lp-name { font-weight:600; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.lp-cap { width:16px; height:16px; border-radius:4px; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--font-disp); font-weight:800; font-size:9px; color:#4a3608;
+  background:linear-gradient(180deg, var(--gold-2), var(--gold)); box-shadow:0 1px 2px rgba(0,0,0,.25); }
+.lp-cap:empty { visibility:hidden; }
+.lp-pos { font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.08em;
+  text-transform:uppercase; color:var(--panel-muted); text-align:right; }
+.lp-row.bench { opacity:.62; }
+.lp-row.bench .lp-name { font-weight:500; font-size:11px; }
+.lp-row.bench .lp-num { width:20px; height:20px; font-size:10px; }
+.lp-row.xi + .lp-row.bench { border-top:2px dashed var(--panel-line); margin-top:5px; padding-top:8px; }
+</style>
+<div class="cb-wrap"><div class="clipboard lp">
+  <div class="cb-head">
+    <span class="cb-grp">{{ rows[0].`Team`.formatted }}</span>
+    <span class="cb-sub">{{ rows[0].`Formation`.formatted }} · starting XI</span>
+  </div>
+{% map(rows) %}
+  <div class="lp-row {{ `Role`.formatted }}">
+  <button class="lp-hit" type="button" popovertarget="ppl-{{ `Pid`.raw }}" style="anchor-name:--ppl-{{ `Pid`.raw }};">
+    <span class="lp-num wc-num" style="background:{{ `Kit`.raw }};">{{ `Num`.formatted }}</span>
+    <span class="lp-name">{{ `Name`.formatted }}</span>
+    <span class="lp-cap">{{ `Cap`.formatted }}</span>
+    <span class="lp-pos">{{ `Pos`.formatted }}</span>
+  </button>
+  <div id="ppl-{{ `Pid`.raw }}" popover class="pp-card" style="position-anchor:--ppl-{{ `Pid`.raw }}; --ppc:{{ `Kit`.raw }};">
+  <div class="pp-top">
+  <div class="pp-fig"><img src="{{ `Photo`.raw }}" alt="" style="margin:0 !important" /></div>
+  <div class="pp-id">
+  <div class="pp-nm">{{ `Name`.formatted }}</div>
+  <div class="pp-sub"><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />{{ `Team`.formatted }} &middot; #{{ `Num`.formatted }} &middot; {{ `Pos`.formatted }}</div>
+  <div class="pp-chips"><span class="pp-chip cl-age">{{ `Age`.formatted }}</span><span class="pp-chip cl-pos">{{ `PosDetail`.formatted }}</span><span class="pp-chip cl-club">{{ `Club`.formatted }}</span><span class="pp-chip cl-ht">{{ `Height`.formatted }}</span></div>
+  </div>
+  </div>
+  <div class="pp-stats"><div class="pp-stat hl"><b class="wc-num">{{ `Goals`.formatted }}</b><i>Goals</i></div><div class="pp-stat"><b class="wc-num">{{ `Assists`.formatted }}</b><i>Assists</i></div><div class="pp-stat"><b class="wc-num">{{ `Apps`.formatted }}</b><i>Apps</i></div><div class="pp-stat"><b class="wc-num">{{ `Starts`.formatted }}</b><i>Starts</i></div><div class="pp-stat"><b class="wc-num">{{ `Yellows`.formatted }}</b><i>Yellow</i></div><div class="pp-stat"><b class="wc-num">{{ `Reds`.formatted }}</b><i>Red</i></div></div>
+  <div class="pp-goal"><div class="pp-goal-box"><svg class="pp-net" viewBox="0 0 120 58" aria-hidden="true" style="margin:0 !important"><defs><linearGradient id="pplPost-{{ `Pid`.raw }}" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#aeb9c4"/></linearGradient><pattern id="pplnet-{{ `Pid`.raw }}" width="6.5" height="6.5" patternUnits="userSpaceOnUse"><path d="M0 0 L6.5 6.5 M6.5 0 L0 6.5" stroke="rgba(226,233,242,.15)" stroke-width=".5"/></pattern></defs><polygon class="pp-depth" points="11,9 19,3 101,3 109,9"/><rect x="19" y="3" width="82" height="6" fill="url(#pplnet-{{ `Pid`.raw }})" opacity=".45"/><rect x="11" y="9" width="98" height="43" fill="url(#pplnet-{{ `Pid`.raw }})"/><rect x="0" y="52" width="120" height="6" fill="rgba(74,128,86,.16)"/><line class="ground" x1="6" y1="52" x2="114" y2="52"/><rect x="8" y="6" width="104" height="3" rx="1.5" fill="url(#pplPost-{{ `Pid`.raw }})"/><rect x="8" y="6" width="3" height="46" rx="1.5" fill="url(#pplPost-{{ `Pid`.raw }})"/><rect x="109" y="6" width="3" height="46" rx="1.5" fill="url(#pplPost-{{ `Pid`.raw }})"/><g class="pp-dots">{{ `GoalSvg`.raw }}</g></svg></div></div>
+  <ul class="pp-gl">{{ `Log`.raw }}</ul>
+  </div>
+  </div>
+{% end %}
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--gold);"></span>C — captain</span>
+    <span class="sp">Bench below the dashed cut</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'rsort'
+            direction: 'asc'
+          },
+          SortSetting {
+            key: 'psort'
+            direction: 'asc'
+          },
+          SortSetting {
+            key: 'shirt'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 26
+        row_limit: 26
+      }
+    }
+  }
+}
+
+Func wc_mc_lineup_away() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_lineups.side)
+        operator: 'is'
+        value: 'away'
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'Kit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Formation'
+          ref: r(wc_matches.away_formation)
+        },
+        VizFieldFull {
+          label: 'Num'
+          ref: r(wc_players.shirt_number)
+          uname: 'shirt'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Name'
+          ref: r(wc_players.name)
+        },
+        VizFieldFull {
+          label: 'Pos'
+          ref: r(wc_players.position_group)
+        },
+        VizFieldFull {
+          label: 'PosSort'
+          ref: r(wc_players.position)
+          uname: 'psort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Role'
+          ref: r(wc_lineups.role)
+        },
+        VizFieldFull {
+          label: 'RoleSort'
+          ref: r(wc_lineups.role_sort)
+          uname: 'rsort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Cap'
+          ref: r(wc_lineups.captain_tag)
+        },
+        VizFieldFull { label: 'Pid' ref: r(wc_lineups.fifa_player_id) },
+        VizFieldFull { label: 'Flag' ref: r(wc_teams.flag_url) },
+        VizFieldFull { label: 'Photo' ref: r(wc_player_stats.picture_url) },
+        VizFieldFull { label: 'Goals' ref: r(wc_player_stats.goals) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Assists' ref: r(wc_player_stats.assists) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Apps' ref: r(wc_player_stats.apps) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Starts' ref: r(wc_player_stats.starts) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Yellows' ref: r(wc_player_stats.yellows) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Reds' ref: r(wc_player_stats.reds) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Age' ref: r(wc_player_bio.age) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Club' ref: r(wc_player_bio.club) },
+        VizFieldFull { label: 'PosDetail' ref: r(wc_player_bio.position_detail) },
+        VizFieldFull { label: 'Height' ref: r(wc_player_bio.height) },
+        VizFieldFull { label: 'Log' ref: r(wc_player_stats.goal_log_html) },
+        VizFieldFull { label: 'GoalSvg' ref: r(wc_player_stats.goal_placement_svg) }
+      ]
+      content: @md
+<style>
+.lp-row + .lp-row { border-top:1px solid var(--panel-line); }
+/* the row is now a popover trigger — the grid moves onto the button so each player opens their profile */
+.lp-hit { display:grid; grid-template-columns:26px minmax(0,1fr) 18px 26px; gap:7px; align-items:center;
+  width:100%; padding:4px 4px; appearance:none; -webkit-appearance:none; border:none; background:none;
+  font:inherit; color:inherit; text-align:left; cursor:pointer; border-radius:6px; transition:background .14s ease; }
+.lp-hit:hover, .lp-hit:focus-visible { background:rgba(12,36,24,.07); outline:none; }
+.lp-num { width:24px; height:24px; border-radius:50%; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--font-disp); font-weight:800; font-size:11px; color:#fff;
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.4), 0 1px 2px rgba(0,0,0,.3); }
+.lp-name { font-weight:600; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.lp-cap { width:16px; height:16px; border-radius:4px; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--font-disp); font-weight:800; font-size:9px; color:#4a3608;
+  background:linear-gradient(180deg, var(--gold-2), var(--gold)); box-shadow:0 1px 2px rgba(0,0,0,.25); }
+.lp-cap:empty { visibility:hidden; }
+.lp-pos { font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.08em;
+  text-transform:uppercase; color:var(--panel-muted); text-align:right; }
+.lp-row.bench { opacity:.62; }
+.lp-row.bench .lp-name { font-weight:500; font-size:11px; }
+.lp-row.bench .lp-num { width:20px; height:20px; font-size:10px; }
+.lp-row.xi + .lp-row.bench { border-top:2px dashed var(--panel-line); margin-top:5px; padding-top:8px; }
+</style>
+<div class="cb-wrap"><div class="clipboard lp">
+  <div class="cb-head">
+    <span class="cb-grp">{{ rows[0].`Team`.formatted }}</span>
+    <span class="cb-sub">{{ rows[0].`Formation`.formatted }} · starting XI</span>
+  </div>
+{% map(rows) %}
+  <div class="lp-row {{ `Role`.formatted }}">
+  <button class="lp-hit" type="button" popovertarget="ppl-{{ `Pid`.raw }}" style="anchor-name:--ppl-{{ `Pid`.raw }};">
+    <span class="lp-num wc-num" style="background:{{ `Kit`.raw }};">{{ `Num`.formatted }}</span>
+    <span class="lp-name">{{ `Name`.formatted }}</span>
+    <span class="lp-cap">{{ `Cap`.formatted }}</span>
+    <span class="lp-pos">{{ `Pos`.formatted }}</span>
+  </button>
+  <div id="ppl-{{ `Pid`.raw }}" popover class="pp-card" style="position-anchor:--ppl-{{ `Pid`.raw }}; --ppc:{{ `Kit`.raw }};">
+  <div class="pp-top">
+  <div class="pp-fig"><img src="{{ `Photo`.raw }}" alt="" style="margin:0 !important" /></div>
+  <div class="pp-id">
+  <div class="pp-nm">{{ `Name`.formatted }}</div>
+  <div class="pp-sub"><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />{{ `Team`.formatted }} &middot; #{{ `Num`.formatted }} &middot; {{ `Pos`.formatted }}</div>
+  <div class="pp-chips"><span class="pp-chip cl-age">{{ `Age`.formatted }}</span><span class="pp-chip cl-pos">{{ `PosDetail`.formatted }}</span><span class="pp-chip cl-club">{{ `Club`.formatted }}</span><span class="pp-chip cl-ht">{{ `Height`.formatted }}</span></div>
+  </div>
+  </div>
+  <div class="pp-stats"><div class="pp-stat hl"><b class="wc-num">{{ `Goals`.formatted }}</b><i>Goals</i></div><div class="pp-stat"><b class="wc-num">{{ `Assists`.formatted }}</b><i>Assists</i></div><div class="pp-stat"><b class="wc-num">{{ `Apps`.formatted }}</b><i>Apps</i></div><div class="pp-stat"><b class="wc-num">{{ `Starts`.formatted }}</b><i>Starts</i></div><div class="pp-stat"><b class="wc-num">{{ `Yellows`.formatted }}</b><i>Yellow</i></div><div class="pp-stat"><b class="wc-num">{{ `Reds`.formatted }}</b><i>Red</i></div></div>
+  <div class="pp-goal"><div class="pp-goal-box"><svg class="pp-net" viewBox="0 0 120 58" aria-hidden="true" style="margin:0 !important"><defs><linearGradient id="pplPost-{{ `Pid`.raw }}" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#aeb9c4"/></linearGradient><pattern id="pplnet-{{ `Pid`.raw }}" width="6.5" height="6.5" patternUnits="userSpaceOnUse"><path d="M0 0 L6.5 6.5 M6.5 0 L0 6.5" stroke="rgba(226,233,242,.15)" stroke-width=".5"/></pattern></defs><polygon class="pp-depth" points="11,9 19,3 101,3 109,9"/><rect x="19" y="3" width="82" height="6" fill="url(#pplnet-{{ `Pid`.raw }})" opacity=".45"/><rect x="11" y="9" width="98" height="43" fill="url(#pplnet-{{ `Pid`.raw }})"/><rect x="0" y="52" width="120" height="6" fill="rgba(74,128,86,.16)"/><line class="ground" x1="6" y1="52" x2="114" y2="52"/><rect x="8" y="6" width="104" height="3" rx="1.5" fill="url(#pplPost-{{ `Pid`.raw }})"/><rect x="8" y="6" width="3" height="46" rx="1.5" fill="url(#pplPost-{{ `Pid`.raw }})"/><rect x="109" y="6" width="3" height="46" rx="1.5" fill="url(#pplPost-{{ `Pid`.raw }})"/><g class="pp-dots">{{ `GoalSvg`.raw }}</g></svg></div></div>
+  <ul class="pp-gl">{{ `Log`.raw }}</ul>
+  </div>
+  </div>
+{% end %}
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--gold);"></span>C — captain</span>
+    <span class="sp">Bench below the dashed cut</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'rsort'
+            direction: 'asc'
+          },
+          SortSetting {
+            key: 'psort'
+            direction: 'asc'
+          },
+          SortSetting {
+            key: 'shirt'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 26
+        row_limit: 26
+      }
+    }
+  }
+}
+
+Func wc_mc_odds() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeColor'
+          ref: r(wc_home_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayColor'
+          ref: r(wc_away_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'FeaturedSort'
+          ref: r(wc_matches.featured_sort)
+          uname: 'ofeat'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'HomePct'
+          ref: r(wc_match_odds.p_home_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'DrawPct'
+          ref: r(wc_match_odds.p_draw_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'AwayPct'
+          ref: r(wc_match_odds.p_away_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'ExpScore'
+          ref: r(wc_match_odds.exp_score_label)
+        },
+        VizFieldFull {
+          label: 'RunLabel'
+          ref: r(wc_match_odds.run_label)
+        },
+        VizFieldFull {
+          label: 'StatusNote'
+          ref: r(wc_match_odds.status_note)
+        },
+        VizFieldFull {
+          label: 'DeltaNote'
+          ref: r(wc_match_odds.delta_note)
+        },
+        VizFieldFull {
+          label: 'DHome'
+          ref: r(wc_match_odds.d_home_label)
+        },
+        VizFieldFull {
+          label: 'DDraw'
+          ref: r(wc_match_odds.d_draw_label)
+        },
+        VizFieldFull {
+          label: 'DAway'
+          ref: r(wc_match_odds.d_away_label)
+        },
+        VizFieldFull {
+          label: 'DHomeColor'
+          ref: r(wc_match_odds.d_home_color)
+        },
+        VizFieldFull {
+          label: 'DDrawColor'
+          ref: r(wc_match_odds.d_draw_color)
+        },
+        VizFieldFull {
+          label: 'DAwayColor'
+          ref: r(wc_match_odds.d_away_color)
+        }
+      ]
+      content: @md
+<style>
+/* split-flap odds board: a mechanical departure-board housing — graphite metal case,
+   one flap tile per outcome with the horizontal split line and side hinges, printed
+   name plates above each tile. A new object on this page: not clipboard paper, not
+   LED glass. Matches without a sim run keep their row (wc_match_odds emits all 104):
+   flaps fall back to "—" and status_note says why, so the platform pill never appears.
+   HEIGHT BUDGET (block = 320px): housing pad 16+14 + head 20 + meter 7 + plates 16
+   + flaps 64 + meta 14 + note ≤16 + foot 13 + flex gaps 5×10 = ~230 used, ~90 spare. */
+.fb { width:100%; height:100%; box-sizing:border-box; display:flex; padding:0 2px; }
+.fb-case { flex:1; min-width:0; border-radius:13px; padding:16px 26px 14px;
+  display:flex; flex-direction:column; justify-content:center; gap:10px;
+  background:linear-gradient(180deg,#31383c,#23282b 55%,#1a1e21);
+  border:1px solid #121517;
+  box-shadow:0 18px 32px -16px rgba(4,18,11,.7), 0 2px 0 rgba(0,0,0,.35),
+    inset 0 1px 0 rgba(255,255,255,.16), inset 0 -3px 8px rgba(0,0,0,.45); }
+.fb-head { display:flex; justify-content:space-between; align-items:baseline; gap:12px; }
+.fb-title { font-family:var(--font-disp); font-weight:800; font-size:14px; letter-spacing:.2em;
+  text-transform:uppercase; color:#e8edef; }
+.fb-title b { color:var(--gold-2); }
+.fb-sub { font-size:10px; color:rgba(232,237,239,.55); letter-spacing:.04em; white-space:nowrap;
+  overflow:hidden; text-overflow:ellipsis; }
+.fb-meter { display:flex; height:7px; border-radius:4px; overflow:hidden;
+  background:rgba(255,255,255,.08); box-shadow:inset 0 1px 2px rgba(0,0,0,.5); }
+.fb-meter i { display:block; height:100%; }
+.fb-row { display:grid; grid-template-columns:1fr 1fr 1fr 230px; gap:18px; }
+.fb-cell { display:flex; flex-direction:column; gap:6px; min-width:0; }
+.fb-plate { display:flex; align-items:center; gap:8px; min-width:0; }
+.fb-plate .tab { flex:none; width:10px; height:10px; border-radius:2px; background:var(--bandc);
+  box-shadow:0 0 0 1px rgba(0,0,0,.4), inset 0 1px 0 rgba(255,255,255,.25); }
+.fb-plate .nm { font-family:var(--font-disp); font-weight:700; font-size:11px; letter-spacing:.1em;
+  text-transform:uppercase; color:rgba(232,237,239,.85); white-space:nowrap; overflow:hidden;
+  text-overflow:ellipsis; }
+.fb-plate .nm:empty::after { content:"TBD"; opacity:.5; font-style:italic; }
+/* the flap tile: split line across the middle + hinge notches on both edges */
+.fb-flap { position:relative; height:64px; border-radius:8px; overflow:hidden;
+  display:flex; align-items:center; justify-content:center;
+  background:linear-gradient(180deg,#15181a 0%,#1e2326 47%,#0c0e10 53%,#15181a 100%);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.07), inset 0 -10px 16px rgba(0,0,0,.45),
+    0 3px 5px rgba(0,0,0,.4); }
+.fb-flap::before { content:""; position:absolute; left:0; right:0; top:50%; height:2px;
+  margin-top:-1px; background:rgba(0,0,0,.85); box-shadow:0 1px 0 rgba(255,255,255,.07); }
+.fb-flap::after { content:""; position:absolute; top:50%; left:0; right:0; height:16px;
+  margin-top:-8px; pointer-events:none;
+  background:linear-gradient(90deg, #0a0c0d 0 7px, transparent 7px calc(100% - 7px), #0a0c0d calc(100% - 7px)); }
+.fb-pct { font-family:var(--font-disp); font-weight:800; font-size:40px; line-height:1;
+  color:#f4f7f8; text-shadow:0 2px 3px rgba(0,0,0,.65); font-variant-numeric:tabular-nums; }
+.fb-pct:empty::after { content:"—"; color:rgba(232,237,239,.3); text-shadow:none; }
+.fb-pct b { font-size:.45em; font-weight:700; color:rgba(232,237,239,.5); }
+.fb-meta { display:flex; justify-content:space-between; align-items:baseline; gap:8px;
+  font-size:9.5px; text-transform:uppercase; letter-spacing:.1em; color:rgba(232,237,239,.45); }
+.fb-d { font-family:var(--font-disp); font-weight:800; font-size:11.5px; letter-spacing:.02em; white-space:nowrap; }
+.fb-d:empty { display:none; }
+/* expected score: gold-lit digits, same mechanical flap */
+.fb-cell.exp .fb-pct { color:var(--gold-2); text-shadow:0 2px 3px rgba(0,0,0,.65), 0 0 14px rgba(242,200,75,.35); }
+.fb-foot { display:flex; justify-content:space-between; align-items:baseline; gap:12px;
+  font-size:9px; text-transform:uppercase; letter-spacing:.1em; color:rgba(232,237,239,.4); }
+.fb-note { font-style:italic; text-transform:none; letter-spacing:.02em; font-size:10.5px;
+  color:rgba(232,237,239,.6); }
+.fb-note:empty { display:none; }
+/* ── motion: split-flap reveal ───────────────────────────────────────────
+   The board boots like a real departure board — the probability bar draws in
+   from the left, then each flap clacks down from its top hinge (L→R), the
+   printed figure snapping visible as the flap lands. The gold expected-score
+   keeps a slow idle glow. --fd staggers the cells (CSS vars inherit down into
+   the flap + its digit). perspective() is baked into the flip so no ancestor
+   needs a perspective context. */
+.fb-cell:nth-child(1) { --fd:.34s; }
+.fb-cell:nth-child(2) { --fd:.46s; }
+.fb-cell:nth-child(3) { --fd:.58s; }
+.fb-cell:nth-child(4) { --fd:.70s; }
+.fb-meter { transform-origin:left center; animation:fb-wipe .5s cubic-bezier(.22,.61,.36,1) .08s both; }
+.fb-flap { transform-origin:top center; backface-visibility:hidden;
+  animation:fb-flip .46s cubic-bezier(.3,.72,.32,1) var(--fd) both; }
+.fb-flap .fb-pct { animation:fb-digit .46s steps(1,end) var(--fd) both; }
+.fb-cell.exp .fb-pct { animation:fb-digit .46s steps(1,end) var(--fd) both,
+  fb-expglow 3.4s ease-in-out 1.3s infinite; }
+@keyframes fb-wipe { from { transform:scaleX(0); } to { transform:scaleX(1); } }
+@keyframes fb-flip { 0% { transform:perspective(620px) rotateX(-92deg); }
+  70% { transform:perspective(620px) rotateX(6deg); }
+  100% { transform:perspective(620px) rotateX(0); } }
+@keyframes fb-digit { 0%,62% { opacity:0; } 70%,100% { opacity:1; } }
+@keyframes fb-expglow {
+  0%,100% { text-shadow:0 2px 3px rgba(0,0,0,.65), 0 0 14px rgba(242,200,75,.32); }
+  50% { text-shadow:0 2px 3px rgba(0,0,0,.65), 0 0 24px rgba(242,200,75,.75); } }
+@media (prefers-reduced-motion: reduce) {
+  .fb-meter, .fb-flap, .fb-flap .fb-pct, .fb-cell.exp .fb-pct {
+    animation:none !important; transform:none !important; opacity:1 !important; } }
+</style>
+<div class="fb">
+{% map(rows) %}
+  <div class="fb-case">
+    <div class="fb-head">
+      <span class="fb-title">Win <b>probability</b></span>
+      <span class="fb-sub">Elo→Poisson · 10k sims · {{ `RunLabel`.formatted }} · {{ `DeltaNote`.formatted }}</span>
+    </div>
+    <div class="fb-meter">
+      <i style="width:{{ `HomePct`.raw }}%; background:{{ `HomeColor`.raw }};"></i>
+      <i style="width:{{ `DrawPct`.raw }}%; background:#9AA4B2;"></i>
+      <i style="width:{{ `AwayPct`.raw }}%; background:{{ `AwayColor`.raw }};"></i>
+    </div>
+    <div class="fb-row">
+      <div class="fb-cell" style="--bandc:{{ `HomeColor`.raw }};">
+        <div class="fb-plate"><span class="tab"></span><span class="nm">{{ `Home`.formatted }}</span></div>
+        <div class="fb-flap"><span class="fb-pct wc-num">{{ `HomePct`.formatted }}<b>%</b></span></div>
+        <div class="fb-meta"><span>Home win</span><span class="fb-d wc-num" style="color:{{ `DHomeColor`.raw }};">{{ `DHome`.formatted }}</span></div>
+      </div>
+      <div class="fb-cell" style="--bandc:#9AA4B2;">
+        <div class="fb-plate"><span class="tab"></span><span class="nm">Draw</span></div>
+        <div class="fb-flap"><span class="fb-pct wc-num">{{ `DrawPct`.formatted }}<b>%</b></span></div>
+        <div class="fb-meta"><span>After 90 minutes</span><span class="fb-d wc-num" style="color:{{ `DDrawColor`.raw }};">{{ `DDraw`.formatted }}</span></div>
+      </div>
+      <div class="fb-cell" style="--bandc:{{ `AwayColor`.raw }};">
+        <div class="fb-plate"><span class="tab"></span><span class="nm">{{ `Away`.formatted }}</span></div>
+        <div class="fb-flap"><span class="fb-pct wc-num">{{ `AwayPct`.formatted }}<b>%</b></span></div>
+        <div class="fb-meta"><span>Away win</span><span class="fb-d wc-num" style="color:{{ `DAwayColor`.raw }};">{{ `DAway`.formatted }}</span></div>
+      </div>
+      <div class="fb-cell exp" style="--bandc:var(--gold);">
+        <div class="fb-plate"><span class="tab"></span><span class="nm">Expected score</span></div>
+        <div class="fb-flap"><span class="fb-pct wc-num">{{ `ExpScore`.formatted }}</span></div>
+        <div class="fb-meta"><span>Poisson means</span></div>
+      </div>
+    </div>
+    <div class="fb-foot">
+      <span>▲▼ day-over-day move in percentage points</span>
+      <span class="fb-note">{{ `StatusNote`.formatted }}</span>
+      <span>Probabilities, never a predicted winner</span>
+    </div>
+  </div>
+{% end %}
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'ofeat'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 1
+        row_limit: 1
+      }
+    }
+  }
+}
+
+Func wc_mc_formations() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Seq'
+          ref: r(wc_lineup_grid.seq)
+          uname: 'gseq'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'SideG'
+          ref: r(wc_lineup_grid.side)
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'StageX'
+          ref: r(wc_lineup_grid.stage_x)
+        },
+        VizFieldFull {
+          label: 'Y'
+          ref: r(wc_lineup_grid.y_pct)
+        },
+        VizFieldFull {
+          label: 'Delay'
+          ref: r(wc_lineup_grid.reveal_delay)
+        },
+        VizFieldFull {
+          label: 'Shirt'
+          ref: r(wc_lineup_grid.shirt_number)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Player'
+          ref: r(wc_lineup_grid.name)
+        },
+        VizFieldFull {
+          label: 'Photo'
+          ref: r(wc_lineup_grid.picture_url)
+        },
+        VizFieldFull {
+          label: 'Role'
+          ref: r(wc_lineup_grid.role)
+        },
+        VizFieldFull {
+          label: 'Cap'
+          ref: r(wc_lineup_grid.cap_tag)
+        },
+        VizFieldFull {
+          label: 'Kit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'HomeName'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayName'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeForm'
+          ref: r(wc_matches.home_formation)
+        },
+        VizFieldFull {
+          label: 'AwayForm'
+          ref: r(wc_matches.away_formation)
+        }
+      ]
+      content: @md
+<style>
+/* broadcast frame: night-stadium glass panel — floodlit night turf, glass sheen and
+   corner blooms so the graphic pops off the day pitch behind it (TV line-up board) */
+.fmx { position:relative; width:100%; height:100%; box-sizing:border-box; display:flex;
+  flex-direction:column; border-radius:14px; padding:12px 14px 14px; overflow:hidden;
+  background:
+    radial-gradient(55% 45% at 6% 0%, rgba(150,255,195,.13), transparent 65%),
+    radial-gradient(55% 45% at 94% 0%, rgba(150,255,195,.13), transparent 65%),
+    radial-gradient(130% 100% at 50% 110%, rgba(0,0,0,.4), transparent 60%),
+    linear-gradient(180deg, #14301f, #0b1d14);
+  box-shadow:0 22px 38px -18px rgba(4,18,11,.75), 0 0 0 1px rgba(234,255,242,.14),
+    inset 0 1px 0 rgba(255,255,255,.12), inset 0 -2px 8px rgba(0,0,0,.4); }
+/* glass sheen sweep across the whole board */
+.fmx::before { content:""; position:absolute; inset:0; pointer-events:none; z-index:3;
+  background:linear-gradient(115deg, transparent 32%, rgba(255,255,255,.05) 44%, transparent 58%); }
+.fmx-caps { display:grid; grid-template-columns:46% 1fr 46%; padding-bottom:8px; margin-bottom:10px;
+  border-bottom:1px solid rgba(234,255,242,.14); }
+.fmx-cap { text-align:center; font-family:var(--font-disp); font-weight:800; font-size:12.5px;
+  letter-spacing:.1em; text-transform:uppercase; color:#eafff2;
+  text-shadow:0 0 10px rgba(120,255,180,.25); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.fmx-cap small { color:var(--gold-2); font-size:.85em; letter-spacing:.14em; }
+.fmx-stage { position:relative; flex:1; min-height:0; }
+.fmx-pitch { position:absolute; top:0; bottom:0; width:46%; border-radius:9px; overflow:hidden;
+  background:
+    radial-gradient(120% 60% at 50% -5%, rgba(160,255,200,.09), transparent 60%),
+    repeating-linear-gradient(180deg, #16402a 0 28px, #1a4a31 28px 56px);
+  box-shadow:inset 0 0 0 1px rgba(234,255,242,.16), inset 0 0 30px rgba(0,0,0,.4); }
+/* turf grain */
+.fmx-pitch::before { content:""; position:absolute; inset:0; pointer-events:none; opacity:.05;
+  background-image:radial-gradient(rgba(255,255,255,.9) .5px, transparent .6px); background-size:4px 4px; }
+.fmx-pitch.home { left:0; }
+.fmx-pitch.away { right:0; }
+/* markings: touchline box, halfway arc at the attacking end, penalty area + six-yard + spot */
+.fmx-pitch i { position:absolute; display:block; border:2px solid rgba(234,255,242,.32); }
+.fmx-pitch .tlb { inset:7px; border-radius:6px; }
+.fmx-pitch .cca { top:7px; left:50%; width:88px; height:42px; transform:translateX(-50%);
+  border-top:0; border-radius:0 0 999px 999px; }
+.fmx-pitch .pa { left:17%; right:17%; bottom:7px; height:21%; border-bottom:0; }
+.fmx-pitch .gb { left:31%; right:31%; bottom:7px; height:10%; border-bottom:0; }
+.fmx-pitch .ps { left:50%; bottom:16%; width:5px; height:5px; margin-left:-2.5px; border:0;
+  border-radius:50%; background:rgba(234,255,242,.5); }
+.fmt { position:absolute; z-index:2; width:58px; margin-left:-29px; transform:translateY(-50%);
+  display:flex; flex-direction:column; align-items:center; gap:3px;
+  opacity:0; animation:fmt-pop .5s cubic-bezier(.18,.89,.32,1.28) forwards; }
+@keyframes fmt-pop {
+  from { opacity:0; transform:translateY(-50%) scale(.25); }
+  to { opacity:1; transform:translateY(-50%) scale(1); }
+}
+@media (prefers-reduced-motion: reduce) { .fmt { animation:none; opacity:1; } }
+.fmt-bust { position:relative; }
+.fmt-ph { display:block; width:40px; height:40px; border-radius:50%; overflow:hidden;
+  background:
+    url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='xMidYMax meet'><g fill='%23a7bfae'><circle cx='50' cy='36' r='15'/><path d='M20 100c1-24 14-36 30-36s29 12 30 36z'/></g></svg>") center bottom / 70% no-repeat,
+    radial-gradient(120% 90% at 50% 0%, #e8f1ea, #c9d8cd);
+  box-shadow:0 0 0 2.5px var(--kitc), 0 0 0 4.5px rgba(255,255,255,.85), 0 5px 10px -3px rgba(0,0,0,.55); }
+.fmx .fmt-ph img { width:100% !important; height:100% !important; object-fit:cover;
+  object-position:top center; transform:scale(1.8); transform-origin:top center;
+  display:block !important; margin:0 !important; }
+.fmx .fmt-ph img[src=""], .fmx .fmt-ph img:not([src]) { display:none !important; }
+.fmt.gk .fmt-ph { box-shadow:0 0 0 2.5px var(--gold-2), 0 0 0 4.5px rgba(255,255,255,.85),
+  0 0 14px rgba(242,200,75,.55), 0 5px 10px -3px rgba(0,0,0,.55); }
+.fmt-num { position:absolute; bottom:-3px; right:-6px; z-index:3; min-width:17px; height:17px;
+  padding:0 3px; border-radius:999px; display:inline-flex; align-items:center; justify-content:center;
+  font-family:var(--font-disp); font-weight:800; font-size:9.5px; color:#fff; background:var(--kitc);
+  box-shadow:0 1px 3px rgba(0,0,0,.45), inset 0 0 0 1.5px rgba(255,255,255,.65); }
+.fmt.gk .fmt-num { background:linear-gradient(180deg, var(--gold-2), var(--gold)); color:#3c2c06; }
+.fmt-cap { position:absolute; top:-4px; right:-6px; z-index:3; width:13px; height:13px; border-radius:4px;
+  display:inline-flex; align-items:center; justify-content:center; font-family:var(--font-disp);
+  font-weight:800; font-size:8px; color:#4a3608; background:linear-gradient(180deg, var(--gold-2), var(--gold));
+  box-shadow:0 1px 2px rgba(0,0,0,.4), inset 0 1px 0 rgba(255,255,255,.5); }
+.fmt-cap:empty { display:none; }
+.fmt-nm { max-width:58px; font-size:8.5px; font-weight:700; line-height:1.2; color:#eafff2;
+  background:rgba(4,18,10,.55); border-radius:999px; padding:1px 6px;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; text-align:center; box-sizing:border-box; }
+</style>
+<div class="fmx">
+  <div class="fmx-caps">
+    <span class="fmx-cap">{{ rows[0].`HomeName`.formatted }} <small class="wc-num">{{ rows[0].`HomeForm`.formatted }}</small></span>
+    <span></span>
+    <span class="fmx-cap">{{ rows[0].`AwayName`.formatted }} <small class="wc-num">{{ rows[0].`AwayForm`.formatted }}</small></span>
+  </div>
+  <div class="fmx-stage">
+    <div class="fmx-pitch home"><i class="tlb"></i><i class="cca"></i><i class="pa"></i><i class="gb"></i><i class="ps"></i></div>
+    <div class="fmx-pitch away"><i class="tlb"></i><i class="cca"></i><i class="pa"></i><i class="gb"></i><i class="ps"></i></div>
+{% map(rows) %}
+  <div class="fmt {{ `Role`.formatted }}" style="left:{{ `StageX`.raw }}%; top:{{ `Y`.raw }}%; animation-delay:{{ `Delay`.raw }}s; --kitc:{{ `Kit`.raw }};">
+    <span class="fmt-bust"><span class="fmt-ph"><img src="{{ `Photo`.raw }}" alt="" /></span><span class="fmt-num wc-num">{{ `Shirt`.formatted }}</span><span class="fmt-cap">{{ `Cap`.formatted }}</span></span>
+    <span class="fmt-nm">{{ `Player`.formatted }}</span>
+  </div>
+{% end %}
+  </div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'gseq'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 22
+        row_limit: 22
+      }
+    }
+  }
+}
+
+// ---- Momentum: in-match swing as a native trace on a crafted "plotter" chrome ----
+// FIRST native-viz-on-crafted-chrome surface (the reusable pattern). Two stacked blocks:
+//   (1) wc_mc_momentum_frame() — a crafted light chart-recorder card (TextBlock = no dataset,
+//       so it never entangles with filters); it owns the MATERIAL + title + plot well + labels.
+//   (2) wc_mc_momentum_chart() — a transparent native LineChart drawing the gold step trace of
+//       wc_events.score_margin (running home−away) over minute_num; it owns the DATA + axes +
+//       built-in tooltip/hover. Layered on top of the frame's plot well.
+// Light well on purpose: native axis-tick text colour isn't themeable in AML, so dark ticks need
+// a light backdrop to read. The chart auto-maps to the Match filter via wc_events→wc_matches.
+Func wc_mc_zone_momentum() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">Momentum · the swing of the match</p>
+;;
+  }
+}
+
+Func wc_mc_momentum_frame() {
+  TextBlock {
+    content: @md
+<style>
+/* momentum monitor — a dark telemetry instrument: graphite housing + a phosphor screen the
+   native trace plots onto (its white graticule + light ticks read as an oscilloscope grid, so
+   no hand-drawn grid is needed). Own material — a graph readout, distinct from the LED numeric
+   scoreboard, the clipboard ticker, and the split-flap odds board; shares the panel typography. */
+.mom-wrap { width:100%; height:100%; box-sizing:border-box; padding:0 2px; }
+.mom-card { position:relative; width:100%; height:100%; box-sizing:border-box; border-radius:13px;
+  background:linear-gradient(180deg,#2b3134,#1f2427 55%,#15191b); border:1px solid #0f1214;
+  box-shadow:0 18px 32px -16px rgba(4,18,11,.7), 0 2px 0 rgba(0,0,0,.35),
+    inset 0 1px 0 rgba(255,255,255,.14), inset 0 -3px 8px rgba(0,0,0,.45);
+  padding:11px 13px 9px; display:flex; flex-direction:column; }
+.mom-head { display:flex; align-items:baseline; justify-content:space-between; gap:10px; padding:0 3px 8px; }
+.mom-title { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.16em;
+  font-size:14px; line-height:1; color:rgba(234,255,242,.86); text-shadow:0 0 10px var(--board-glow); }
+.mom-title b { color:var(--gold-2); }
+.mom-sub { font-size:9px; text-transform:uppercase; letter-spacing:.1em; color:rgba(234,255,242,.5); white-space:nowrap; }
+/* phosphor screen — the native chart (white grid + light ticks + gold trace) draws onto this; no
+   baked grid or centre rule, so the native 0-gridline stays the single authoritative baseline. */
+.mom-screen { position:relative; flex:1; border-radius:8px; overflow:hidden;
+  background:radial-gradient(130% 120% at 50% -12%, rgba(80,200,140,.12), transparent 58%), var(--board-bg);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.07), inset 0 0 44px rgba(0,0,0,.6); }
+.mom-screen::after { content:""; position:absolute; inset:0; pointer-events:none; opacity:.32;
+  background:repeating-linear-gradient(180deg, rgba(255,255,255,.05) 0 1px, transparent 1px 3px); }
+/* home/away read hints, parked in the screen's right gutter (the chart's right margin) */
+.mom-flag { position:absolute; right:8px; z-index:1; font-family:var(--font-disp); font-weight:700;
+  font-size:9px; letter-spacing:.1em; text-transform:uppercase; }
+.mom-flag.up { top:7px; color:rgba(110,240,170,.82); }
+.mom-flag.dn { bottom:7px; color:rgba(255,150,140,.85); }
+.mom-foot { display:flex; gap:9px; padding:7px 3px 0; font-size:8px; text-transform:uppercase;
+  letter-spacing:.05em; color:rgba(234,255,242,.45); }
+.mom-foot .sp { margin-left:auto; font-style:italic; opacity:.9; text-transform:none; letter-spacing:.02em; }
+</style>
+<div class="mom-wrap"><div class="mom-card">
+  <div class="mom-head"><span class="mom-title">Momentum <b>trace</b></span><span class="mom-sub">Running goal margin · by minute</span></div>
+  <div class="mom-screen"><span class="mom-flag up">&#9650; Home ahead</span><span class="mom-flag dn">&#9660; Away ahead</span></div>
+  <div class="mom-foot"><span>Each step = a goal</span><span class="sp">A flat line is a tight game, not missing data</span></div>
+</div></div>
+;;
+  }
+}
+
+Func wc_mc_momentum_chart() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: LineChart {
+      dataset: worldcup
+      filter {
+        field: r(wc_events.is_key_event)
+        operator: 'is'
+        value: true
+      }
+      x_axis: VizFieldFull {
+        label: 'Minute'
+        ref: r(wc_events.minute_num)
+        format {
+          type: 'number'
+          pattern: '0'
+        }
+      }
+      y_axis {
+        series {
+          field: VizFieldFull {
+            label: 'Margin'
+            ref: r(wc_events.score_margin)
+            aggregation: 'max'
+            format {
+              type: 'number'
+              pattern: '0'
+            }
+          }
+          settings {
+            color: '#f2c84b'
+            line_interpolation: 'step_after'
+          }
+        }
+        settings {
+          axis_min: -3
+          axis_max: 3
+        }
+      }
+      settings {
+        legend_label: 'hidden'
+        show_data_points: true
+        connect_discontinuous_points: true
+        sort: LineFamilySort {
+          type: 'xaxis'
+          direction: 'asc'
+        }
+        row_limit: 100
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_player_gallery.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_player_gallery.block.aml
@@ -1,0 +1,219 @@
+// Players tab — "Stars of the Tournament": a wall of FUT cards for every goal contributor,
+// ranked by G+A. REUSES the exact .fut card material (shield/foil/tiers/deal/hover) defined in
+// header_rail — identical to the Tournament boot podium, one source. This block only owns the
+// .fut-wall grid (with padding so the hover lift/glow isn't clipped by the block's overflow).
+// Cards are tiered by G+A (gold 3+ / silver 2 / bronze 1) and open the shared profile popover.
+
+// Gallery backdrop — a FUT "pack-reveal" void the foil cards stand in, replacing the pitch under
+// this wall (a pitch is where matches happen; a card wall is a reveal). Deep navy-black with a cool
+// gantry spotlight + faint volumetric beams + a warm floor sheen the cards rise from. Its own block
+// at the lowest layer so the gallery (above) reads as a lit display, unified with the dark ladders.
+Func wc_pack_reveal() {
+  TextBlock {
+    content: @md
+<style>
+/* IMPORTANT: the FUT card wall (a block ABOVE this one) covers the centre — cards occupy roughly
+   the middle 80% width × the band from ~14%→90% height. So every effect here is aimed at the
+   parts that actually show: the TOP CROWN (above row 1), the BOTTOM STAGE (below the last row),
+   the SIDE MARGINS, and the gaps the light bleeds through. Nothing relies on the covered centre. */
+.pkr { position:relative; width:100%; height:100%; border-radius:14px; overflow:hidden;
+  background:
+    radial-gradient(44% 60% at -3% 44%, rgba(66,132,162,.20), transparent 62%),   /* left teal rim — shows in the left margin */
+    radial-gradient(44% 60% at 103% 56%, rgba(242,200,75,.15), transparent 62%),   /* right gold rim — shows in the right margin */
+    radial-gradient(120% 64% at 50% 104%, rgba(242,200,75,.12), transparent 60%),  /* warm floor wash — bottom band */
+    radial-gradient(132% 90% at 50% -6%, #1c2836 0%, #0c121b 52%, #05080d 100%);
+  /* lit inner-edge frame so the case glows around the wall, + outer drop */
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.06), inset 0 0 0 1px rgba(0,0,0,.5),
+    inset 0 0 58px -8px rgba(150,184,224,.22), 0 34px 64px -34px rgba(0,0,0,.62); }
+/* floodlight gantry RAISED into the top crown (above the cards) so the rig + its glow are visible;
+   preserveAspectRatio=none maps the viewBox straight to the thin crown band. */
+.pkr-arch { position:absolute; left:0; top:0; width:100%; height:15%; z-index:1; display:block; margin:0 !important; pointer-events:none;
+  filter:drop-shadow(0 0 6px rgba(196,220,252,.7)); }
+.pkr-arch .lite { animation:pkr-twinkle 3.6s ease-in-out infinite; transform-box:fill-box; transform-origin:center; }
+.pkr-arch .lite:nth-child(2n){ animation-duration:4.4s; animation-delay:-1.1s; }
+.pkr-arch .lite:nth-child(3n){ animation-duration:5.2s; animation-delay:-2.3s; }
+/* volumetric beams fanning down from the gantry — brightest in the crown, bleeding through card gaps */
+.pkr-rays { position:absolute; inset:0; z-index:1; pointer-events:none; opacity:.6; mix-blend-mode:screen;
+  background:repeating-conic-gradient(from 161deg at 50% 2%, transparent 0 4.6deg, rgba(182,208,244,.06) 4.6deg 6deg);
+  -webkit-mask-image:linear-gradient(180deg, rgba(0,0,0,.95) 0%, transparent 52%);
+  mask-image:linear-gradient(180deg, rgba(0,0,0,.95) 0%, transparent 52%); }
+/* spotlight pooled as a CROWN at the top, raking down — its visible part is the crown + the gaps */
+.pkr-spot { position:absolute; left:50%; top:-26%; width:90%; height:62%; z-index:2; transform:translateX(-50%); pointer-events:none;
+  background:radial-gradient(closest-side, rgba(182,208,246,.26), rgba(150,180,220,.08) 46%, transparent 72%);
+  animation:pkr-flare 7s ease-in-out infinite; }
+/* dust motes — biased to the SIDE columns + bottom band (the visible void), drifting up */
+.pkr-dust { position:absolute; inset:0; z-index:3; pointer-events:none; }
+.pkr-mote { position:absolute; width:4px; height:4px; border-radius:50%;
+  background:radial-gradient(closest-side, rgba(226,238,255,.95), rgba(190,214,245,.3) 60%, transparent);
+  animation:pkr-drift 13s linear infinite; }
+.pkr-dust .pkr-mote:nth-child(1){ left:7%;  bottom:12%; animation-duration:12s; animation-delay:-1s; }
+.pkr-dust .pkr-mote:nth-child(2){ left:12%; bottom:30%; animation-duration:15s; animation-delay:-5s; transform:scale(.7); }
+.pkr-dust .pkr-mote:nth-child(3){ left:90%; bottom:14%; animation-duration:11s; animation-delay:-8s; }
+.pkr-dust .pkr-mote:nth-child(4){ left:94%; bottom:32%; animation-duration:16s; animation-delay:-3s; transform:scale(1.3); }
+.pkr-dust .pkr-mote:nth-child(5){ left:5%;  bottom:44%; animation-duration:14s; animation-delay:-10s; transform:scale(.8); }
+.pkr-dust .pkr-mote:nth-child(6){ left:92%; bottom:46%; animation-duration:17s; animation-delay:-6s; transform:scale(1.1); }
+.pkr-dust .pkr-mote:nth-child(7){ left:50%; bottom:3%;  animation-duration:13s; animation-delay:-12s; transform:scale(.6); }
+/* the STAGE — a perspective deck in the bottom band the wall stands on: bright horizon line + a
+   receding grid + warm pool, all anchored to the bottom so they sit BELOW the last card row */
+.pkr-floor { position:absolute; left:50%; bottom:0; width:92%; height:22%; z-index:2; transform:translateX(-50%); pointer-events:none;
+  background:radial-gradient(82% 130% at 50% 100%, rgba(242,200,75,.14), transparent 66%); }
+.pkr-grid { position:absolute; left:-25%; right:-25%; bottom:0; height:14%; z-index:2; pointer-events:none; opacity:.6;
+  background:
+    repeating-linear-gradient(90deg, transparent 0 58px, rgba(182,208,244,.2) 58px 59px),
+    repeating-linear-gradient(0deg, transparent 0 26px, rgba(182,208,244,.14) 26px 27px);
+  transform:perspective(380px) rotateX(66deg); transform-origin:bottom center;
+  -webkit-mask-image:linear-gradient(0deg, rgba(0,0,0,.95) 0%, transparent 82%);
+  mask-image:linear-gradient(0deg, rgba(0,0,0,.95) 0%, transparent 82%); }
+/* the lit horizon line where the deck meets the wall base — anchored into the visible bottom band,
+   just below the last card row (not behind it) */
+.pkr-floor::before { content:""; position:absolute; left:5%; right:5%; bottom:42%; height:1px;
+  background:linear-gradient(90deg, transparent, rgba(202,224,252,.55), transparent);
+  box-shadow:0 0 14px 1px rgba(182,208,244,.35); }
+/* vignette deepens the outer corners over the glows (keeps the lit frame, darkens beyond it) */
+.pkr::after { content:""; position:absolute; inset:0; z-index:4; pointer-events:none;
+  background:radial-gradient(128% 108% at 50% 32%, transparent 54%, rgba(0,0,0,.58) 100%); }
+@media (prefers-reduced-motion: reduce) {
+  .pkr-spot, .pkr-mote, .pkr-arch .lite { animation:none !important; }
+  .pkr-mote { opacity:.55 !important; } }
+</style>
+<div class="pkr">
+  <svg class="pkr-arch" viewBox="0 0 1480 180" preserveAspectRatio="none" aria-hidden="true">
+    <path d="M-60 168 Q740 52 1540 168" fill="none" stroke="rgba(160,190,228,.12)" stroke-width="2.5"/>
+    <path d="M-60 180 Q740 86 1540 180" fill="none" stroke="rgba(160,190,228,.07)" stroke-width="2.5"/>
+    <g fill="#f2f8ff">
+      <circle class="lite" cx="100" cy="153" r="5"/><circle class="lite" cx="260" cy="137" r="5"/>
+      <circle class="lite" cx="420" cy="125" r="5"/><circle class="lite" cx="580" cy="117" r="5"/>
+      <circle class="lite" cx="740" cy="115" r="5.5"/><circle class="lite" cx="900" cy="117" r="5"/>
+      <circle class="lite" cx="1060" cy="125" r="5"/><circle class="lite" cx="1220" cy="137" r="5"/>
+      <circle class="lite" cx="1380" cy="153" r="5"/>
+    </g>
+  </svg>
+  <span class="pkr-rays"></span>
+  <span class="pkr-spot"></span>
+  <span class="pkr-dust"><span class="pkr-mote"></span><span class="pkr-mote"></span><span class="pkr-mote"></span><span class="pkr-mote"></span><span class="pkr-mote"></span><span class="pkr-mote"></span><span class="pkr-mote"></span></span>
+  <span class="pkr-grid"></span>
+  <span class="pkr-floor"></span>
+</div>
+;;
+  }
+}
+
+Func wc_players_zone_label() {
+  TextBlock {
+    content: @md
+<style>
+.pl-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="pl-zone-label">Stars of the tournament · ranked by goal contributions</p>
+;;
+  }
+}
+
+Func wc_player_gallery() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_player_stats.goal_contributions)
+        operator: 'greater_than'
+        value: 0
+      }
+      rows: [
+        VizFieldFull { label: 'Pid' ref: r(wc_player_stats.fifa_player_id) },
+        VizFieldFull { label: 'Name' ref: r(wc_player_stats.name) },
+        VizFieldFull { label: 'Team' ref: r(wc_player_stats.team_code) },
+        VizFieldFull { label: 'PosG' ref: r(wc_player_stats.position_group) },
+        VizFieldFull { label: 'Photo' ref: r(wc_player_stats.picture_url) },
+        VizFieldFull { label: 'Flag' ref: r(wc_teams.flag_url) },
+        VizFieldFull { label: 'Kit' ref: r(wc_teams.color_hex) },
+        VizFieldFull { label: 'Tier' ref: r(wc_player_stats.card_tier) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull {
+          label: 'GA'
+          ref: r(wc_player_stats.goal_contributions)
+          uname: 'ga'
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_player_stats.goals)
+          uname: 'goals'
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull { label: 'Assists' ref: r(wc_player_stats.assists) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Apps' ref: r(wc_player_stats.apps) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Starts' ref: r(wc_player_stats.starts) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Yellows' ref: r(wc_player_stats.yellows) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Reds' ref: r(wc_player_stats.reds) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'GARank' ref: r(wc_player_stats.ga_rank) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Num' ref: r(wc_player_stats.shirt_number) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Log' ref: r(wc_player_stats.goal_log_html) },
+        VizFieldFull { label: 'GoalSvg' ref: r(wc_player_stats.goal_placement_svg) },
+        VizFieldFull { label: 'Age' ref: r(wc_player_bio.age) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Club' ref: r(wc_player_bio.club) },
+        VizFieldFull { label: 'PosDetail' ref: r(wc_player_bio.position_detail) },
+        VizFieldFull { label: 'Height' ref: r(wc_player_bio.height) }
+      ]
+      content: @md
+<style>
+/* Only the wall layout is local — the .fut card itself is the shared material from header_rail.
+   Generous padding keeps the hover lift + foil glow clear of the viz block's overflow:hidden. */
+button.fut { appearance:none; -webkit-appearance:none; border:none; padding:0; font:inherit; text-align:inherit; cursor:pointer; }
+.fut-wall { display:flex; flex-wrap:wrap; justify-content:center; align-content:flex-start; gap:32px 24px; padding:44px 36px 42px; }
+.fut-cell { position:relative; flex:none; width:176px; }
+.fut-wall .fut-cell:nth-child(1) .fut { animation-delay:.04s; }
+.fut-wall .fut-cell:nth-child(2) .fut { animation-delay:.09s; }
+.fut-wall .fut-cell:nth-child(3) .fut { animation-delay:.14s; }
+.fut-wall .fut-cell:nth-child(4) .fut { animation-delay:.19s; }
+.fut-wall .fut-cell:nth-child(5) .fut { animation-delay:.24s; }
+.fut-wall .fut-cell:nth-child(6) .fut { animation-delay:.29s; }
+.fut-wall .fut-cell:nth-child(7) .fut { animation-delay:.34s; }
+.fut-wall .fut-cell:nth-child(8) .fut { animation-delay:.39s; }
+.fut-wall .fut-cell:nth-child(n+9) .fut { animation-delay:.44s; }
+</style>
+<div class="fut-wall">
+{% map(rows) %}
+  <div class="fut-cell">
+  <button class="fut t{{ `Tier`.formatted }}" type="button" popovertarget="pp-{{ `Pid`.raw }}" style="anchor-name:--pp-{{ `Pid`.raw }}; --teamc:{{ `Kit`.raw }};">
+  <svg class="fut-frame" viewBox="0 0 176 232" aria-hidden="true" style="margin:0 !important"><path d="M 0 34 C 0 18 10 8 26 7 L 64 7 C 74 7 80 2 88 2 C 96 2 102 7 112 7 L 150 7 C 166 8 176 18 176 34 L 176 168 C 176 192 168 204 146 214 C 124 223 102 230 88 230 C 74 230 52 223 30 214 C 8 204 0 192 0 168 Z" fill="none" stroke="#a37920" stroke-width="5"/></svg>
+  <span class="fut-medal wc-num">{{ `GARank`.formatted }}</span>
+  <div class="fut-body">
+  <div class="fut-top">
+  <div class="fut-rate"><span class="n wc-num">{{ `GA`.formatted }}</span><span class="u">G+A</span><img class="fut-flag" src="{{ `Flag`.raw }}" alt="" /></div>
+  <div class="fut-ph"><img src="{{ `Photo`.raw }}" alt="" /></div>
+  </div>
+  <div class="fut-name">{{ `Name`.formatted }}</div>
+  <div class="fut-meta">{{ `Team`.formatted }} &middot; {{ `PosG`.formatted }} &middot; <b class="wc-num">{{ `Goals`.formatted }}</b>G <b class="wc-num">{{ `Assists`.formatted }}</b>A</div>
+  </div>
+  </button>
+  <div id="pp-{{ `Pid`.raw }}" popover class="pp-card" style="position-anchor:--pp-{{ `Pid`.raw }}; --ppc:{{ `Kit`.raw }};">
+  <div class="pp-top">
+  <div class="pp-fig"><img src="{{ `Photo`.raw }}" alt="" style="margin:0 !important" /></div>
+  <div class="pp-id">
+  <div class="pp-nm">{{ `Name`.formatted }}</div>
+  <div class="pp-sub"><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />{{ `Team`.formatted }} &middot; #{{ `Num`.formatted }} &middot; {{ `PosG`.formatted }}</div>
+  <div class="pp-chips"><span class="pp-chip cl-age">{{ `Age`.formatted }}</span><span class="pp-chip cl-pos">{{ `PosDetail`.formatted }}</span><span class="pp-chip cl-club">{{ `Club`.formatted }}</span><span class="pp-chip cl-ht">{{ `Height`.formatted }}</span></div>
+  </div>
+  </div>
+  <div class="pp-stats"><div class="pp-stat hl"><b class="wc-num">{{ `Goals`.formatted }}</b><i>Goals</i></div><div class="pp-stat"><b class="wc-num">{{ `Assists`.formatted }}</b><i>Assists</i></div><div class="pp-stat"><b class="wc-num">{{ `Apps`.formatted }}</b><i>Apps</i></div><div class="pp-stat"><b class="wc-num">{{ `Starts`.formatted }}</b><i>Starts</i></div><div class="pp-stat"><b class="wc-num">{{ `Yellows`.formatted }}</b><i>Yellow</i></div><div class="pp-stat"><b class="wc-num">{{ `Reds`.formatted }}</b><i>Red</i></div></div>
+  <div class="pp-goal"><div class="pp-goal-box"><svg class="pp-net" viewBox="0 0 120 58" aria-hidden="true" style="margin:0 !important"><defs><linearGradient id="ppPost-{{ `Pid`.raw }}" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#aeb9c4"/></linearGradient><pattern id="ppnet-{{ `Pid`.raw }}" width="6.5" height="6.5" patternUnits="userSpaceOnUse"><path d="M0 0 L6.5 6.5 M6.5 0 L0 6.5" stroke="rgba(226,233,242,.15)" stroke-width=".5"/></pattern></defs><polygon class="pp-depth" points="11,9 19,3 101,3 109,9"/><rect x="19" y="3" width="82" height="6" fill="url(#ppnet-{{ `Pid`.raw }})" opacity=".45"/><rect x="11" y="9" width="98" height="43" fill="url(#ppnet-{{ `Pid`.raw }})"/><rect x="0" y="52" width="120" height="6" fill="rgba(74,128,86,.16)"/><line class="ground" x1="6" y1="52" x2="114" y2="52"/><rect x="8" y="6" width="104" height="3" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><rect x="8" y="6" width="3" height="46" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><rect x="109" y="6" width="3" height="46" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><g class="pp-dots">{{ `GoalSvg`.raw }}</g></svg></div></div>
+  <ul class="pp-gl">{{ `Log`.raw }}</ul>
+  </div>
+  </div>
+{% end %}
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting { key: 'ga' direction: 'desc' },
+          SortSetting { key: 'goals' direction: 'desc' }
+        ]
+        pagination_size: 24
+        row_limit: 24
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_race_ladder.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_race_ladder.block.aml
@@ -1,0 +1,161 @@
+// Players tab — "The Race": two broadcast TIMING-BOARDS standing apart from the FUT wall.
+//   · Golden Boot  — top scorers, lanes lit gold, ranked by goals (wc_player_stats.goals_rank)
+//   · Playmaker    — top assisters, lanes lit ice, ranked by assists (wc_player_stats.assists_rank)
+// Each contender owns a lane that FILLS toward the current leader (goals_bar_pct / assists_bar_pct,
+// resolved in SQL since MarkdownViz has no cross-row max). The shared rl-* material lives in
+// header_rail (global host) so the two boards are one component differing only by metric + hue —
+// deliberately NOT the foil .fut card. These boards stay analytical (no popover) so the gallery
+// owns the card-back interaction and we avoid duplicate popover ids on the page.
+
+// Backdrop for the race section so the two timing-boards sit in one unified dark zone instead of
+// floating as two panels on the green page surround. A CALMER sibling of the gallery's pack-reveal
+// (its own material — a broadcast "analyst's desk", no gantry/motes): a deep navy-black panel with
+// a soft central lift + faint scanlines, and accent pools that echo each board — GOLD under the
+// Golden Boot (left), ICE under the Playmaker (right). Lowest layer; the boards + label stack on it.
+Func wc_race_backdrop() {
+  TextBlock {
+    content: @md
+<style>
+.rbk { position:relative; width:100%; height:100%; border-radius:16px; overflow:hidden;
+  background:
+    radial-gradient(48% 82% at -1% 52%, rgba(242,200,75,.11), transparent 60%),
+    radial-gradient(48% 82% at 101% 52%, rgba(120,210,232,.11), transparent 60%),
+    radial-gradient(82% 72% at 50% 32%, rgba(150,184,224,.07), transparent 64%),
+    radial-gradient(130% 96% at 50% -8%, #1a2531 0%, #0c121b 54%, #060a10 100%);
+  box-shadow:inset 0 1px 0 rgba(255,255,255,.05), inset 0 0 0 1px rgba(0,0,0,.5),
+    inset 0 0 54px -10px rgba(150,184,224,.16), 0 30px 60px -34px rgba(0,0,0,.6); }
+/* faint broadcast scanlines — the analyst-desk texture that sets it apart from the stadium void */
+.rbk::before { content:""; position:absolute; inset:0; pointer-events:none; opacity:.5;
+  background:repeating-linear-gradient(0deg, rgba(255,255,255,.014) 0 1px, transparent 1px 4px); }
+/* vignette into the corners */
+.rbk::after { content:""; position:absolute; inset:0; pointer-events:none;
+  background:radial-gradient(122% 100% at 50% 40%, transparent 56%, rgba(0,0,0,.5) 100%); }
+</style>
+<div class="rbk"></div>
+;;
+  }
+}
+
+Func wc_race_zone_label() {
+  TextBlock {
+    content: @md
+<style>
+.rc-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="rc-zone-label">The race · golden boot &amp; playmaker</p>
+;;
+  }
+}
+
+Func wc_boot_ladder() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_player_stats.goals)
+        operator: 'greater_than'
+        value: 0
+      }
+      rows: [
+        VizFieldFull { label: 'Rank' ref: r(wc_player_stats.goals_rank) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Name' ref: r(wc_player_stats.name) },
+        VizFieldFull { label: 'Team' ref: r(wc_player_stats.team_code) },
+        VizFieldFull { label: 'Club' ref: r(wc_player_bio.club) },
+        VizFieldFull { label: 'Flag' ref: r(wc_teams.flag_url) },
+        VizFieldFull { label: 'Bar' ref: r(wc_player_stats.goals_bar_pct) },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_player_stats.goals)
+          uname: 'goals'
+          format { type: 'number' pattern: '#,##0' }
+        }
+      ]
+      content: @md
+<div class="rl boot">
+  <div class="rl-head">
+    <div class="rl-mark"><svg viewBox="0 0 24 24" fill="none" stroke="var(--ac)" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" style="margin:0 !important"><path d="M3 7h3.4l.7 4.1 7.3 2.3c2.4.7 4.3 1.9 4.3 4V18a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1z"/><path d="M6 19v1.4M10 19v1.4M14 19v1.4" stroke-width="1.5"/></svg></div>
+    <div class="rl-ttl"><span class="a">Golden Boot</span><span class="b">The race for <em>goals</em></span></div>
+  </div>
+  <div class="rl-list">
+{% map(rows) %}
+  <div class="rl-row r{{ `Rank`.formatted }}">
+  <span class="rl-fill" style="--w:{{ `Bar`.raw }}%"></span>
+  <span class="rl-rank wc-num">{{ `Rank`.formatted }}</span>
+  <img class="rl-flag" src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />
+  <span class="rl-id"><span class="n">{{ `Name`.formatted }}</span><span class="s">{{ `Team`.formatted }} &middot; {{ `Club`.formatted }}</span></span>
+  <span class="rl-val wc-num">{{ `Goals`.formatted }}</span>
+  </div>
+{% end %}
+  </div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting { key: 'goals' direction: 'desc' }
+        ]
+        pagination_size: 8
+        row_limit: 8
+      }
+    }
+  }
+}
+
+Func wc_playmaker_ladder() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_player_stats.assists)
+        operator: 'greater_than'
+        value: 0
+      }
+      rows: [
+        VizFieldFull { label: 'Rank' ref: r(wc_player_stats.assists_rank) format { type: 'number' pattern: '#,##0' } },
+        VizFieldFull { label: 'Name' ref: r(wc_player_stats.name) },
+        VizFieldFull { label: 'Team' ref: r(wc_player_stats.team_code) },
+        VizFieldFull { label: 'Club' ref: r(wc_player_bio.club) },
+        VizFieldFull { label: 'Flag' ref: r(wc_teams.flag_url) },
+        VizFieldFull { label: 'Bar' ref: r(wc_player_stats.assists_bar_pct) },
+        VizFieldFull {
+          label: 'Assists'
+          ref: r(wc_player_stats.assists)
+          uname: 'assists'
+          format { type: 'number' pattern: '#,##0' }
+        }
+      ]
+      content: @md
+<div class="rl play">
+  <div class="rl-head">
+    <div class="rl-mark"><svg viewBox="0 0 24 24" fill="none" stroke="var(--ac)" stroke-width="1.8" stroke-linejoin="round" stroke-linecap="round" style="margin:0 !important"><path d="M3 8h12M12 5l3 3-3 3"/><path d="M21 16H9m3 3-3-3 3-3"/></svg></div>
+    <div class="rl-ttl"><span class="a">Playmaker</span><span class="b">The race for <em>assists</em></span></div>
+  </div>
+  <div class="rl-list">
+{% map(rows) %}
+  <div class="rl-row r{{ `Rank`.formatted }}">
+  <span class="rl-fill" style="--w:{{ `Bar`.raw }}%"></span>
+  <span class="rl-rank wc-num">{{ `Rank`.formatted }}</span>
+  <img class="rl-flag" src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />
+  <span class="rl-id"><span class="n">{{ `Name`.formatted }}</span><span class="s">{{ `Team`.formatted }} &middot; {{ `Club`.formatted }}</span></span>
+  <span class="rl-val wc-num">{{ `Assists`.formatted }}</span>
+  </div>
+{% end %}
+  </div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting { key: 'assists' direction: 'desc' }
+        ]
+        pagination_size: 8
+        row_limit: 8
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_squad.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_squad.block.aml
@@ -1,0 +1,303 @@
+// Team HQ panini-sticker squad wall. wc_squad_section covers the three outfield bands
+// (DF / MF / FW) — identical but for position filter, accent dot colour and band title.
+// Goalkeepers is its own func (aggregate-aware, shows all GKs, no row cap).
+// .stk-* styling lives in theme wc_pitch_day; album-drop keyframes in header_rail.
+// Spine is wc_player_stats (identity + tournament output) joined to wc_player_bio — each
+// sticker is a button that opens the SHARED player-profile popover (pp-* skin in header_rail).
+Func wc_squad_section(pos: String, color: String, title: String) {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_player_stats.position_group)
+        operator: 'is'
+        value: pos
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Pid'
+          ref: r(wc_player_stats.fifa_player_id)
+        },
+        VizFieldFull {
+          label: 'Num'
+          ref: r(wc_player_stats.shirt_number)
+          uname: 'shirt'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Name'
+          ref: r(wc_player_stats.name)
+        },
+        VizFieldFull {
+          label: 'Photo'
+          ref: r(wc_player_stats.picture_url)
+        },
+        VizFieldFull {
+          label: 'Kit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_player_stats.team_code)
+        },
+        VizFieldFull {
+          label: 'PosG'
+          ref: r(wc_player_stats.position_group)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_player_stats.goals)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Assists'
+          ref: r(wc_player_stats.assists)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Apps'
+          ref: r(wc_player_stats.apps)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Starts'
+          ref: r(wc_player_stats.starts)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Yellows'
+          ref: r(wc_player_stats.yellows)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Reds'
+          ref: r(wc_player_stats.reds)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Log'
+          ref: r(wc_player_stats.goal_log_html)
+        },
+        VizFieldFull {
+          label: 'GoalSvg'
+          ref: r(wc_player_stats.goal_placement_svg)
+        },
+        VizFieldFull {
+          label: 'Age'
+          ref: r(wc_player_bio.age)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Club'
+          ref: r(wc_player_bio.club)
+        },
+        VizFieldFull {
+          label: 'PosDetail'
+          ref: r(wc_player_bio.position_detail)
+        },
+        VizFieldFull {
+          label: 'Height'
+          ref: r(wc_player_bio.height)
+        }
+      ]
+      content: @md
+<div class="stk-band">
+  <div class="stk-head"><span class="stk-dot" style="background:${color};"></span><span class="stk-title">${title}</span><span class="stk-rule"></span></div>
+  <div class="stk-rail">
+{% map(rows) %}
+  <button class="stk" type="button" popovertarget="pp-{{ `Pid`.raw }}" style="anchor-name:--pp-{{ `Pid`.raw }};">
+  <span class="stk-num wc-num" style="background:{{ `Kit`.raw }};">{{ `Num`.formatted }}</span>
+  <div class="stk-ph"><img src="{{ `Photo`.raw }}" alt="" /></div>
+  <div class="stk-kit" style="background:{{ `Kit`.raw }};"></div>
+  <div class="stk-name">{{ `Name`.formatted }}</div>
+  </button>
+  <div id="pp-{{ `Pid`.raw }}" popover class="pp-card" style="position-anchor:--pp-{{ `Pid`.raw }}; --ppc:{{ `Kit`.raw }};">
+  <div class="pp-top">
+  <div class="pp-fig"><img src="{{ `Photo`.raw }}" alt="" style="margin:0 !important" /></div>
+  <div class="pp-id">
+  <div class="pp-nm">{{ `Name`.formatted }}</div>
+  <div class="pp-sub"><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />{{ `Team`.formatted }} &middot; #{{ `Num`.formatted }} &middot; {{ `PosG`.formatted }}</div>
+  <div class="pp-chips"><span class="pp-chip cl-age">{{ `Age`.formatted }}</span><span class="pp-chip cl-pos">{{ `PosDetail`.formatted }}</span><span class="pp-chip cl-club">{{ `Club`.formatted }}</span><span class="pp-chip cl-ht">{{ `Height`.formatted }}</span></div>
+  </div>
+  </div>
+  <div class="pp-stats"><div class="pp-stat hl"><b class="wc-num">{{ `Goals`.formatted }}</b><i>Goals</i></div><div class="pp-stat"><b class="wc-num">{{ `Assists`.formatted }}</b><i>Assists</i></div><div class="pp-stat"><b class="wc-num">{{ `Apps`.formatted }}</b><i>Apps</i></div><div class="pp-stat"><b class="wc-num">{{ `Starts`.formatted }}</b><i>Starts</i></div><div class="pp-stat"><b class="wc-num">{{ `Yellows`.formatted }}</b><i>Yellow</i></div><div class="pp-stat"><b class="wc-num">{{ `Reds`.formatted }}</b><i>Red</i></div></div>
+  <div class="pp-goal"><div class="pp-goal-box"><svg class="pp-net" viewBox="0 0 120 58" aria-hidden="true" style="margin:0 !important"><defs><linearGradient id="ppPost-{{ `Pid`.raw }}" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#aeb9c4"/></linearGradient><pattern id="ppnet-{{ `Pid`.raw }}" width="6.5" height="6.5" patternUnits="userSpaceOnUse"><path d="M0 0 L6.5 6.5 M6.5 0 L0 6.5" stroke="rgba(226,233,242,.15)" stroke-width=".5"/></pattern></defs><polygon class="pp-depth" points="11,9 19,3 101,3 109,9"/><rect x="19" y="3" width="82" height="6" fill="url(#ppnet-{{ `Pid`.raw }})" opacity=".45"/><rect x="11" y="9" width="98" height="43" fill="url(#ppnet-{{ `Pid`.raw }})"/><rect x="0" y="52" width="120" height="6" fill="rgba(74,128,86,.16)"/><line class="ground" x1="6" y1="52" x2="114" y2="52"/><rect x="8" y="6" width="104" height="3" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><rect x="8" y="6" width="3" height="46" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><rect x="109" y="6" width="3" height="46" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><g class="pp-dots">{{ `GoalSvg`.raw }}</g></svg></div></div>
+  <ul class="pp-gl">{{ `Log`.raw }}</ul>
+  </div>
+{% end %}
+  </div>
+</div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'shirt'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 15
+        row_limit: 15
+      }
+    }
+  }
+}
+
+// Goalkeepers band — aggregate-aware, shows every GK (no row cap).
+Func wc_squad_gk() {
+  VizBlock {
+    label: 'Num, Name and 2 more'
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_player_stats.position_group)
+        operator: 'is'
+        value: 'GK'
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Pid'
+          ref: r(wc_player_stats.fifa_player_id)
+        },
+        VizFieldFull {
+          label: 'Num'
+          ref: r(wc_player_stats.shirt_number)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+          uname: 'shirt'
+        },
+        VizFieldFull {
+          label: 'Name'
+          ref: r(wc_player_stats.name)
+        },
+        VizFieldFull {
+          label: 'Photo'
+          ref: r(wc_player_stats.picture_url)
+        },
+        VizFieldFull {
+          label: 'Kit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_player_stats.team_code)
+        },
+        VizFieldFull {
+          label: 'PosG'
+          ref: r(wc_player_stats.position_group)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_player_stats.goals)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Assists'
+          ref: r(wc_player_stats.assists)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Apps'
+          ref: r(wc_player_stats.apps)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Starts'
+          ref: r(wc_player_stats.starts)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Yellows'
+          ref: r(wc_player_stats.yellows)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Reds'
+          ref: r(wc_player_stats.reds)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Log'
+          ref: r(wc_player_stats.goal_log_html)
+        },
+        VizFieldFull {
+          label: 'GoalSvg'
+          ref: r(wc_player_stats.goal_placement_svg)
+        },
+        VizFieldFull {
+          label: 'Age'
+          ref: r(wc_player_bio.age)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'Club'
+          ref: r(wc_player_bio.club)
+        },
+        VizFieldFull {
+          label: 'PosDetail'
+          ref: r(wc_player_bio.position_detail)
+        },
+        VizFieldFull {
+          label: 'Height'
+          ref: r(wc_player_bio.height)
+        }
+      ]
+      content: @md <div class="stk-band">
+  <div class="stk-head"><span class="stk-dot" style="background:#E0A23B;"></span><span class="stk-title">Goalkeepers</span><span class="stk-rule"></span></div>
+  <div class="stk-rail">
+{% map(rows) %}
+  <button class="stk" type="button" popovertarget="pp-{{ `Pid`.raw }}" style="anchor-name:--pp-{{ `Pid`.raw }};">
+  <span class="stk-num wc-num" style="background:{{ `Kit`.raw }};">{{ `Num`.formatted }}</span>
+  <div class="stk-ph"><img src="{{ `Photo`.raw }}" alt="" /></div>
+  <div class="stk-kit" style="background:{{ `Kit`.raw }};"></div>
+  <div class="stk-name">{{ `Name`.formatted }}</div>
+  </button>
+  <div id="pp-{{ `Pid`.raw }}" popover class="pp-card" style="position-anchor:--pp-{{ `Pid`.raw }}; --ppc:{{ `Kit`.raw }};">
+  <div class="pp-top">
+  <div class="pp-fig"><img src="{{ `Photo`.raw }}" alt="" style="margin:0 !important" /></div>
+  <div class="pp-id">
+  <div class="pp-nm">{{ `Name`.formatted }}</div>
+  <div class="pp-sub"><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />{{ `Team`.formatted }} &middot; #{{ `Num`.formatted }} &middot; {{ `PosG`.formatted }}</div>
+  <div class="pp-chips"><span class="pp-chip cl-age">{{ `Age`.formatted }}</span><span class="pp-chip cl-pos">{{ `PosDetail`.formatted }}</span><span class="pp-chip cl-club">{{ `Club`.formatted }}</span><span class="pp-chip cl-ht">{{ `Height`.formatted }}</span></div>
+  </div>
+  </div>
+  <div class="pp-stats"><div class="pp-stat hl"><b class="wc-num">{{ `Goals`.formatted }}</b><i>Goals</i></div><div class="pp-stat"><b class="wc-num">{{ `Assists`.formatted }}</b><i>Assists</i></div><div class="pp-stat"><b class="wc-num">{{ `Apps`.formatted }}</b><i>Apps</i></div><div class="pp-stat"><b class="wc-num">{{ `Starts`.formatted }}</b><i>Starts</i></div><div class="pp-stat"><b class="wc-num">{{ `Yellows`.formatted }}</b><i>Yellow</i></div><div class="pp-stat"><b class="wc-num">{{ `Reds`.formatted }}</b><i>Red</i></div></div>
+  <div class="pp-goal"><div class="pp-goal-box"><svg class="pp-net" viewBox="0 0 120 58" aria-hidden="true" style="margin:0 !important"><defs><linearGradient id="ppPost-{{ `Pid`.raw }}" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffffff"/><stop offset="1" stop-color="#aeb9c4"/></linearGradient><pattern id="ppnet-{{ `Pid`.raw }}" width="6.5" height="6.5" patternUnits="userSpaceOnUse"><path d="M0 0 L6.5 6.5 M6.5 0 L0 6.5" stroke="rgba(226,233,242,.15)" stroke-width=".5"/></pattern></defs><polygon class="pp-depth" points="11,9 19,3 101,3 109,9"/><rect x="19" y="3" width="82" height="6" fill="url(#ppnet-{{ `Pid`.raw }})" opacity=".45"/><rect x="11" y="9" width="98" height="43" fill="url(#ppnet-{{ `Pid`.raw }})"/><rect x="0" y="52" width="120" height="6" fill="rgba(74,128,86,.16)"/><line class="ground" x1="6" y1="52" x2="114" y2="52"/><rect x="8" y="6" width="104" height="3" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><rect x="8" y="6" width="3" height="46" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><rect x="109" y="6" width="3" height="46" rx="1.5" fill="url(#ppPost-{{ `Pid`.raw }})"/><g class="pp-dots">{{ `GoalSvg`.raw }}</g></svg></div></div>
+  <ul class="pp-gl">{{ `Log`.raw }}</ul>
+  </div>
+{% end %}
+  </div>
+</div> ;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'shirt'
+            direction: 'asc'
+          }
+        ]
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_standings.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_standings.block.aml
@@ -1,0 +1,106 @@
+// Tournament-tab compact group standings clipboard (Pl · Pts · Form columns).
+// One per group A–C on the Tournament tab. Param `grp` drives the filter + heading.
+// Distinct from wc_group_card (Groups tab) which shows the full P/W/D/L/GF/GA/GD ledger.
+// Styling lives in theme wc_pitch_day (.clipboard/.cb-*) + header_rail keyframes.
+Func wc_group_standings_card(grp: String) {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_group_standings.group_code)
+        operator: 'is'
+        value: grp
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Rank'
+          ref: r(wc_group_standings.rank)
+          uname: 'rank'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_group_standings.team_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Played'
+          ref: r(wc_group_standings.played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'QualColor'
+          ref: r(wc_group_standings.qual_color)
+        },
+        VizFieldFull {
+          label: 'QualStatus'
+          ref: r(wc_group_standings.qual_status)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'Pts'
+          ref: r(worldcup.points)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Form'
+          ref: r(worldcup.team_form_html)
+          format {
+            type: 'html'
+          }
+        }
+      ]
+      content: @md
+<div class="cb-wrap"><div class="clipboard">
+  <div class="cb-head">
+    <span class="cb-grp">Group <b>${grp}</b></span>
+    <span class="cb-sub">Group stage · matchday 1</span>
+  </div>
+  <div class="cb-colhead"><span class="c">#</span><span></span><span>Team</span><span class="c">Pl</span><span class="c">Pts</span><span class="e">Form</span></div>
+{% map(rows) %}
+  <div class="cb-row" style="border-left-color:{{ `QualColor`.raw }};">
+    <span class="cb-rank">{{ `Rank`.formatted }}</span>
+    <img src="{{ `Flag`.raw }}" alt="" />
+    <span class="cb-name">{{ `Team`.formatted }}</span>
+    <span class="cb-p wc-num">{{ `Played`.formatted }}</span>
+    <span class="cb-pts wc-num">{{ values.`Pts`.formatted }}</span>
+    <span class="cb-form" title="{{ `QualStatus`.formatted }}">{{ values.`Form`.formatted }}</span>
+  </div>
+{% end %}
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--qual-adv);"></span>Advance</span>
+    <span class="lg"><span class="dot" style="background:var(--qual-po);"></span>Playoff</span>
+    <span class="lg"><span class="dot" style="background:var(--qual-out);"></span>Out</span>
+    <span class="sp">Form fills in as matches kick off</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'rank'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 4
+        row_limit: 4
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_team_hq.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_team_hq.block.aml
@@ -1,0 +1,891 @@
+// Team HQ tab blocks (scouting dossier). Nation filter (hq_team_filter) stays inline in the page.
+// Squad wall = wc_squad_section / wc_squad_gk. Styling in theme wc_pitch_day; keyframes in header_rail.
+
+Func wc_hq_filter_hint() {
+  TextBlock {
+    content: @md
+<style>
+.hq-hint { font-size:10.5px; line-height:1.5; color:rgba(234,255,242,.62); padding:2px 4px; }
+.hq-hint b { color:rgba(234,255,242,.85); font-weight:600; }
+</style>
+<div class="hq-hint"><b>Pick a nation</b> — the nameplate, pedigree, scouting report and squad sheet all re-arm. Squads fill in as each team's first match kicks off.</div>
+;;
+  }
+}
+
+Func wc_hq_banner() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Kit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Grp'
+          ref: r(wc_teams.group_code)
+        },
+        VizFieldFull {
+          label: 'Code'
+          ref: r(wc_teams.code)
+        },
+        VizFieldFull {
+          label: 'Host'
+          ref: r(wc_teams.cohost_tag)
+        },
+        VizFieldFull {
+          label: 'Elo'
+          ref: r(wc_team_snapshot.elo)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'EloRank'
+          ref: r(wc_team_snapshot.elo_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Odds'
+          ref: r(wc_team_snapshot.p_champion_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          label: 'RunDate'
+          ref: r(wc_team_snapshot.run_date_label)
+        }
+      ]
+      content: @md
+<style>
+.hqb { display:flex; justify-content:center; padding:8px 10px 16px; }
+.hqb-bezel { position:relative; width:100%; border-radius:14px; padding:10px;
+  background:linear-gradient(180deg, var(--board-bezel-a), var(--board-bezel-b));
+  box-shadow:0 14px 26px -14px rgba(0,0,0,.6), 0 3px 0 rgba(0,0,0,.35),
+    inset 0 1px 0 rgba(255,255,255,.55), inset 0 -2px 5px rgba(0,0,0,.22); }
+.hqb-screen { position:relative; border-radius:8px; overflow:hidden; padding:16px 24px;
+  background:radial-gradient(120% 140% at 50% -20%, rgba(120,255,180,.18), transparent 55%), var(--board-bg);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.08), inset 0 0 40px rgba(0,0,0,.6); }
+.hqb-screen::after { content:""; position:absolute; inset:0; pointer-events:none; opacity:.5;
+  background:repeating-linear-gradient(180deg, rgba(255,255,255,.05) 0 1px, transparent 1px 3px); }
+.hqb-row { position:relative; display:flex; align-items:center; gap:22px; }
+.hqb-kit { flex:none; width:7px; align-self:stretch; border-radius:4px; box-shadow:0 0 12px rgba(255,255,255,.18); }
+.hqb-id { display:flex; align-items:center; gap:20px; min-width:0; flex:1; }
+.hqb-id img { width:78px !important; height:52px !important; border-radius:4px !important; margin:0 !important;
+  display:block !important; object-fit:cover; flex:none; box-shadow:var(--flag-shadow); }
+.hqb-name { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.03em;
+  font-size:48px; line-height:1; color:var(--board-ink); text-shadow:0 0 14px var(--board-glow);
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hqb-tag { flex:none; font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.12em;
+  text-transform:uppercase; color:rgba(234,255,242,.8); border:1px solid rgba(234,255,242,.28);
+  border-radius:999px; padding:4px 12px; margin-left:6px; white-space:nowrap; }
+.hqb-tag:empty { display:none; }
+.hqb-tag.host { color:var(--gold-2); border-color:rgba(242,200,75,.45); }
+.hqb-kpis { display:flex; gap:30px; flex:none; }
+.hqb-kpi { text-align:center; min-width:128px; }
+.hqb-kpi .v { font-family:var(--font-disp); font-weight:800; font-size:44px; line-height:.95; color:var(--gold-2);
+  text-shadow:0 0 16px var(--board-glow), 0 2px 0 rgba(0,0,0,.45); }
+.hqb-kpi .v small { font-size:.46em; color:rgba(234,255,242,.6); font-weight:700; }
+.hqb-kpi .l { font-size:10.5px; text-transform:uppercase; letter-spacing:.13em; color:rgba(234,255,242,.78); margin-top:5px; }
+.hqb-kpi .bl { font-size:9.5px; letter-spacing:.08em; color:rgba(234,255,242,.45); margin-top:3px; }
+.hqb-sep { width:1px; align-self:stretch; background:rgba(234,255,242,.16); }
+/* ── Team HQ motion (page block style on this tab; wc-power-on / cb-drop / wc-deal-in
+   keyframes come from header_rail. Honours/campaigns/H2H are .clipboard → already hinge in.) */
+.hqb-screen { animation:wc-power-on .6s ease-out .2s 1; }
+/* squad stickers drop into the album from above, settling to their resting tilt (--rest); hover straightens + lifts */
+.stk { animation:stk-drop .5s cubic-bezier(.2,.74,.3,1.1) backwards; transition:transform .2s cubic-bezier(.2,.7,.3,1.1), box-shadow .2s ease; }
+@keyframes stk-drop { 0% { opacity:0; transform:translateY(-22px) rotate(-7deg) scale(.92); } 60% { opacity:1; } 100% { opacity:1; transform:var(--rest); } }
+.stk-rail .stk:nth-child(1){animation-delay:.04s} .stk-rail .stk:nth-child(2){animation-delay:.09s}
+.stk-rail .stk:nth-child(3){animation-delay:.14s} .stk-rail .stk:nth-child(4){animation-delay:.19s}
+.stk-rail .stk:nth-child(5){animation-delay:.24s} .stk-rail .stk:nth-child(6){animation-delay:.29s}
+.stk-rail .stk:nth-child(7){animation-delay:.34s} .stk-rail .stk:nth-child(8){animation-delay:.39s}
+.stk-rail .stk:nth-child(n+9){animation-delay:.44s}
+.stk:hover { transform:translateY(-7px) rotate(0deg) scale(1.06); z-index:5;
+  box-shadow:0 24px 34px -14px var(--shadow-dir), 0 3px 0 rgba(0,0,0,.16), inset 0 1px 0 #fff; }
+/* next-match card hinges from its clip and lifts on hover, like the clipboards */
+.nx { animation:cb-drop .55s cubic-bezier(.2,.74,.3,1.05) backwards; transform-origin:top center;
+  transition:transform .2s cubic-bezier(.2,.7,.3,1.05), box-shadow .2s ease; }
+.nx:hover { transform:translateY(-3px);
+  box-shadow:0 26px 40px -16px var(--shadow-dir), 0 2px 0 rgba(0,0,0,.12), inset 0 1px 0 rgba(255,255,255,.75); }
+/* team-pulse stat tiles deal in L→R (the resting ±.5° tilt is restored after via fill:backwards) */
+.pl-tile { animation:wc-deal-in .5s cubic-bezier(.2,.7,.3,1) backwards; }
+.pl-plate:nth-child(1) .pl-tile{animation-delay:.05s} .pl-plate:nth-child(2) .pl-tile{animation-delay:.10s}
+.pl-plate:nth-child(3) .pl-tile{animation-delay:.15s} .pl-plate:nth-child(4) .pl-tile{animation-delay:.20s}
+.pl-plate:nth-child(5) .pl-tile{animation-delay:.25s} .pl-plate:nth-child(6) .pl-tile{animation-delay:.30s}
+.pl-plate:nth-child(7) .pl-tile{animation-delay:.35s} .pl-plate:nth-child(8) .pl-tile{animation-delay:.40s}
+@media (prefers-reduced-motion: reduce) {
+  .hqb-screen { animation:none !important; }
+  .stk, .nx, .pl-tile { animation:none !important; opacity:1 !important; transform:var(--rest, none) !important; }
+  .stk:hover { transform:var(--rest) !important; } }
+</style>
+<div class="hqb"><div class="hqb-bezel"><div class="hqb-screen">
+{% map(rows) %}
+  <div class="hqb-row">
+    <span class="hqb-kit" style="background:{{ `Kit`.raw }};"></span>
+    <div class="hqb-id">
+      <img src="{{ `Flag`.raw }}" alt="" />
+      <span class="hqb-name">{{ `Team`.formatted }}</span>
+      <span class="hqb-tag wc-num">FIFA · {{ `Code`.formatted }}</span>
+      <span class="hqb-tag">Group {{ `Grp`.formatted }}</span>
+      <span class="hqb-tag host">{{ `Host`.formatted }}</span>
+    </div>
+    <span class="hqb-sep"></span>
+    <div class="hqb-kpis">
+      <div class="hqb-kpi"><div class="v wc-num">{{ `Elo`.formatted }}</div><div class="l">Elo rating</div><div class="bl wc-num">#{{ `EloRank`.formatted }} of 48 by Elo</div></div>
+      <div class="hqb-kpi"><div class="v wc-num">{{ `Odds`.formatted }}<small>%</small></div><div class="l">Title odds</div><div class="bl wc-num">field avg 2.1% · sim {{ `RunDate`.formatted }}</div></div>
+    </div>
+  </div>
+{% end %}
+</div></div></div>
+;;
+      settings {
+        pagination_size: 1
+        row_limit: 1
+      }
+    }
+  }
+}
+
+Func wc_hq_zone_left() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">The pedigree · World Cups 1930–2022</p>
+;;
+  }
+}
+
+Func wc_hq_zone_right() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">Next up · the scouting report</p>
+;;
+  }
+}
+
+Func wc_hq_zone_squad() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+.hq-zone-sub { text-align:center; font-size:10.5px; color:rgba(234,255,242,.65); margin:6px 0 0;
+  text-shadow:0 1px 3px rgba(0,0,0,.4); }
+</style>
+<p class="grp-zone-label">The squad · team sheet</p>
+<p class="hq-zone-sub">FIFA publishes each 26-man list with the nation's first match — stickers appear at first kickoff.</p>
+;;
+  }
+}
+
+Func wc_hq_zone_alltime() {
+  TextBlock {
+    content: @md
+<style>
+.grp-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="grp-zone-label">Every rival · all-time head-to-head</p>
+;;
+  }
+}
+
+Func wc_hq_honours() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      values: [
+        VizFieldFull {
+          label: 'Titles'
+          ref: r(worldcup.wc_titles)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Finals'
+          ref: r(worldcup.wc_finals_reached)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Semis'
+          ref: r(worldcup.wc_semis_reached)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Apps'
+          ref: r(worldcup.wc_appearances)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Wins'
+          ref: r(worldcup.hist_wins)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Draws'
+          ref: r(worldcup.hist_draws)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Losses'
+          ref: r(worldcup.hist_losses)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GF'
+          ref: r(worldcup.hist_gf)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GA'
+          ref: r(worldcup.hist_ga)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md
+<style>
+.hn-grid { display:grid; grid-template-columns:repeat(4, minmax(0,1fr)); gap:6px; }
+.hn-tile { text-align:center; padding:10px 4px 8px; }
+.hn-tile + .hn-tile { border-left:1px solid var(--panel-line); }
+.hn-v { font-family:var(--font-disp); font-weight:800; font-size:40px; line-height:.95; color:var(--panel-ink);
+  font-variant-numeric:tabular-nums; }
+.hn-v:empty::after { content:"0"; }
+.hn-tile.gold .hn-v { color:var(--gold); text-shadow:0 1px 0 rgba(255,255,255,.6); }
+.hn-tile.gold .hn-v::before { content:"★ "; font-size:.5em; vertical-align:.45em; }
+.hn-l { font-size:10.5px; text-transform:uppercase; letter-spacing:.12em; color:var(--panel-muted); margin-top:6px; }
+.hn-rec { display:flex; justify-content:center; gap:18px; margin-top:11px; padding-top:10px;
+  border-top:1px solid var(--panel-line); font-size:11px; color:var(--panel-muted);
+  text-transform:uppercase; letter-spacing:.06em; }
+.hn-rec b { font-family:var(--font-disp); font-size:15px; color:var(--panel-ink); font-weight:800; }
+</style>
+<div class="cb-wrap"><div class="clipboard">
+  <div class="cb-head">
+    <span class="cb-grp">Honours <b>board</b></span>
+    <span class="cb-sub">All World Cups · defunct nations roll up</span>
+  </div>
+  <div class="hn-grid">
+    <div class="hn-tile gold"><div class="hn-v wc-num">{{ rows[0].values.`Titles`.formatted }}</div><div class="hn-l">Titles</div></div>
+    <div class="hn-tile"><div class="hn-v wc-num">{{ rows[0].values.`Finals`.formatted }}</div><div class="hn-l">Finals</div></div>
+    <div class="hn-tile"><div class="hn-v wc-num">{{ rows[0].values.`Semis`.formatted }}</div><div class="hn-l">Semi-finals</div></div>
+    <div class="hn-tile"><div class="hn-v wc-num">{{ rows[0].values.`Apps`.formatted }}</div><div class="hn-l">Editions</div></div>
+  </div>
+  <div class="hn-rec">
+    <span><b class="wc-num">{{ rows[0].values.`Wins`.formatted }}</b> W</span>
+    <span><b class="wc-num">{{ rows[0].values.`Draws`.formatted }}</b> D</span>
+    <span><b class="wc-num">{{ rows[0].values.`Losses`.formatted }}</b> L</span>
+    <span><b class="wc-num">{{ rows[0].values.`GF`.formatted }}</b> GF</span>
+    <span><b class="wc-num">{{ rows[0].values.`GA`.formatted }}</b> GA</span>
+  </div>
+</div></div>
+;;
+    }
+  }
+}
+
+Func wc_hq_campaigns() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Year'
+          ref: r(wc_history_team_editions.year_text)
+        },
+        VizFieldFull {
+          label: 'YearSort'
+          ref: r(wc_history_team_editions.year)
+          uname: 'ysort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'P'
+          ref: r(wc_history_team_editions.played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'W'
+          ref: r(wc_history_team_editions.won)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'D'
+          ref: r(wc_history_team_editions.drawn)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'L'
+          ref: r(wc_history_team_editions.lost)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GF'
+          ref: r(wc_history_team_editions.gf)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GA'
+          ref: r(wc_history_team_editions.ga)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Finish'
+          ref: r(wc_history_team_editions.finish_label)
+        },
+        VizFieldFull {
+          label: 'FinishColor'
+          ref: r(wc_history_team_editions.finish_color)
+        }
+      ]
+      content: @md
+<style>
+.cp-colhead, .cp-row { display:grid; grid-template-columns:64px repeat(6, 40px) minmax(0,1fr); align-items:center; gap:8px; }
+.cp-colhead { padding:0 2px 6px; font-family:var(--font-disp); font-weight:700; font-size:10px;
+  text-transform:uppercase; letter-spacing:.08em; color:var(--panel-muted); }
+.cp-colhead .c { text-align:center; }
+.cp-colhead .e { text-align:right; }
+.cp-row { padding:8px 2px; }
+.cp-row + .cp-row { border-top:1px solid var(--panel-line); }
+.cp-year { font-family:var(--font-disp); font-weight:800; font-size:18px; font-variant-numeric:tabular-nums; }
+.cp-n { font-family:var(--font-disp); font-size:15px; text-align:center; color:var(--panel-muted);
+  font-variant-numeric:tabular-nums; }
+.cp-n.w { color:var(--panel-ink); font-weight:700; }
+.cp-fin { justify-self:end; font-family:var(--font-disp); font-weight:700; font-size:10.5px;
+  letter-spacing:.08em; text-transform:uppercase; color:#fff; border-radius:999px; padding:3px 11px;
+  box-shadow:0 1px 2px rgba(0,0,0,.18); }
+</style>
+<div class="cb-wrap"><div class="clipboard">
+  <div class="cb-head">
+    <span class="cb-grp">Campaign <b>ledger</b></span>
+    <span class="cb-sub">Latest first · shootouts count as draws</span>
+  </div>
+  <div class="cp-colhead"><span>Edition</span><span class="c">P</span><span class="c">W</span><span class="c">D</span><span class="c">L</span><span class="c">GF</span><span class="c">GA</span><span class="e">Finish</span></div>
+{% map(rows) %}
+  <div class="cp-row">
+    <span class="cp-year">{{ `Year`.formatted }}</span>
+    <span class="cp-n">{{ `P`.formatted }}</span>
+    <span class="cp-n w">{{ `W`.formatted }}</span>
+    <span class="cp-n">{{ `D`.formatted }}</span>
+    <span class="cp-n">{{ `L`.formatted }}</span>
+    <span class="cp-n">{{ `GF`.formatted }}</span>
+    <span class="cp-n">{{ `GA`.formatted }}</span>
+    <span class="cp-fin" style="background:{{ `FinishColor`.raw }};">{{ `Finish`.formatted }}</span>
+  </div>
+{% end %}
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--gold);"></span>Champions</span>
+    <span class="lg"><span class="dot" style="background:#8b979d;"></span>Final</span>
+    <span class="lg"><span class="dot" style="background:#a9714b;"></span>Semi-final</span>
+    <span class="sp">Showing the 10 most recent campaigns</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'ysort'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 10
+        row_limit: 10
+      }
+    }
+  }
+}
+
+Func wc_hq_next_match() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_teams.name)
+        },
+        VizFieldFull {
+          label: 'TeamFlag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'TeamKit'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Opp'
+          ref: r(wc_team_next_h2h.opponent_name)
+        },
+        VizFieldFull {
+          label: 'OppFlag'
+          ref: r(wc_team_next_h2h.opponent_flag)
+        },
+        VizFieldFull {
+          label: 'OppKit'
+          ref: r(wc_team_next_h2h.opponent_color)
+        },
+        VizFieldFull {
+          label: 'KO'
+          ref: r(wc_team_next_h2h.next_ko_label)
+        },
+        VizFieldFull {
+          label: 'Stage'
+          ref: r(wc_team_next_h2h.next_stage_label)
+        },
+        VizFieldFull {
+          label: 'Venue'
+          ref: r(wc_team_next_h2h.next_venue)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_team_next_h2h.next_city)
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'Met'
+          ref: r(wc_team_next_h2h.meetings)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'HW'
+          ref: r(wc_team_next_h2h.h2h_wins)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'HD'
+          ref: r(wc_team_next_h2h.h2h_draws)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'HL'
+          ref: r(wc_team_next_h2h.h2h_losses)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md
+<style>
+.nx-wrap { width:100%; height:100%; box-sizing:border-box; display:flex; align-items:flex-start;
+  justify-content:center; padding:16px 8px 10px; }
+.nx { position:relative; width:100%; border-radius:11px 11px 13px 13px; color:var(--panel-ink);
+  background:linear-gradient(180deg,#fbfdfb,#ecf3ee); border:1px solid var(--panel-line); padding:22px 16px 11px;
+  box-shadow:0 18px 30px -16px var(--shadow-dir), 0 2px 0 rgba(0,0,0,.10), inset 0 1px 0 rgba(255,255,255,.7); }
+.nx::before { content:""; position:absolute; top:-9px; left:50%; transform:translateX(-50%);
+  width:72px; height:17px; border-radius:5px; background:linear-gradient(180deg,#e2e8ea,#9aa6ab 55%,#6f7a7f);
+  box-shadow:0 2px 4px rgba(0,0,0,.30), inset 0 1px 0 rgba(255,255,255,.85); }
+.nx::after { content:""; position:absolute; top:-2px; left:50%; transform:translateX(-50%);
+  width:28px; height:6px; border-radius:3px; background:#586267; box-shadow:inset 0 1px 1px rgba(0,0,0,.55); }
+.nx-meta { display:flex; align-items:baseline; justify-content:space-between; gap:8px;
+  margin-bottom:12px; padding-bottom:8px; border-bottom:1px solid var(--panel-line); }
+.nx-stage { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.07em;
+  font-size:15px; }
+.nx-stage b { color:var(--gold); }
+.nx-ko { font-size:11px; font-weight:600; color:var(--panel-muted); white-space:nowrap; }
+.nx-grid { display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:14px; padding:4px 0 10px; }
+.nx-side { display:flex; flex-direction:column; align-items:center; gap:8px; min-width:0; text-align:center; }
+.nx-side img { width:62px !important; height:42px !important; border-radius:3px !important; margin:0 !important;
+  display:block !important; object-fit:cover; box-shadow:var(--flag-shadow); }
+.nx-side .nm { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; font-size:16px;
+  letter-spacing:.03em; line-height:1.1; }
+.nx-side .kit { width:34px; height:4px; border-radius:2px; }
+.nx-vs { font-family:var(--font-disp); font-weight:800; font-size:13px; color:var(--panel-muted);
+  text-transform:uppercase; letter-spacing:.14em; }
+.nx-venue { text-align:center; font-size:11px; color:var(--panel-muted); padding-bottom:10px; }
+.nx-tally { display:flex; justify-content:center; align-items:center; gap:14px; padding-top:9px;
+  border-top:1px solid var(--panel-line); font-size:10px; text-transform:uppercase;
+  letter-spacing:.06em; color:var(--panel-muted); }
+.nx-tally b { font-family:var(--font-disp); font-size:14px; font-weight:800; color:var(--panel-ink); }
+.nx-tally .tw b { color:var(--win); }
+.nx-tally .td b { color:var(--draw); }
+.nx-tally .tl b { color:var(--loss); }
+</style>
+<div class="nx-wrap">
+{% map(rows) %}
+  <div class="nx">
+    <div class="nx-meta">
+      <span class="nx-stage">Next <b>fixture</b> · {{ `Stage`.formatted }}</span>
+      <span class="nx-ko">{{ `KO`.formatted }} UTC</span>
+    </div>
+    <div class="nx-grid">
+      <div class="nx-side"><img src="{{ `TeamFlag`.raw }}" alt="" /><span class="nm">{{ `Team`.formatted }}</span><span class="kit" style="background:{{ `TeamKit`.raw }};"></span></div>
+      <span class="nx-vs">vs</span>
+      <div class="nx-side"><img src="{{ `OppFlag`.raw }}" alt="" /><span class="nm">{{ `Opp`.formatted }}</span><span class="kit" style="background:{{ `OppKit`.raw }};"></span></div>
+    </div>
+    <div class="nx-venue">{{ `Venue`.formatted }} · {{ `City`.formatted }}</div>
+    <div class="nx-tally">
+      <span><b class="wc-num">{{ values.`Met`.formatted }}</b> WC meetings</span>
+      <span class="tw"><b class="wc-num">{{ values.`HW`.formatted }}</b> W</span>
+      <span class="td"><b class="wc-num">{{ values.`HD`.formatted }}</b> D</span>
+      <span class="tl"><b class="wc-num">{{ values.`HL`.formatted }}</b> L</span>
+    </div>
+  </div>
+{% end %}
+</div>
+;;
+      settings {
+        pagination_size: 1
+        row_limit: 1
+      }
+    }
+  }
+}
+
+Func wc_hq_h2h() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Year'
+          ref: r(wc_team_next_h2h.year_text)
+        },
+        VizFieldFull {
+          label: 'YearSort'
+          ref: r(wc_team_next_h2h.year)
+          uname: 'hsort'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Stage'
+          ref: r(wc_team_next_h2h.stage_name)
+        },
+        VizFieldFull {
+          label: 'Score'
+          ref: r(wc_team_next_h2h.score_label)
+        },
+        VizFieldFull {
+          label: 'Res'
+          ref: r(wc_team_next_h2h.result)
+        },
+        VizFieldFull {
+          label: 'ResColor'
+          ref: r(wc_team_next_h2h.result_color)
+        }
+      ]
+      content: @md
+<style>
+.hh-colhead, .hh-row { display:grid; grid-template-columns:26px 60px minmax(0,1fr) 86px; align-items:center; gap:10px; }
+.hh-colhead { padding:0 2px 6px; font-family:var(--font-disp); font-weight:700; font-size:10px;
+  text-transform:uppercase; letter-spacing:.08em; color:var(--panel-muted); }
+.hh-colhead .e { text-align:right; }
+.hh-row { padding:8px 2px; }
+.hh-row + .hh-row { border-top:1px solid var(--panel-line); }
+.hh-chip { width:20px; height:20px; border-radius:5px; display:inline-flex; align-items:center; justify-content:center;
+  color:#fff; font-family:var(--font-disp); font-weight:800; font-size:11px;
+  box-shadow:inset 0 0 0 1px rgba(0,0,0,.14), 0 1px 1px rgba(0,0,0,.12); }
+.hh-chip:empty::after { content:"·"; }
+.hh-year { font-family:var(--font-disp); font-weight:800; font-size:18px; font-variant-numeric:tabular-nums; }
+.hh-year:empty::after { content:"—"; color:var(--panel-muted); font-weight:500; }
+.hh-stage { font-size:13px; color:var(--panel-muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.hh-stage:empty::after { content:"No World Cup meeting yet — first one is next"; font-style:italic; }
+.hh-score { font-family:var(--font-disp); font-weight:800; font-size:18px; text-align:right;
+  font-variant-numeric:tabular-nums; white-space:nowrap; }
+</style>
+<div class="cb-wrap"><div class="clipboard">
+  <div class="cb-head">
+    <span class="cb-grp">Head-to-<b>head</b></span>
+    <span class="cb-sub">All WC meetings vs the next opponent</span>
+  </div>
+  <div class="hh-colhead"><span></span><span>Year</span><span>Stage</span><span class="e">Score</span></div>
+{% map(rows) %}
+  <div class="hh-row">
+    <span class="hh-chip" style="background:{{ `ResColor`.raw }};">{{ `Res`.formatted }}</span>
+    <span class="hh-year">{{ `Year`.formatted }}</span>
+    <span class="hh-stage">{{ `Stage`.formatted }}</span>
+    <span class="hh-score">{{ `Score`.formatted }}</span>
+  </div>
+{% end %}
+  <div class="cb-foot">
+    <span class="lg"><span class="dot" style="background:var(--win);"></span>Win</span>
+    <span class="lg"><span class="dot" style="background:var(--draw);"></span>Draw</span>
+    <span class="lg"><span class="dot" style="background:var(--loss);"></span>Loss</span>
+    <span class="sp">Score shown from the selected team's side</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'hsort'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 12
+        row_limit: 12
+      }
+    }
+  }
+}
+
+Func wc_hq_alltime_h2h() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Opp'
+          ref: r(wc_history_h2h.opp_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_history_h2h.opp_flag)
+        },
+        VizFieldFull {
+          label: 'Span'
+          ref: r(wc_history_h2h.span_label)
+        },
+        VizFieldFull {
+          label: 'P'
+          ref: r(wc_history_h2h.played)
+          uname: 'p_sort'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Rec'
+          ref: r(wc_history_h2h.record_label)
+        },
+        VizFieldFull {
+          label: 'W'
+          ref: r(wc_history_h2h.wins)
+          uname: 'w_sort'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'D'
+          ref: r(wc_history_h2h.draws)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'L'
+          ref: r(wc_history_h2h.losses)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'GD'
+          ref: r(wc_history_h2h.gd_label)
+        },
+        VizFieldFull {
+          label: 'GDColor'
+          ref: r(wc_history_h2h.gd_color)
+        }
+      ]
+      content: @md
+<style>
+/* ===== Team HQ · all-time rivalry RECORD BOOK (own material: a bound football almanac) =====
+   Shared Saira type scale + gold accent (house style); bespoke surface = aged leaf, oxblood
+   leather spine binding, ruled register lines. Dominance bar = flex segments ∝ W:D:L share. */
+.rb-wrap { width:100%; height:100%; box-sizing:border-box; display:flex; align-items:flex-start;
+  justify-content:center; padding:14px 6px 10px; }
+.rb-book { position:relative; width:100%; border-radius:3px 13px 13px 3px; overflow:hidden;
+  color:#2c2418; padding:18px 24px 12px 36px;
+  background:
+    radial-gradient(135% 120% at 100% -10%, rgba(255,251,238,.85), transparent 58%),
+    linear-gradient(180deg,#f4ebd6,#e8ddc0); -webkit-print-color-adjust:exact;
+  box-shadow:0 24px 42px -18px rgba(7,30,18,.55), 0 3px 0 rgba(60,40,15,.18),
+    inset 0 1px 0 rgba(255,255,255,.6), inset 0 0 0 1px rgba(120,90,40,.18); }
+/* bound leather spine = the book's binding (a material edge, NOT a team-colour accent stripe) */
+.rb-book::before { content:""; position:absolute; left:0; top:0; bottom:0; width:18px;
+  background:linear-gradient(90deg,#4c1a16,#7d2c22 55%,#591f18);
+  box-shadow:inset -3px 0 5px rgba(0,0,0,.45), inset 2px 0 0 rgba(255,255,255,.12), 1px 0 0 rgba(0,0,0,.2); }
+.rb-book::after { content:""; position:absolute; left:23px; top:14px; bottom:14px; width:0;
+  border-left:1px dashed rgba(255,224,150,.5); }
+.rb-mast { position:relative; display:flex; align-items:baseline; justify-content:space-between;
+  gap:10px; padding-bottom:9px; border-bottom:2px solid rgba(120,75,30,.5); margin-bottom:1px; }
+.rb-mast::after { content:""; position:absolute; left:0; right:0; bottom:-4px; height:1px; background:rgba(120,75,30,.28); }
+.rb-title { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.06em;
+  font-size:18px; line-height:1; color:#2c2418; }
+.rb-title b { color:var(--gold); }
+.rb-sub { font-size:9px; text-transform:uppercase; letter-spacing:.14em; color:#9c8a68; white-space:nowrap; }
+.rb-colhead, .rb-row { display:grid;
+  grid-template-columns:26px 184px 94px 28px 62px minmax(220px,1fr) 56px;
+  align-items:center; gap:12px; }
+.rb-colhead { padding:11px 2px 6px; font-family:var(--font-disp); font-weight:700; font-size:9px;
+  text-transform:uppercase; letter-spacing:.11em; color:#a08a66; }
+.rb-colhead .c { text-align:center; }
+.rb-colhead .e { text-align:right; }
+.rb-row { padding:7px 2px; }
+.rb-row + .rb-row { border-top:1px solid rgba(120,75,30,.16); }
+.rb-book .rb-row img { width:25px !important; height:17px !important; border-radius:2px !important;
+  margin:0 !important; display:block !important; object-fit:cover; box-shadow:0 1px 2px rgba(0,0,0,.32); }
+.rb-name { font-family:var(--font-disp); font-weight:700; font-size:14.5px; letter-spacing:.01em;
+  text-transform:uppercase; color:#2c2418; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.rb-span { font-size:10.5px; color:#9c8a68; font-variant-numeric:tabular-nums; white-space:nowrap; }
+.rb-p { font-family:var(--font-disp); font-weight:700; font-size:14px; text-align:center; color:#7a6a4c;
+  font-variant-numeric:tabular-nums; }
+.rb-rec { font-family:var(--font-disp); font-weight:800; font-size:14.5px; color:#2c2418; letter-spacing:.03em;
+  font-variant-numeric:tabular-nums; }
+.rb-bar { position:relative; display:flex; height:14px; border-radius:2px; overflow:hidden;
+  background:rgba(120,75,30,.12); box-shadow:inset 0 1px 2px rgba(60,40,15,.28), inset 0 0 0 1px rgba(120,75,30,.2); }
+.rb-seg { height:100%; min-width:0; }
+.rb-seg.w { background:linear-gradient(180deg,#36c07f,#1f9a64); }
+.rb-seg.d { background:linear-gradient(180deg,#ecb454,#d99a2f); }
+.rb-seg.l { background:linear-gradient(180deg,#ee5a4f,#d83a2e); }
+.rb-gd { font-family:var(--font-disp); font-weight:800; font-size:14px; text-align:right; color:#5b4a30;
+  font-variant-numeric:tabular-nums; }
+.rb-foot { display:flex; align-items:center; gap:13px; flex-wrap:wrap; margin-top:9px; padding-top:8px;
+  border-top:2px solid rgba(120,75,30,.38); font-size:9px; text-transform:uppercase; letter-spacing:.06em; color:#9c8a68; }
+.rb-foot .rb-lg { display:inline-flex; align-items:center; gap:5px; }
+.rb-foot .rb-dot { width:9px; height:9px; border-radius:2px; flex:none; box-shadow:inset 0 0 0 1px rgba(0,0,0,.14); }
+.rb-foot .rb-sp { margin-left:auto; text-transform:none; letter-spacing:.02em; font-style:italic; }
+/* motion — the leaf opens from its spine; dominance bars ink across (reduced-motion safe) */
+.rb-book { animation:rb-open .55s cubic-bezier(.2,.7,.3,1.05) both; transform-origin:left center; }
+@keyframes rb-open { 0% { opacity:0; transform:perspective(1300px) rotateY(-10deg) translateY(8px); } 100% { opacity:1; transform:none; } }
+.rb-bar .rb-seg { animation:rb-ink .5s ease-out both; transform-origin:left center; }
+@keyframes rb-ink { 0% { transform:scaleX(0); } 100% { transform:scaleX(1); } }
+.rb-rows .rb-row:nth-child(1) .rb-seg{animation-delay:.24s} .rb-rows .rb-row:nth-child(2) .rb-seg{animation-delay:.27s}
+.rb-rows .rb-row:nth-child(3) .rb-seg{animation-delay:.30s} .rb-rows .rb-row:nth-child(4) .rb-seg{animation-delay:.33s}
+.rb-rows .rb-row:nth-child(5) .rb-seg{animation-delay:.36s} .rb-rows .rb-row:nth-child(6) .rb-seg{animation-delay:.39s}
+.rb-rows .rb-row:nth-child(7) .rb-seg{animation-delay:.42s} .rb-rows .rb-row:nth-child(8) .rb-seg{animation-delay:.45s}
+.rb-rows .rb-row:nth-child(9) .rb-seg{animation-delay:.48s} .rb-rows .rb-row:nth-child(n+10) .rb-seg{animation-delay:.51s}
+@media (prefers-reduced-motion:reduce){ .rb-book,.rb-bar .rb-seg{animation:none !important; opacity:1 !important; transform:none !important;} }
+</style>
+<div class="rb-wrap"><div class="rb-book">
+  <div class="rb-mast">
+    <span class="rb-title">The Record <b>Book</b></span>
+    <span class="rb-sub">All-time World Cup meetings · 1930–2022</span>
+  </div>
+  <div class="rb-colhead"><span></span><span>Rival</span><span>Years</span><span class="c">P</span><span>W–D–L</span><span>Dominance</span><span class="e">GD</span></div>
+  <div class="rb-rows">
+{% map(rows) %}
+  <div class="rb-row">
+    <img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" />
+    <span class="rb-name">{{ `Opp`.formatted }}</span>
+    <span class="rb-span wc-num">{{ `Span`.formatted }}</span>
+    <span class="rb-p wc-num">{{ `P`.formatted }}</span>
+    <span class="rb-rec wc-num">{{ `Rec`.formatted }}</span>
+    <span class="rb-bar"><span class="rb-seg w" style="flex:{{ `W`.formatted }}"></span><span class="rb-seg d" style="flex:{{ `D`.formatted }}"></span><span class="rb-seg l" style="flex:{{ `L`.formatted }}"></span></span>
+    <span class="rb-gd wc-num" style="color:{{ `GDColor`.raw }}">{{ `GD`.formatted }}</span>
+  </div>
+{% end %}
+  </div>
+  <div class="rb-foot">
+    <span class="rb-lg"><span class="rb-dot" style="background:var(--win)"></span>Won</span>
+    <span class="rb-lg"><span class="rb-dot" style="background:var(--draw)"></span>Drawn</span>
+    <span class="rb-lg"><span class="rb-dot" style="background:var(--loss)"></span>Lost</span>
+    <span class="rb-sp">12 most-played rivals · bar = win / draw / loss share</span>
+  </div>
+</div></div>
+;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'p_sort'
+            direction: 'desc'
+          },
+          SortSetting {
+            key: 'w_sort'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 12
+        row_limit: 12
+      }
+    }
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_tournament.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_tournament.block.aml
@@ -1,0 +1,867 @@
+// Tournament tab blocks. Styling lives in theme wc_pitch_day; shared keyframes in header_rail.
+// (Group standings cards = wc_group_standings_card; knockout = wc_knockout_*.)
+
+Func wc_jumbotron() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      values: [
+        VizFieldFull {
+          ref: r(worldcup.avg_attendance)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          ref: r(worldcup.matches_played)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          ref: r(worldcup.total_matches)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          ref: r(worldcup.total_goals)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          ref: r(worldcup.goals_per_match)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        },
+        VizFieldFull {
+          ref: r(worldcup.hist_goals_per_match_modern)
+          format {
+            type: 'number'
+            pattern: '#,##0.0'
+          }
+        }
+      ]
+      content: @md
+<style>
+/* mounted stadium board: centered + narrower than the pitch (so the LED text reads big), tilted in 3D,
+   chrome bezel on mounting arms. Side/bottom padding keeps the tilt + shadow inside the clipped block. */
+.wc-jumbo { display:flex; justify-content:center; padding:18px 16px 24px; }
+.wc-jumbo-bezel { position:relative; width:min(1040px,100%); border-radius:14px; padding:11px;
+  background:linear-gradient(180deg, var(--board-bezel-a), var(--board-bezel-b));
+  box-shadow:0 14px 26px -14px rgba(0,0,0,.6), 0 3px 0 rgba(0,0,0,.35),
+    inset 0 1px 0 rgba(255,255,255,.55), inset 0 -2px 5px rgba(0,0,0,.22);
+  transform:perspective(1400px) rotateX(5deg); transform-origin:top center; }
+/* metal mounting arms hanging the board */
+.wc-jumbo-bezel::before, .wc-jumbo-bezel::after { content:""; position:absolute; top:-15px; width:8px; height:17px;
+  background:linear-gradient(180deg,#9aa6ab,#5e696e); border-radius:3px 3px 0 0; }
+.wc-jumbo-bezel::before { left:24%; }
+.wc-jumbo-bezel::after { right:24%; }
+.wc-jumbo-screen { position:relative; border-radius:8px; overflow:hidden; padding:14px 26px;
+  background:radial-gradient(120% 140% at 50% -20%, rgba(120,255,180,.18), transparent 55%), var(--board-bg);
+  box-shadow:inset 0 0 0 1px rgba(255,255,255,.08), inset 0 0 40px rgba(0,0,0,.6);
+  animation: wc-power-on .6s ease-out .2s 1; }
+/* jumbotron "power on" flicker — keyframe lives in the theme (shared by all LED boards) */
+@media (prefers-reduced-motion: reduce) { .wc-jumbo-screen { animation:none; } }
+.wc-jumbo-screen::after { content:""; position:absolute; inset:0; pointer-events:none; opacity:.5;
+  background:repeating-linear-gradient(180deg, rgba(255,255,255,.05) 0 1px, transparent 1px 3px); }
+.wc-jumbo-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:10px; position:relative; }
+.wc-jumbo-title { font-family:var(--font-disp); font-weight:700; text-transform:uppercase; letter-spacing:.14em;
+  font-size:15px; color:var(--board-ink); text-shadow:0 0 10px var(--board-glow); }
+.wc-jumbo-asof { font-size:11px; color:rgba(234,255,242,.72); letter-spacing:.02em; }
+.wc-kpis { display:grid; grid-template-columns:repeat(4, minmax(0,1fr)); gap:8px; position:relative; }
+.wc-kpi { text-align:center; padding:4px 2px; }
+.wc-kpi .v { font-family:var(--font-disp); font-weight:800; font-size:52px; line-height:.92; color:var(--gold-2);
+  text-shadow:0 0 16px var(--board-glow), 0 2px 0 rgba(0,0,0,.45); }
+.wc-kpi .v:empty::after { content:"0"; }
+.wc-kpi .v small { font-size:.5em; color:rgba(234,255,242,.6); font-weight:700; }
+.wc-kpi .l { font-size:11px; text-transform:uppercase; letter-spacing:.13em; color:rgba(234,255,242,.78); margin-top:6px; }
+/* historical baseline under a KPI — dimmer LED row so the live number stays the headline */
+.wc-kpi .bl { font-size:9.5px; letter-spacing:.08em; color:rgba(234,255,242,.45); margin-top:4px; }
+</style>
+<div class="wc-jumbo"><div class="wc-jumbo-bezel"><div class="wc-jumbo-screen">
+  <div class="wc-jumbo-head">
+    <span class="wc-jumbo-title">Tournament scoreboard</span>
+    <span class="wc-jumbo-asof"><span class="wc-pulse"></span> Group stage · opening day</span>
+  </div>
+  <div class="wc-kpis">
+    <div class="wc-kpi"><div class="v wc-num">{{ rows[0].values.`Matches Played`.formatted }}<small>/{{ rows[0].values.`Total Matches`.formatted }}</small></div><div class="l">Matches played</div></div>
+    <div class="wc-kpi"><div class="v wc-num">{{ rows[0].values.`Total Goals`.formatted }}</div><div class="l">Goals</div></div>
+    <div class="wc-kpi"><div class="v wc-num">{{ rows[0].values.`Goals per Match`.formatted }}</div><div class="l">Goals / match</div><div class="bl wc-num">’98–’22 avg: {{ rows[0].values.`Goals per Match Since 1998`.formatted }}</div></div>
+    <div class="wc-kpi"><div class="v wc-num">{{ rows[0].values.`Average Attendance`.formatted }}</div><div class="l">Avg attendance</div></div>
+  </div>
+</div></div></div>
+;;
+    }
+  }
+}
+
+Func wc_match_cards() {
+  VizBlock {
+    label: 'MatchNum, Home and 12 more'
+    viz: MarkdownViz {
+      dataset: worldcup
+      // "Upcoming fixtures" = matches not yet finished AND not the featured match (the hero above shows
+      // the next match; the band lists the upcoming fixtures after it, so neither shows it twice). Soonest
+      // first (kickoff asc, below), rolling forward to the next 12 as matches play. in_fixture_band carries
+      // both conditions because a viz takes a single inline filter.
+      filter {
+        field: r(wc_matches.in_fixture_band)
+        operator: 'is'
+        value: true
+      }
+      rows: [
+        VizFieldFull {
+          label: 'MatchNum'
+          ref: r(wc_matches.match_num)
+        },
+        VizFieldFull { label: 'HomeCode' ref: r(wc_home_teams.code) },
+        VizFieldFull { label: 'AwayCode' ref: r(wc_away_teams.code) },
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeFlag'
+          ref: r(wc_home_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'HomeColor'
+          ref: r(wc_home_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayFlag'
+          ref: r(wc_away_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'AwayColor'
+          ref: r(wc_away_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'HomeScore'
+          ref: r(wc_matches.home_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'AwayScore'
+          ref: r(wc_matches.away_score)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'StatusText'
+          ref: r(wc_matches.status_label)
+        },
+        VizFieldFull {
+          label: 'StatusColor'
+          ref: r(wc_matches.status_color)
+        },
+        VizFieldFull {
+          label: 'Grp'
+          ref: r(wc_matches.group_code)
+        },
+        VizFieldFull {
+          label: 'KO'
+          ref: r(wc_matches.kickoff_utc)
+          hidden: true
+          uname: 'kickoff'
+        },
+        VizFieldFull {
+          label: 'KODay'
+          ref: r(wc_matches.kickoff_day)
+        },
+        VizFieldFull {
+          label: 'KOTime'
+          ref: r(wc_matches.kickoff_time)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_matches.city)
+        },
+        VizFieldFull {
+          label: 'PHome'
+          ref: r(wc_match_odds.p_home_pct)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'PDraw'
+          ref: r(wc_match_odds.p_draw_pct)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull {
+          label: 'PAway'
+          ref: r(wc_match_odds.p_away_pct)
+          format { type: 'number' pattern: '#,##0' }
+        },
+        VizFieldFull { label: 'ExpScore' ref: r(wc_match_odds.exp_score_label) },
+        VizFieldFull { label: 'OddsRun' ref: r(wc_match_odds.run_label) },
+        VizFieldFull { label: 'OddsNote' ref: r(wc_match_odds.status_note) }
+      ]
+      content: @md <style>
+.wc-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0 0 14px; }
+/* fixed 6 cols (not auto-fit) → 12 cards = exactly 2 rows, independent of container-width guesswork.
+   At the 1280px block: card = (1280 − 5×12)/6 ≈ 203px. */
+.match-row { display:grid; grid-template-columns:repeat(6, minmax(0,1fr)); gap:12px; }
+.mcard { position:relative; background:linear-gradient(180deg, var(--panel), var(--panel-2)); border:1px solid var(--panel-line);
+  border-radius:12px; padding:12px 13px 11px; color:var(--panel-ink); overflow:hidden;
+  box-shadow:0 1px 1px rgba(0,0,0,.18), 0 14px 28px -18px var(--shadow-dir), inset 0 1px 0 rgba(255,255,255,.4); }
+/* team kit colours live on each team row (.mteam border-left), not the card edge */
+.mcard-top { display:flex; align-items:flex-start; justify-content:space-between; gap:8px; margin-bottom:11px; }
+.mbadge { flex:none; display:inline-flex; align-items:center; gap:5px; font-family:var(--font-disp); font-weight:700;
+  font-size:10px; letter-spacing:.07em; text-transform:uppercase; padding:3px 9px; border-radius:999px; color:#fff;
+  box-shadow:0 1px 2px rgba(0,0,0,.18); }
+.mmeta { flex:none; display:flex; flex-direction:column; align-items:flex-end; text-align:right; gap:2px; line-height:1.1; }
+.mmeta .mgrp { font-family:var(--font-disp); font-weight:700; font-size:9px; text-transform:uppercase;
+  letter-spacing:.14em; color:var(--panel-muted); }
+.mmeta .mko { font-size:11px; font-weight:600; color:var(--panel-ink); white-space:nowrap; letter-spacing:.01em; }
+.mmeta .mko .t { color:var(--panel-muted); font-weight:500; }
+.mteam { display:flex; align-items:center; justify-content:space-between; gap:10px; padding:4px 0; min-width:0; }
+.mteam .side { display:flex; align-items:center; gap:8px; min-width:0; line-height:1; }
+.mteam .kit { flex:0 0 auto; align-self:center; display:block; width:4px; height:16px; border-radius:2px; }
+.mcard .mteam .side img { display:block !important; align-self:center !important; margin:0 !important; width:26px !important; height:18px !important; border-radius:2px !important; object-fit:cover; flex:none; box-shadow:0 1px 3px rgba(0,0,0,.3); }
+.mteam .tn { align-self:center; line-height:1; font-weight:600; font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.mteam .sc { font-family:var(--font-disp); font-weight:800; font-size:22px; line-height:1; color:var(--panel-ink); min-width:14px; text-align:right; }
+.mteam .sc:empty::after { content:"–"; color:var(--panel-muted); }
+.mvenue { font-size:10.5px; color:var(--panel-muted); margin-top:8px; display:flex; align-items:center; gap:5px; }
+.mvenue::before { content:""; flex:none; width:7px; height:7px; margin:0 2px 2px 0; background:currentColor; opacity:.7;
+  border-radius:50% 50% 50% 0; transform:rotate(45deg); }
+/* ── motion: fixtures dealt onto the turf — L→R across the top row, then the
+   bottom (12-card stagger). fill:backwards holds each off-stage until its turn
+   then releases, so the hover lift works. */
+.mcard { animation:wc-deal-in .5s cubic-bezier(.2,.7,.3,1) backwards;
+  transition:transform .2s cubic-bezier(.2,.7,.3,1.05), box-shadow .2s ease, border-color .2s ease; }
+.match-row .mcard:nth-child(1){animation-delay:.06s} .match-row .mcard:nth-child(2){animation-delay:.10s}
+.match-row .mcard:nth-child(3){animation-delay:.14s} .match-row .mcard:nth-child(4){animation-delay:.18s}
+.match-row .mcard:nth-child(5){animation-delay:.22s} .match-row .mcard:nth-child(6){animation-delay:.26s}
+.match-row .mcard:nth-child(7){animation-delay:.30s} .match-row .mcard:nth-child(8){animation-delay:.34s}
+.match-row .mcard:nth-child(9){animation-delay:.38s} .match-row .mcard:nth-child(10){animation-delay:.42s}
+.match-row .mcard:nth-child(11){animation-delay:.46s} .match-row .mcard:nth-child(12){animation-delay:.50s}
+.mcard:hover { transform:translateY(-3px); border-color:rgba(12,36,24,.30);
+  box-shadow:0 2px 2px rgba(0,0,0,.2), 0 20px 34px -16px var(--shadow-dir), inset 0 1px 0 rgba(255,255,255,.5); }
+@media (prefers-reduced-motion: reduce) {
+  .mcard { animation:none !important; opacity:1 !important; transform:none !important; }
+  .mcard:hover { transform:none !important; } }
+/* ── match-prediction popover: tap a fixture → the model's win-probability forecast.
+   A floating dark broadcast card (same popover family as the player profile), escaping the
+   card's overflow:hidden via the top layer; kit-coloured probability bar + gold expected score.
+   The overlay button makes the whole card the tap target without disturbing the deal-in stagger. */
+.mcard-hit { position:absolute; inset:0; z-index:3; appearance:none; -webkit-appearance:none; border:none;
+  background:none; padding:0; margin:0; cursor:pointer; border-radius:12px; }
+.mcard-hit:focus-visible { outline:2px solid var(--gold); outline-offset:-2px; }
+.mp-card { margin:auto; border:none; padding:0 0 14px; width:384px; color:#eaf1f8; border-radius:16px; overflow:hidden;
+  background:linear-gradient(180deg,#1b2735,#0e151f);
+  box-shadow:0 26px 52px -18px rgba(0,0,0,.72), inset 0 1px 0 rgba(255,255,255,.08), inset 0 0 0 1px rgba(0,0,0,.5); }
+.mp-card::backdrop { background:rgba(8,11,15,.5); }
+@supports (anchor-name:--a) {
+  .mp-card { margin:8px; inset:auto; position-area:top; position-try-fallbacks:flip-block, flip-inline, flip-block flip-inline; } }
+.mp-card:popover-open { animation:mp-in .2s cubic-bezier(.2,.7,.25,1) both; }
+@keyframes mp-in { from { opacity:0; transform:translateY(7px) scale(.96); } to { opacity:1; transform:none; } }
+.mp-hd { display:flex; align-items:baseline; justify-content:space-between; gap:10px; padding:14px 16px 0; }
+.mp-ey { font-family:var(--font-disp); font-weight:800; font-size:9.5px; letter-spacing:.16em; text-transform:uppercase; color:var(--gold-2); }
+.mp-run { font-size:9px; letter-spacing:.1em; text-transform:uppercase; color:rgba(234,241,248,.5); white-space:nowrap; }
+.mp-mu { display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:12px; padding:13px 16px 2px; }
+.mp-side { display:flex; align-items:center; gap:8px; min-width:0; }
+.mp-side.r { justify-content:flex-end; }
+.mp-card .mp-side img { width:30px !important; height:20px !important; border-radius:3px !important; margin:0 !important;
+  display:block !important; object-fit:cover; box-shadow:0 1px 3px rgba(0,0,0,.5); }
+.mp-nm { font-family:var(--font-disp); font-weight:800; font-size:15px; text-transform:uppercase; letter-spacing:.02em;
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.mp-xg { font-family:var(--font-disp); font-weight:800; font-size:23px; color:var(--gold-2); letter-spacing:.02em; line-height:1; white-space:nowrap; }
+.mp-xg:empty::after { content:"—"; color:rgba(234,241,248,.4); }
+.mp-bar { display:flex; height:8px; border-radius:4px; overflow:hidden; margin:11px 16px 0;
+  background:rgba(255,255,255,.08); box-shadow:inset 0 1px 2px rgba(0,0,0,.4); }
+.mp-bar i { display:block; height:100%; }
+.mp-lg { display:flex; justify-content:space-between; gap:10px; padding:10px 16px 0; }
+.mp-lg .s { display:flex; flex-direction:column; gap:1px; flex:1; }
+.mp-lg .s.h { align-items:flex-start; } .mp-lg .s.d { align-items:center; } .mp-lg .s.a { align-items:flex-end; }
+.mp-lg .pc { font-family:var(--font-disp); font-weight:800; font-size:16px; font-variant-numeric:tabular-nums; }
+.mp-lg .pc::after { content:"%"; font-size:.6em; font-weight:700; color:rgba(234,241,248,.5); margin-left:1px; }
+.mp-lg .pc:empty::after { content:"—"; font-size:1em; }
+.mp-lg .l { font-size:8.5px; letter-spacing:.12em; text-transform:uppercase; color:rgba(234,241,248,.55); white-space:nowrap; }
+.mp-note { font-size:10px; font-style:italic; color:rgba(234,241,248,.5); padding:11px 16px 0; }
+.mp-note:empty { display:none; }
+</style>
+<p class="wc-zone-label">Around midfield · upcoming fixtures</p>
+<div class="match-row">
+{% map(rows) %}
+  <article class="mcard">
+    <button class="mcard-hit" type="button" popovertarget="mp-{{ `MatchNum`.raw }}" style="anchor-name:--mp-{{ `MatchNum`.raw }};" aria-label="Model prediction"></button>
+    <div class="mcard-top">
+      <span class="mbadge" style="background:{{ `StatusColor`.raw }};">{{ `StatusText`.formatted }}</span>
+      <span class="mmeta">
+        <span class="mgrp">Group {{ `Grp`.formatted }}</span>
+        <span class="mko">{{ `KODay`.formatted }} <span class="t">· {{ `KOTime`.formatted }}</span></span>
+      </span>
+    </div>
+    <div class="mteam">
+      <span class="side"><span class="kit" style="background:{{ `HomeColor`.raw }};"></span><img src="{{ `HomeFlag`.raw }}" alt="" /><span class="tn">{{ `Home`.formatted }}</span></span>
+      <span class="sc wc-num">{{ `HomeScore`.formatted }}</span>
+    </div>
+    <div class="mteam">
+      <span class="side"><span class="kit" style="background:{{ `AwayColor`.raw }};"></span><img src="{{ `AwayFlag`.raw }}" alt="" /><span class="tn">{{ `Away`.formatted }}</span></span>
+      <span class="sc wc-num">{{ `AwayScore`.formatted }}</span>
+    </div>
+    <div class="mvenue">{{ `City`.formatted }}</div>
+    <div id="mp-{{ `MatchNum`.raw }}" popover class="mp-card" style="position-anchor:--mp-{{ `MatchNum`.raw }};">
+      <div class="mp-hd"><span class="mp-ey">Model prediction</span><span class="mp-run">{{ `OddsRun`.formatted }}</span></div>
+      <div class="mp-mu">
+        <span class="mp-side"><img src="{{ `HomeFlag`.raw }}" alt="" /><span class="mp-nm">{{ `Home`.formatted }}</span></span>
+        <span class="mp-xg wc-num">{{ `ExpScore`.formatted }}</span>
+        <span class="mp-side r"><span class="mp-nm">{{ `Away`.formatted }}</span><img src="{{ `AwayFlag`.raw }}" alt="" /></span>
+      </div>
+      <div class="mp-bar"><i style="width:{{ `PHome`.raw }}%; background:{{ `HomeColor`.raw }};"></i><i style="width:{{ `PDraw`.raw }}%; background:#9AA4B2;"></i><i style="width:{{ `PAway`.raw }}%; background:{{ `AwayColor`.raw }};"></i></div>
+      <div class="mp-lg">
+        <span class="s h"><span class="pc wc-num">{{ `PHome`.formatted }}</span><span class="l">{{ `HomeCode`.formatted }} win</span></span>
+        <span class="s d"><span class="pc wc-num">{{ `PDraw`.formatted }}</span><span class="l">Draw</span></span>
+        <span class="s a"><span class="pc wc-num">{{ `PAway`.formatted }}</span><span class="l">{{ `AwayCode`.formatted }} win</span></span>
+      </div>
+      <div class="mp-note">{{ `OddsNote`.formatted }}</div>
+    </div>
+  </article>
+{% end %}
+</div> ;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'kickoff'
+            direction: 'asc'
+          }
+        ]
+        pagination_size: 12
+        row_limit: 12
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+}
+
+Func wc_featured_match() {
+  VizBlock {
+    viz: MarkdownViz {
+      dataset: worldcup
+      // The hero = the single featured match (live, else soonest upcoming). Filtering on is_featured
+      // (rather than just sort+limit) keys it to the SAME match the fixtures band excludes, so they agree.
+      filter {
+        field: r(wc_matches.is_featured)
+        operator: 'is'
+        value: true
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Home'
+          ref: r(wc_home_teams.name)
+        },
+        VizFieldFull {
+          label: 'HomeFlag'
+          ref: r(wc_home_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'HomeColor'
+          ref: r(wc_home_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Away'
+          ref: r(wc_away_teams.name)
+        },
+        VizFieldFull {
+          label: 'AwayFlag'
+          ref: r(wc_away_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'AwayColor'
+          ref: r(wc_away_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'StatusText'
+          ref: r(wc_matches.status_label)
+        },
+        VizFieldFull {
+          label: 'StatusColor'
+          ref: r(wc_matches.status_color)
+        },
+        VizFieldFull {
+          label: 'StageLabel'
+          ref: r(wc_matches.stage_label)
+        },
+        VizFieldFull {
+          label: 'FeaturedSort'
+          ref: r(wc_matches.featured_sort)
+          uname: 'featured'
+          hidden: true
+        },
+        VizFieldFull {
+          label: 'Display'
+          ref: r(wc_matches.featured_display)
+        },
+        VizFieldFull {
+          label: 'DisplaySub'
+          ref: r(wc_matches.featured_display_sub)
+        },
+        VizFieldFull {
+          label: 'Note'
+          ref: r(wc_matches.featured_note)
+        },
+        VizFieldFull {
+          label: 'KODay'
+          ref: r(wc_matches.kickoff_day)
+        },
+        VizFieldFull {
+          label: 'KOTime'
+          ref: r(wc_matches.kickoff_time)
+        },
+        VizFieldFull {
+          label: 'Venue'
+          ref: r(wc_matches.venue)
+        },
+        VizFieldFull {
+          label: 'City'
+          ref: r(wc_matches.city)
+        },
+        VizFieldFull {
+          label: 'PHome'
+          ref: r(wc_match_odds.p_home_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'PDraw'
+          ref: r(wc_match_odds.p_draw_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'PAway'
+          ref: r(wc_match_odds.p_away_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'ExpScore'
+          ref: r(wc_match_odds.exp_score_label)
+        },
+        VizFieldFull {
+          label: 'OddsRun'
+          ref: r(wc_match_odds.run_label)
+        },
+        VizFieldFull {
+          label: 'OddsNote'
+          ref: r(wc_match_odds.status_note)
+        }
+      ]
+      content: @md <style>
+/* full-height wrapper: centers the card in the (transparent) block + its padding gives the card's outer
+   glow/shadow room so the block's overflow:hidden doesn't clip it. Surplus is just turf around the card. */
+.kwrap { width:100%; height:100%; box-sizing:border-box; display:flex; align-items:center; justify-content:center; padding:30px; }
+.kcard { position:relative; width:100%; text-align:center; color:var(--panel-ink);
+  background:radial-gradient(120% 120% at 50% 0%, rgba(242,200,75,.16), var(--panel) 48%), var(--panel);
+  border:1px solid var(--panel-line); border-radius:22px; padding:16px 26px 18px;
+  box-shadow:0 16px 34px -18px var(--shadow-dir), 0 0 0 6px rgba(255,255,255,.10), inset 0 1px 0 rgba(255,255,255,.5); }
+.kcard::after { content:""; position:absolute; inset:0; border-radius:22px; pointer-events:none;
+  box-shadow:inset 0 0 50px rgba(242,200,75,.16); }
+.ko-rail { position:relative; display:flex; height:4px; border-radius:3px; overflow:hidden; margin-bottom:14px; }
+.ko-rail i { flex:1; }
+.ko-tag { position:relative; display:inline-flex; align-items:center; gap:8px; font-family:var(--font-disp); font-weight:700;
+  text-transform:uppercase; letter-spacing:.16em; font-size:10.5px; color:var(--panel-muted); margin-bottom:13px; }
+.ko-tag .kbadge { font-family:var(--font-disp); font-weight:700; font-size:10px; letter-spacing:.07em;
+  padding:3px 9px; border-radius:999px; color:#fff; box-shadow:0 1px 2px rgba(0,0,0,.18); }
+.ko-grid { position:relative; display:grid; grid-template-columns:1fr auto 1fr; align-items:center; gap:22px; }
+.ko-team { display:flex; flex-direction:column; align-items:center; gap:8px; min-width:0; }
+.kcard .ko-grid .ko-team img { width:74px !important; height:auto !important; border-radius:4px !important;
+  margin:0 !important; display:block !important; box-shadow:0 6px 16px -6px rgba(0,0,0,.5); }
+.ko-team .name { font-family:var(--font-disp); font-weight:800; font-size:22px; letter-spacing:.02em;
+  text-transform:uppercase; line-height:1; }
+.ko-team .sub { font-size:10px; text-transform:uppercase; letter-spacing:.12em; color:var(--panel-muted); }
+.ko-score { display:flex; flex-direction:column; align-items:center; line-height:1; }
+.ko-score .kt { font-family:var(--font-disp); font-weight:800; font-size:46px; color:var(--gold); letter-spacing:.02em; }
+.ko-score .ksub { font-size:9px; text-transform:uppercase; letter-spacing:.16em; color:var(--panel-muted); margin-top:5px; }
+.ko-minute { position:relative; font-family:var(--font-disp); font-weight:700; color:var(--panel-ink); font-size:13px;
+  letter-spacing:.05em; text-transform:uppercase; margin-top:14px; }
+.ko-venue { position:relative; font-size:11px; color:var(--panel-muted); margin-top:7px; }
+.ko-note { position:relative; font-size:11px; color:var(--panel-muted); margin-top:13px; padding-top:12px;
+  border-top:1px solid var(--panel-line); }
+/* model prediction strip: the win-probability rail + expected score, rendered in the card's own
+   material (kit-coloured segments, gold expected score). Gracefully shows "—" + a status note for
+   fixtures with no sim run (knockout slots / matches played before the model went live). */
+.ko-odds { position:relative; margin-top:14px; padding-top:13px; border-top:1px solid var(--panel-line); }
+.koo-cap { display:flex; justify-content:space-between; align-items:baseline; gap:12px; margin-bottom:9px;
+  font-size:9.5px; text-transform:uppercase; letter-spacing:.14em; color:var(--panel-muted); }
+.koo-cap b { color:var(--gold); font-weight:700; }
+.koo-cap .xg { font-family:var(--font-disp); font-weight:800; color:var(--panel-ink); letter-spacing:.02em; }
+.koo-cap .xg:empty::after { content:"—"; color:var(--panel-muted); }
+.koo-bar { display:flex; height:7px; border-radius:4px; overflow:hidden; background:rgba(0,0,0,.07);
+  box-shadow:inset 0 1px 2px rgba(0,0,0,.22); }
+.koo-bar i { display:block; height:100%; }
+.koo-legend { display:flex; justify-content:space-between; align-items:baseline; gap:12px; margin-top:9px; }
+.koo-legend .s { display:inline-flex; align-items:baseline; gap:6px; min-width:0; }
+.koo-legend .nm { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.04em;
+  font-size:11.5px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.koo-legend .pc { font-family:var(--font-disp); font-weight:800; font-size:14px; font-variant-numeric:tabular-nums;
+  color:var(--panel-ink); }
+.koo-legend .pc::after { content:"%"; font-size:.62em; font-weight:700; color:var(--panel-muted); margin-left:1px; }
+.koo-legend .pc:empty::after { content:"—"; font-size:1em; }
+.koo-legend .mid { display:inline-flex; align-items:baseline; gap:6px; font-size:10.5px; text-transform:uppercase;
+  letter-spacing:.1em; color:var(--panel-muted); }
+.koo-note { margin-top:9px; font-size:10.5px; font-style:italic; color:var(--panel-muted); }
+.koo-note:empty { display:none; }
+/* ── motion: the hero lands on the centre spot, then breathes a gold inner glow.
+   ko-in uses fill:backwards so the resting card releases to base and :hover lifts.
+   The idle breathe animates the existing ::after inner-glow (0%/100% = its base). */
+.kcard { animation:ko-in .6s cubic-bezier(.2,.7,.25,1.12) .12s backwards;
+  transition:transform .3s cubic-bezier(.2,.7,.3,1.05), box-shadow .3s ease; }
+@keyframes ko-in { 0% { opacity:0; transform:translateY(24px) scale(.9); } 100% { opacity:1; transform:none; } }
+.kcard::after { animation:ko-glow 4s ease-in-out 1.1s infinite; }
+@keyframes ko-glow {
+  0%,100% { box-shadow:inset 0 0 50px rgba(242,200,75,.16); }
+  50% { box-shadow:inset 0 0 66px rgba(242,200,75,.32); } }
+.kcard:hover { transform:translateY(-4px) scale(1.012);
+  box-shadow:0 24px 44px -18px var(--shadow-dir), 0 0 0 6px rgba(255,255,255,.13), inset 0 1px 0 rgba(255,255,255,.5); }
+/* the probability rail wipes in from the left as the card settles — the model "reporting in" */
+.koo-bar { transform-origin:left center; animation:koo-wipe .55s cubic-bezier(.22,.61,.36,1) .5s backwards; }
+@keyframes koo-wipe { from { transform:scaleX(0); } to { transform:scaleX(1); } }
+@media (prefers-reduced-motion: reduce) {
+  .kcard, .kcard::after, .koo-bar { animation:none !important; }
+  .kcard, .koo-bar { opacity:1 !important; transform:none !important; }
+  .kcard:hover { transform:none !important; } }
+</style>
+<div class="kwrap">
+<article class="kcard" style="--home:{{ rows[0].`HomeColor`.raw }}; --away:{{ rows[0].`AwayColor`.raw }};">
+  <div class="ko-rail"><i style="background:{{ rows[0].`HomeColor`.raw }};"></i><i style="background:{{ rows[0].`AwayColor`.raw }};"></i></div>
+  <div class="ko-tag">
+    <span class="kbadge" style="background:{{ rows[0].`StatusColor`.raw }};">{{ rows[0].`StatusText`.formatted }}</span>
+    <span>{{ rows[0].`StageLabel`.formatted }} · featured</span>
+  </div>
+  <div class="ko-grid">
+    <div class="ko-team"><img src="{{ rows[0].`HomeFlag`.raw }}" alt="" /><span class="name">{{ rows[0].`Home`.formatted }}</span><span class="sub">Home</span></div>
+    <div class="ko-score"><span class="kt wc-num">{{ rows[0].`Display`.formatted }}</span><span class="ksub">{{ rows[0].`DisplaySub`.formatted }}</span></div>
+    <div class="ko-team"><img src="{{ rows[0].`AwayFlag`.raw }}" alt="" /><span class="name">{{ rows[0].`Away`.formatted }}</span><span class="sub">Away</span></div>
+  </div>
+  <div class="ko-odds">
+    <div class="koo-cap"><span>Win <b>probability</b> · {{ rows[0].`OddsRun`.formatted }}</span><span>Exp. score <span class="xg wc-num">{{ rows[0].`ExpScore`.formatted }}</span></span></div>
+    <div class="koo-bar">
+      <i style="width:{{ rows[0].`PHome`.raw }}%; background:{{ rows[0].`HomeColor`.raw }};"></i>
+      <i style="width:{{ rows[0].`PDraw`.raw }}%; background:#9AA4B2;"></i>
+      <i style="width:{{ rows[0].`PAway`.raw }}%; background:{{ rows[0].`AwayColor`.raw }};"></i>
+    </div>
+    <div class="koo-legend">
+      <span class="s"><span class="nm" style="color:{{ rows[0].`HomeColor`.raw }};">{{ rows[0].`Home`.formatted }}</span><span class="pc wc-num">{{ rows[0].`PHome`.formatted }}</span></span>
+      <span class="mid">Draw <span class="pc wc-num">{{ rows[0].`PDraw`.formatted }}</span></span>
+      <span class="s"><span class="pc wc-num">{{ rows[0].`PAway`.formatted }}</span><span class="nm" style="color:{{ rows[0].`AwayColor`.raw }};">{{ rows[0].`Away`.formatted }}</span></span>
+    </div>
+    <div class="koo-note">{{ rows[0].`OddsNote`.formatted }}</div>
+  </div>
+  <div class="ko-minute">{{ rows[0].`KODay`.formatted }} · {{ rows[0].`KOTime`.formatted }} UTC</div>
+  <div class="ko-venue">{{ rows[0].`Venue`.formatted }} · {{ rows[0].`City`.formatted }}</div>
+  <div class="ko-note">{{ rows[0].`Note`.formatted }}</div>
+</article>
+</div> ;;
+      settings {
+        pagination_size: 1
+        sorts: [
+          SortSetting {
+            key: 'featured'
+            direction: 'asc'
+          }
+        ]
+        row_limit: 1
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+}
+
+Func wc_boot_podium() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Scorer'
+          ref: r(wc_scorers.player_name)
+        },
+        VizFieldFull {
+          label: 'Photo'
+          ref: r(wc_players.picture_url)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'TeamColor'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_scorers.team_code)
+        },
+        VizFieldFull {
+          label: 'Rank'
+          ref: r(wc_scorers.boot_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Pens'
+          ref: r(wc_scorers.penalty_goals)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_scorers.goals)
+          uname: 'goals'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md <style>
+.bp-title { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9;
+  margin:0 0 24px; }
+/* podium order with 3 cards: leader centre (raised + scaled), runner-up left, third right.
+   With exactly 2 (a tie or thin data) both render equal — no false hero. Count-aware via CSS:
+   :first-child:nth-last-child(2) = first of exactly two; :nth-child(2):nth-last-child(2) = middle of three. */
+.bp-row { flex:1; min-height:0; display:flex; justify-content:center; align-items:flex-end; gap:24px; }
+.bp-row .fut:first-child { --rest:perspective(900px) translateY(0) rotateY(0deg) scale(1.12); transform-origin:bottom center; z-index:2;
+  filter:drop-shadow(0 12px 14px rgba(7,30,18,.45)) drop-shadow(0 0 18px rgba(242,200,75,.5)); }
+.bp-row .fut:first-child:nth-last-child(2), .bp-row .fut:first-child:last-child { --rest:perspective(900px) translateY(0) rotateY(0deg) scale(1); }
+.bp-row .fut:nth-child(2):nth-last-child(2) { order:-1; }
+/* The shared .fut card material (shield, foil, tiers t1/t2/t3, deal + foil-hover) lives in
+   header_rail so the podium and the Players gallery are one identical component. Only the
+   podium LAYOUT is here: deal stagger (leader lands last) + the leader's bigger hover. */
+.bp-row .fut:nth-child(1) { animation-delay:.34s; }
+.bp-row .fut:nth-child(2) { animation-delay:.08s; }
+.bp-row .fut:nth-child(3) { animation-delay:.20s; }
+.bp-row .fut:first-child:hover { transform:perspective(900px) translateY(-12px) rotateY(0deg) scale(1.18); }
+</style>
+<p class="bp-title">Golden Boot race</p>
+<div class="bp-row mt-12">
+{% map(rows) %}
+  <article class="fut t{{ `Rank`.formatted }}" style="--teamc:{{ `TeamColor`.raw }};">
+    <svg class="fut-frame" viewBox="0 0 176 232" aria-hidden="true">
+      <path d="M 0 34 C 0 18 10 8 26 7 L 64 7 C 74 7 80 2 88 2 C 96 2 102 7 112 7 L 150 7 C 166 8 176 18 176 34 L 176 168 C 176 192 168 204 146 214 C 124 223 102 230 88 230 C 74 230 52 223 30 214 C 8 204 0 192 0 168 Z" fill="none" stroke="#a37920" stroke-width="5"/>
+    </svg>
+    <span class="fut-medal wc-num">{{ `Rank`.formatted }}</span>
+    <div class="fut-body">
+      <div class="fut-top">
+        <div class="fut-rate"><span class="n wc-num">{{ `Goals`.formatted }}</span><span class="u">Goals</span><img class="fut-flag" src="{{ `Flag`.raw }}" alt="" /></div>
+        <div class="fut-ph"><img src="{{ `Photo`.raw }}" alt="" /></div>
+      </div>
+      <div class="fut-name">{{ `Scorer`.formatted }}</div>
+      <div class="fut-meta">{{ `Team`.formatted }} · <b class="wc-num">{{ `Goals`.formatted }}</b> gls · <b class="wc-num">{{ `Pens`.formatted }}</b> pen</div>
+    </div>
+  </article>
+{% end %}
+</div> ;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'goals'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 3
+        row_limit: 3
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+  }
+}
+
+Func wc_boot_rack() {
+  VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      filter {
+        field: r(wc_scorers.boot_rank)
+        operator: 'greater_than'
+        value: 3
+      }
+      rows: [
+        VizFieldFull {
+          label: 'Scorer'
+          ref: r(wc_scorers.player_name)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_scorers.team_code)
+        },
+        VizFieldFull {
+          label: 'Rank'
+          ref: r(wc_scorers.boot_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_scorers.goals)
+          uname: 'goals'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      values: [
+        VizFieldFull {
+          label: 'BarPct'
+          ref: r(worldcup.scorer_bar_pct)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md <style>
+.brk-rack { width:100%; height:100%; box-sizing:border-box; overflow:hidden;
+  background:linear-gradient(180deg, var(--panel), var(--panel-2)); border:1px solid var(--panel-line);
+  border-radius:12px; padding:12px 14px; color:var(--panel-ink);
+  box-shadow:0 1px 1px rgba(0,0,0,.18), 0 14px 28px -18px var(--shadow-dir), inset 0 1px 0 rgba(255,255,255,.4); }
+.brk-h { display:flex; align-items:baseline; justify-content:space-between; gap:8px; margin-bottom:10px; }
+.brk-h .t { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.07em; font-size:13px; }
+.brk-h .s { font-size:9px; text-transform:uppercase; letter-spacing:.12em; color:var(--panel-muted); white-space:nowrap; }
+.brk-list { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; }
+.brk-list li { display:flex; align-items:center; gap:8px; min-width:0; }
+.brk-list .rk { font-family:var(--font-disp); font-weight:800; width:18px; text-align:right; color:var(--panel-muted); flex:none; font-size:12px; }
+.brk-list img { width:20px !important; height:14px !important; border-radius:2px !important; object-fit:cover;
+  flex:none; display:block !important; margin:0 !important; box-shadow:0 1px 2px rgba(0,0,0,.25); }
+.brk-list .pn { font-weight:600; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; min-width:0; }
+.brk-list .pn small { color:var(--panel-muted); font-weight:500; font-size:9px; }
+.brk-list .bar { flex:1; height:8px; border-radius:5px; background:var(--panel-line); overflow:hidden; min-width:24px; }
+.brk-list .bar i { display:block; height:100%; background:linear-gradient(90deg, var(--gold), var(--gold-2)); }
+.brk-list .gl { font-family:var(--font-disp); font-weight:800; font-size:14px; width:16px; text-align:right; flex:none; color:var(--gold); }
+</style>
+<div class="brk-rack">
+  <div class="brk-h"><span class="t">Chasing pack</span><span class="s">rank 4+ · goals</span></div>
+  <ul class="brk-list wc-num">
+{% map(rows) %}
+  <li><span class="rk">{{ `Rank`.formatted }}</span><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" /><span class="pn">{{ `Scorer`.formatted }} <small>{{ `Team`.formatted }}</small></span><span class="bar"><i style="width:{{ values.`BarPct`.raw }}%"></i></span><span class="gl">{{ `Goals`.formatted }}</span></li>
+{% end %}
+  </ul>
+</div> ;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'goals'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 7
+        row_limit: 7
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+  }
+}
+
+Func wc_pitch() {
+  TextBlock {
+    content: @md
+<div class="wc-pitch">
+  <i class="pl pl-bound"></i>
+  <i class="pl pl-half"></i>
+  <i class="pl pl-circle"></i>
+  <i class="pl pl-spot"></i>
+  <i class="pl pl-corner tl"></i><i class="pl pl-corner tr"></i>
+  <i class="pl pl-corner bl"></i><i class="pl pl-corner br"></i>
+  <i class="pen tl"></i><i class="pen tr"></i>
+  <i class="pen bl"></i><i class="pen br"></i>
+  <svg class="pl-endtop" viewBox="0 0 1480 250" preserveAspectRatio="xMidYMin meet" aria-hidden="true">
+    <g fill="none" stroke="#e6f0ea" stroke-width="4" stroke-linejoin="round">
+      <path d="M410 32 V212 H1070 V32"/>
+      <path d="M580 32 V112 H900 V32"/>
+      <path d="M660 212 A100 100 0 0 0 820 212"/>
+    </g>
+    <circle cx="740" cy="152" r="6" fill="#e6f0ea"/>
+  </svg>
+</div>
+;;
+  }
+}
+
+Func wc_goal_prize() {
+  TextBlock {
+    content: @md
+<div class="goal-wrap">
+  <div class="goal-funnel">Toward goal · the Final</div>
+  <div class="goal">
+    <img src="https://upload.wikimedia.org/wikipedia/en/thumb/1/17/2026_FIFA_World_Cup_emblem.svg/500px-2026_FIFA_World_Cup_emblem.svg.png" alt="FIFA World Cup 26 — the prize" />
+  </div>
+</div>
+;;
+  }
+}
+
+Func wc_knockout_label() {
+  TextBlock {
+    content: @md
+<style>
+.kbr-zone-label { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9; margin:0; }
+</style>
+<p class="kbr-zone-label">Run on goal · knockout bracket</p>
+;;
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_advance_probs.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_advance_probs.model.aml
@@ -2,7 +2,7 @@ Model wc_advance_probs {
   type: 'table'
   label: 'Advance Probabilities'
   description: 'Monte Carlo (10k sims) tournament probabilities per team. One row per (team, run_date) — championship odds over time come free.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension prob_key {
     label: 'Prob Key'
     type: 'text'
@@ -63,5 +63,5 @@ Model wc_advance_probs {
     definition: @sql {{ #SOURCE.p_champion }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_advance_probs"'
+  table_name: '"public"."wc_advance_probs"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_advance_probs.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_advance_probs.model.aml
@@ -1,0 +1,67 @@
+Model wc_advance_probs {
+  type: 'table'
+  label: 'Advance Probabilities'
+  description: 'Monte Carlo (10k sims) tournament probabilities per team. One row per (team, run_date) — championship odds over time come free.'
+  data_source_name: 'demodb'
+  dimension prob_key {
+    label: 'Prob Key'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }} || '-' || {{ #SOURCE.run_date }};;
+    primary_key: true
+    hidden: true
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension run_date {
+    label: 'Run Date'
+    type: 'date'
+    definition: @sql {{ #SOURCE.run_date }};;
+  }
+  dimension run_date_label {
+    label: 'Run Date Label'
+    type: 'text'
+    description: 'Pre-formatted sim run date for the title-odds trend axis / picker, e.g. "13 Jun".'
+    definition: @aql date_format(wc_advance_probs.run_date, '%d %b') ;;
+  }
+  dimension p_champion_pct {
+    label: 'P Champion %'
+    type: 'number'
+    description: 'p_champion × 100 — the title-odds trend series value (one point per run_date).'
+    definition: @aql wc_advance_probs.p_champion * 100 ;;
+  }
+  dimension p_r32 {
+    label: 'P Reach R32'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_r32 }};;
+  }
+  dimension p_r16 {
+    label: 'P Reach R16'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_r16 }};;
+  }
+  dimension p_qf {
+    label: 'P Reach QF'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_qf }};;
+  }
+  dimension p_sf {
+    label: 'P Reach SF'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_sf }};;
+  }
+  dimension p_final {
+    label: 'P Reach Final'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_final }};;
+  }
+  dimension p_champion {
+    label: 'P Champion'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_champion }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_advance_probs"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_away_teams.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_away_teams.model.aml
@@ -1,0 +1,13 @@
+// Role-playing alias of wc_teams for the AWAY side of a match.
+Model wc_away_teams = wc_teams.extend({
+  label: 'Away Team'
+  dimension name {
+    label: 'Away Team'
+  }
+  dimension flag_url {
+    label: 'Away Flag'
+  }
+  dimension color_hex {
+    label: 'Away Color'
+  }
+})

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_contender_board.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_contender_board.model.aml
@@ -2,7 +2,7 @@ Model wc_contender_board {
   type: 'query'
   label: 'Contender Board'
   description: 'One row per team for the Contender Index: latest Elo + 30-day move, a pre-scaled SVG polyline string of the 24-month Elo curve (field-wide y-bounds so curves are comparable), and the latest Monte Carlo run probabilities with day-over-day deltas vs the previous run. Spark/delta strings are built in SQL — templates cannot loop into a polyline attribute and AQL cast() re-applies digit grouping.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_team_ratings, wc_advance_probs]
   query: @sql
     with snaps as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_contender_board.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_contender_board.model.aml
@@ -1,0 +1,192 @@
+Model wc_contender_board {
+  type: 'query'
+  label: 'Contender Board'
+  description: 'One row per team for the Contender Index: latest Elo + 30-day move, a pre-scaled SVG polyline string of the 24-month Elo curve (field-wide y-bounds so curves are comparable), and the latest Monte Carlo run probabilities with day-over-day deltas vs the previous run. Spark/delta strings are built in SQL — templates cannot loop into a polyline attribute and AQL cast() re-applies digit grouping.'
+  data_source_name: 'demodb'
+  models: [wc_team_ratings, wc_advance_probs]
+  query: @sql
+    with snaps as (
+      select {{ #r.team_code }} as team_code, {{ #r.snapshot_date }} as snapshot_date, {{ #r.elo }} as elo
+      from {{ #wc_team_ratings as r }}
+      where {{ #r.snapshot_date }} >= current_date - interval '24 months'
+    ),
+    bounds as (
+      select min(snapshot_date) as d0, max(snapshot_date) as d1 from snaps
+    ),
+    team_bounds as (
+      select team_code, min(elo) as tlo, max(elo) as thi from snaps group by team_code
+    ),
+    gspan as (
+      -- one Elo-per-pixel scale for every curve: the widest per-team swing fills the height
+      select greatest(max(thi - tlo), 1) as span from team_bounds
+    ),
+    spark as (
+      -- polyline points in a 100x30 viewBox: x is time-true; y is centred on each team's own
+      -- midpoint but shares the field's Elo-per-pixel scale, so SHAPE/SLOPE compare across
+      -- teams while flat-looking curves mean genuinely stable ratings (a field-wide min/max
+      -- y-axis squeezed all top-10 curves into the same flat band)
+      select s.team_code,
+        string_agg(
+          round((s.snapshot_date - b.d0)::numeric / nullif((b.d1 - b.d0), 0) * 100, 1) || ',' ||
+          round((2 + (1 - ((s.elo - ((tb.tlo + tb.thi) / 2 - g.span / 2)) / g.span)) * 26)::numeric, 1),
+          ' ' order by s.snapshot_date
+        ) as spark_points
+      from snaps s
+      join team_bounds tb using (team_code)
+      cross join bounds b
+      cross join gspan g
+      group by s.team_code
+    ),
+    latest as (
+      select distinct on (team_code) team_code, elo, snapshot_date as elo_date
+      from snaps order by team_code, snapshot_date desc
+    ),
+    prior30 as (
+      select distinct on (team_code) team_code, elo as elo_30d
+      from snaps where snapshot_date <= current_date - 30
+      order by team_code, snapshot_date desc
+    ),
+    runs as (
+      select {{ #p.team_code }} as team_code, {{ #p.run_date }} as run_date,
+        {{ #p.p_champion }} as p_champion, {{ #p.p_final }} as p_final, {{ #p.p_sf }} as p_sf,
+        {{ #p.p_qf }} as p_qf, {{ #p.p_r16 }} as p_r16, {{ #p.p_r32 }} as p_r32,
+        row_number() over (partition by {{ #p.team_code }} order by {{ #p.run_date }} desc) as rn
+      from {{ #wc_advance_probs as p }}
+    )
+    select
+      l.team_code,
+      l.elo,
+      l.elo_date,
+      rank() over (order by l.elo desc) as elo_rank,
+      sp.spark_points,
+      case when p30.elo_30d is null then ''
+           when l.elo - p30.elo_30d >= 0.5 then '▲ ' || round((l.elo - p30.elo_30d)::numeric)::text
+           when p30.elo_30d - l.elo >= 0.5 then '▼ ' || round((p30.elo_30d - l.elo)::numeric)::text
+           else '· 0' end as d30_label,
+      case when p30.elo_30d is null or abs(l.elo - p30.elo_30d) < 0.5 then '#9AA4B2'
+           when l.elo > p30.elo_30d then '#1FA36B' else '#E5362B' end as d30_color,
+      c.run_date,
+      case when c.run_date is null then 'no run recorded'
+           else 'run ' || to_char(c.run_date, 'DD Mon') end as run_label,
+      rank() over (order by c.p_champion desc nulls last) as odds_rank,
+      c.p_champion, c.p_final, c.p_sf, c.p_qf, c.p_r16, c.p_r32,
+      case when c.run_date is null or pr.run_date is null then ''
+           when c.p_champion - pr.p_champion > 0.0005 then '▲ ' || to_char((c.p_champion - pr.p_champion) * 100, 'FM990.0')
+           when pr.p_champion - c.p_champion > 0.0005 then '▼ ' || to_char((pr.p_champion - c.p_champion) * 100, 'FM990.0')
+           else '· 0.0' end as d_champ_label,
+      case when c.run_date is null or pr.run_date is null or abs(c.p_champion - pr.p_champion) <= 0.0005 then '#9AA4B2'
+           when c.p_champion > pr.p_champion then '#1FA36B' else '#E5362B' end as d_champ_color
+    from latest l
+    left join prior30 p30 using (team_code)
+    left join spark sp using (team_code)
+    left join (select * from runs where rn = 1) c using (team_code)
+    left join (select * from runs where rn = 2) pr using (team_code);;
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    primary_key: true
+  }
+  dimension elo {
+    label: 'Elo (latest)'
+    type: 'number'
+  }
+  dimension elo_date {
+    label: 'Elo As Of'
+    type: 'date'
+  }
+  dimension elo_rank {
+    label: 'Elo Rank'
+    type: 'number'
+  }
+  dimension spark_points {
+    label: 'Elo Spark Points'
+    type: 'text'
+    description: 'Driver field: pre-scaled "x,y x,y …" polyline for a 100×30 SVG viewBox — 24 months of Elo, centred per team on a shared Elo-per-pixel scale (slopes comparable, absolute heights not).'
+  }
+  dimension d30_label {
+    label: 'Elo 30d Move'
+    type: 'text'
+    description: 'Driver field: signed Elo move over the last 30 days ("▲ 12"); empty when no 30-day-old snapshot exists.'
+  }
+  dimension d30_color {
+    label: 'Elo 30d Color'
+    type: 'text'
+  }
+  dimension run_date {
+    label: 'Sim Run Date'
+    type: 'date'
+  }
+  dimension run_label {
+    label: 'Run Label'
+    type: 'text'
+  }
+  dimension odds_rank {
+    label: 'Odds Rank'
+    type: 'number'
+    description: 'Rank by latest P(champion) — the board order.'
+  }
+  dimension p_champion {
+    label: 'P Champion'
+    type: 'number'
+  }
+  dimension p_champion_pct {
+    label: 'Title Odds %'
+    type: 'number'
+    definition: @aql wc_contender_board.p_champion * 100 ;;
+  }
+  dimension p_final {
+    label: 'P Reach Final'
+    type: 'number'
+  }
+  dimension p_final_pct {
+    label: 'P Final %'
+    type: 'number'
+    definition: @aql wc_contender_board.p_final * 100 ;;
+  }
+  dimension p_sf {
+    label: 'P Reach SF'
+    type: 'number'
+  }
+  dimension p_sf_pct {
+    label: 'P SF %'
+    type: 'number'
+    definition: @aql wc_contender_board.p_sf * 100 ;;
+  }
+  dimension p_qf {
+    label: 'P Reach QF'
+    type: 'number'
+  }
+  dimension p_qf_pct {
+    label: 'P QF %'
+    type: 'number'
+    definition: @aql wc_contender_board.p_qf * 100 ;;
+  }
+  dimension p_r16 {
+    label: 'P Reach R16'
+    type: 'number'
+  }
+  dimension p_r16_pct {
+    label: 'P R16 %'
+    type: 'number'
+    definition: @aql wc_contender_board.p_r16 * 100 ;;
+  }
+  dimension p_r32 {
+    label: 'P Reach R32'
+    type: 'number'
+  }
+  dimension p_r32_pct {
+    label: 'P R32 %'
+    type: 'number'
+    definition: @aql wc_contender_board.p_r32 * 100 ;;
+  }
+  dimension d_champ_label {
+    label: 'Title Odds Delta'
+    type: 'text'
+    description: 'Driver field: day-over-day move in percentage points ("▲ 2.4"); empty until a second run exists.'
+  }
+  dimension d_champ_color {
+    label: 'Title Odds Delta Color'
+    type: 'text'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_edition_compare.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_edition_compare.model.aml
@@ -1,0 +1,73 @@
+Model wc_edition_compare {
+  type: 'query'
+  label: 'Edition Comparison'
+  description: 'One row per World Cup edition 1930–2026 with tournament-shape baselines: matches played, goals, goals per match, and average attendance. History rows come from wc_history_matches; the live 2026 row is aggregated from finished wc_matches (so it grows each matchday). Materialised because it UNIONs the historical fact with the live fact — not expressible as a single AQL measure. Lets the dashboard frame "this World Cup vs the others" (goals/match and attendance are comparable across all editions; cards/possession exist only for 2026 and are intentionally absent here).'
+  data_source_name: 'demodb'
+  models: [wc_history_matches, wc_matches]
+  query: @sql
+    with hist as (
+      select {{ #h.year }} as edition,
+        count(*) as matches,
+        sum({{ #h.home_score }} + {{ #h.away_score }}) as goals,
+        avg({{ #h.attendance }}) as avg_attendance
+      from {{ #wc_history_matches as h }}
+      group by {{ #h.year }}
+    ),
+    live as (
+      select 2026 as edition,
+        count(*) filter (where {{ #m.status }} = 'FT') as matches,
+        sum(case when {{ #m.status }} = 'FT' then {{ #m.home_score }} + {{ #m.away_score }} else 0 end) as goals,
+        avg({{ #m.attendance }}) filter (where {{ #m.status }} = 'FT') as avg_attendance
+      from {{ #wc_matches as m }}
+    ),
+    unioned as (
+      select edition, matches, goals, avg_attendance, false as is_current from hist
+      union all
+      select edition, matches, goals, avg_attendance, true as is_current from live
+    )
+    select
+      edition,
+      edition::text as edition_label,
+      matches,
+      goals,
+      round(goals::numeric / nullif(matches, 0), 2) as goals_per_match,
+      round(avg_attendance) as avg_attendance,
+      is_current
+    from unioned
+    where matches > 0
+    order by edition;;
+  dimension edition {
+    label: 'Edition'
+    type: 'number'
+    primary_key: true
+  }
+  dimension edition_label {
+    label: 'Edition Label'
+    type: 'text'
+    description: 'Year as text ("2026", never "2,026") for axis/labels — a numeric year reapplies digit grouping.'
+  }
+  dimension matches {
+    label: 'Matches'
+    type: 'number'
+    description: 'Matches in the edition; for 2026 this is finished matches only (grows each matchday).'
+  }
+  dimension goals {
+    label: 'Goals'
+    type: 'number'
+  }
+  dimension goals_per_match {
+    label: 'Goals per Match'
+    type: 'number'
+    description: 'The headline baseline — comparable across every edition 1930–2026.'
+  }
+  dimension avg_attendance {
+    label: 'Average Attendance'
+    type: 'number'
+  }
+  dimension is_current {
+    label: 'Is Current Edition'
+    type: 'truefalse'
+    description: 'True for the 2026 row — drives highlight styling against the historical bars.'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_edition_compare.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_edition_compare.model.aml
@@ -2,7 +2,7 @@ Model wc_edition_compare {
   type: 'query'
   label: 'Edition Comparison'
   description: 'One row per World Cup edition 1930–2026 with tournament-shape baselines: matches played, goals, goals per match, and average attendance. History rows come from wc_history_matches; the live 2026 row is aggregated from finished wc_matches (so it grows each matchday). Materialised because it UNIONs the historical fact with the live fact — not expressible as a single AQL measure. Lets the dashboard frame "this World Cup vs the others" (goals/match and attendance are comparable across all editions; cards/possession exist only for 2026 and are intentionally absent here).'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_history_matches, wc_matches]
   query: @sql
     with hist as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_events.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_events.model.aml
@@ -1,0 +1,210 @@
+Model wc_events {
+  type: 'table'
+  label: 'Events'
+  description: 'Match event stream (goals, cards, subs) with running score. Powers the Match Center timeline.'
+  data_source_name: 'demodb'
+  dimension event_id {
+    label: 'Event Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.event_id }};;
+    primary_key: true
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_player_id }};;
+  }
+  dimension type {
+    label: 'Event Type Code'
+    type: 'number'
+    hidden: true
+    definition: @sql {{ #SOURCE.type }};;
+  }
+  dimension type_name {
+    label: 'Event Type'
+    type: 'text'
+    definition: @sql {{ #SOURCE.type_name }};;
+  }
+  dimension match_minute {
+    label: 'Minute'
+    type: 'text'
+    definition: @sql {{ #SOURCE.match_minute }};;
+  }
+  dimension period {
+    label: 'Period'
+    type: 'number'
+    definition: @sql {{ #SOURCE.period }};;
+  }
+  dimension ts {
+    label: 'Event Time'
+    type: 'datetime'
+    hidden: true
+    definition: @sql {{ #SOURCE.ts }};;
+  }
+  dimension home_goals {
+    label: 'Running Home Goals'
+    type: 'number'
+    definition: @sql {{ #SOURCE.home_goals }};;
+  }
+  dimension away_goals {
+    label: 'Running Away Goals'
+    type: 'number'
+    definition: @sql {{ #SOURCE.away_goals }};;
+  }
+  dimension description {
+    label: 'Description'
+    type: 'text'
+    definition: @sql {{ #SOURCE.description }};;
+  }
+  dimension assist_player_id {
+    label: 'Assist Player Id'
+    type: 'text'
+    hidden: true
+    description: 'On goal events (type 0/41), the FIFA id of the assist provider (same-team IdSubPlayer); null otherwise. Powers per-player assist counts.'
+    definition: @sql {{ #SOURCE.assist_player_id }};;
+  }
+  dimension shot_x {
+    label: 'Shot X'
+    type: 'number'
+    hidden: true
+    description: 'Goal events only: pitch X of the shot origin (0–100 attacking space).'
+    definition: @sql {{ #SOURCE.shot_x }};;
+  }
+  dimension shot_y {
+    label: 'Shot Y'
+    type: 'number'
+    hidden: true
+    definition: @sql {{ #SOURCE.shot_y }};;
+  }
+  dimension goal_x {
+    label: 'Goal Mouth X'
+    type: 'number'
+    hidden: true
+    description: 'Goal events only: placement across the goal mouth.'
+    definition: @sql {{ #SOURCE.goal_x }};;
+  }
+  dimension goal_y {
+    label: 'Goal Mouth Y'
+    type: 'number'
+    hidden: true
+    definition: @sql {{ #SOURCE.goal_y }};;
+  }
+  dimension is_goal {
+    label: 'Is Goal'
+    type: 'truefalse'
+    definition: @aql in(wc_events.type, 0, 41) ;;
+  }
+  dimension event_icon {
+    label: 'Event Icon'
+    type: 'text'
+    description: 'Driver field: timeline glyph by event type (goal, yellow 2, red 3, sub 5).'
+    definition: @aql case(
+      when: in(wc_events.type, 0, 41), then: '⚽',
+      when: wc_events.type == 2, then: '🟨',
+      when: wc_events.type == 3, then: '🟥',
+      when: wc_events.type == 5, then: '🔄',
+      else: '•'
+    ) ;;
+  }
+  dimension is_key_event {
+    label: 'Is Key Event'
+    type: 'truefalse'
+    description: 'Timeline filter: goals (0/41), yellow (2), red (3), substitutions (5), plus the structural milestones — period starts (7), first-half end (8, period 3) and final whistle (26). Drops Coin Toss / Delay / Resume noise. Second-half end (8, period 5) is excluded: the final whistle row already closes the match.'
+    definition: @aql in(wc_events.type, 0, 41, 2, 3, 5, 7, 26)
+      or (wc_events.type == 8 and wc_events.period == 3) ;;
+  }
+  dimension side {
+    label: 'Side'
+    type: 'text'
+    description: 'Driver field: "home"/"away" of the event\'s team within its match — drives left/right alignment on the Match Center ticker; structural milestones (kick-off, half-time, full time) get "mid" and render as full-width spine markers.'
+    definition: @aql case(
+      when: in(wc_events.type, 7, 8, 26), then: 'mid',
+      when: wc_events.team_code == wc_matches.home_code, then: 'home',
+      else: 'away'
+    ) ;;
+  }
+  dimension event_kind {
+    label: 'Event Kind'
+    type: 'text'
+    description: 'Driver field: ticker row CSS class — goals render as gold hero cards, cards/subs as compact slips, structural rows as spine chips.'
+    definition: @aql case(
+      when: in(wc_events.type, 0, 41), then: 'goal',
+      when: wc_events.type == 2, then: 'yellow',
+      when: wc_events.type == 3, then: 'red',
+      when: wc_events.type == 5, then: 'sub',
+      else: 'ms'
+    ) ;;
+  }
+  dimension milestone_score {
+    label: 'Milestone Score'
+    type: 'text'
+    description: 'Driver field: the score at the break ("1–1") on half-time/full-time rows, empty otherwise (hides via :empty).'
+    definition: @aql case(
+      when: in(wc_events.type, 8, 26), then: concat(cast(wc_events.home_goals, 'text'), '–', cast(wc_events.away_goals, 'text')),
+      else: ''
+    ) ;;
+  }
+  dimension milestone_label {
+    label: 'Milestone Label'
+    type: 'text'
+    description: 'Driver field: short label for structural rows ("Kick-off", "Half-time", "Second half", "Full time"); empty for player events (hides via :empty). FIFA period codes: 3 = first half, 5 = second half.'
+    definition: @aql case(
+      when: wc_events.type == 7 and wc_events.period == 3, then: 'Kick-off',
+      when: wc_events.type == 7, then: 'Second half',
+      when: wc_events.type == 8 and wc_events.period == 3, then: 'Half-time',
+      when: wc_events.type == 26, then: 'Full time',
+      else: ''
+    ) ;;
+  }
+  dimension event_color {
+    label: 'Event Color'
+    type: 'text'
+    description: 'Driver field: ticker spine-dot colour (goal gold, yellow amber, red red, sub grey).'
+    definition: @aql case(
+      when: in(wc_events.type, 0, 41), then: '#C8920A',
+      when: wc_events.type == 2, then: '#E0A23B',
+      when: wc_events.type == 3, then: '#E5362B',
+      else: '#9AA4B2'
+    ) ;;
+  }
+  dimension score_chip {
+    label: 'Score Chip'
+    type: 'text'
+    description: 'Driver field: running score ("1–0") on goal events only, empty otherwise — empty chips hide via CSS :empty.'
+    definition: @aql case(
+      when: in(wc_events.type, 0, 41), then: concat(cast(wc_events.home_goals, 'text'), '–', cast(wc_events.away_goals, 'text')),
+      else: ''
+    ) ;;
+  }
+  // ---- In-match momentum series + shot map (real data only — coords ride on goal events) ----
+  dimension minute_num {
+    label: 'Minute (numeric)'
+    type: 'number'
+    description: 'Numeric kickoff minute parsed from match_minute ("45+2\'" -> 45) for the momentum x-axis. Order the series by ts for true sequence; use this for axis labels. Parsed in SQL (AQL has no string-to-int on this format).'
+    definition: @sql nullif(regexp_replace(split_part({{ #SOURCE.match_minute }}, '+', 1), '[^0-9]', '', 'g'), '')::int;;
+  }
+  dimension score_margin {
+    label: 'Running Margin (home−away)'
+    type: 'number'
+    description: 'Running home−away goal differential carried on every event row — the momentum line value (step series ordered by ts).'
+    definition: @aql wc_events.home_goals - wc_events.away_goals ;;
+  }
+  dimension is_located_goal {
+    label: 'Is Located Goal'
+    type: 'truefalse'
+    description: 'Goal event that carries FIFA shot/goal-mouth coords (shot_x/shot_y + goal_x/goal_y) — the rows a shot map can plot. ~17 goals so far; only goals carry coords (no all-shots feed exists).'
+    definition: @aql in(wc_events.type, 0, 41) and coalesce(wc_events.goal_x, -1) >= 0 ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_events"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_events.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_events.model.aml
@@ -2,7 +2,7 @@ Model wc_events {
   type: 'table'
   label: 'Events'
   description: 'Match event stream (goals, cards, subs) with running score. Powers the Match Center timeline.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension event_id {
     label: 'Event Id'
     type: 'text'
@@ -206,5 +206,5 @@ Model wc_events {
     definition: @aql in(wc_events.type, 0, 41) and coalesce(wc_events.goal_x, -1) >= 0 ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_events"'
+  table_name: '"public"."wc_events"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_goals.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_goals.model.aml
@@ -1,0 +1,49 @@
+Model wc_goals {
+  type: 'table'
+  label: 'Goals'
+  description: 'Goal events (regular + penalty), player-attributed. Derived view over wc_events.'
+  data_source_name: 'demodb'
+  dimension event_id {
+    label: 'Event Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.event_id }};;
+    primary_key: true
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_player_id }};;
+  }
+  dimension player_name {
+    label: 'Scorer'
+    type: 'text'
+    definition: @sql {{ #SOURCE.player_name }};;
+  }
+  dimension match_minute {
+    label: 'Minute'
+    type: 'text'
+    definition: @sql {{ #SOURCE.match_minute }};;
+  }
+  dimension period {
+    label: 'Period'
+    type: 'number'
+    definition: @sql {{ #SOURCE.period }};;
+  }
+  dimension is_penalty {
+    label: 'Is Penalty'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.is_penalty }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_goals"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_goals.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_goals.model.aml
@@ -2,7 +2,7 @@ Model wc_goals {
   type: 'table'
   label: 'Goals'
   description: 'Goal events (regular + penalty), player-attributed. Derived view over wc_events.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension event_id {
     label: 'Event Id'
     type: 'text'
@@ -45,5 +45,5 @@ Model wc_goals {
     definition: @sql {{ #SOURCE.is_penalty }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_goals"'
+  table_name: '"public"."wc_goals"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_group_standings.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_group_standings.model.aml
@@ -1,0 +1,88 @@
+Model wc_group_standings {
+  type: 'table'
+  label: 'Group Standings'
+  description: 'Live group table A–L (3 pts/win, 1/draw; ranked by Pts, GD, GF). All 48 teams always present.'
+  data_source_name: 'demodb'
+  dimension group_code {
+    label: 'Group'
+    type: 'text'
+    definition: @sql {{ #SOURCE.group_code }};;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+    primary_key: true
+  }
+  dimension team_name {
+    label: 'Team'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_name }};;
+  }
+  dimension played {
+    label: 'Played'
+    type: 'number'
+    definition: @sql {{ #SOURCE.played }};;
+  }
+  dimension won {
+    label: 'Won'
+    type: 'number'
+    definition: @sql {{ #SOURCE.won }};;
+  }
+  dimension drawn {
+    label: 'Drawn'
+    type: 'number'
+    definition: @sql {{ #SOURCE.drawn }};;
+  }
+  dimension lost {
+    label: 'Lost'
+    type: 'number'
+    definition: @sql {{ #SOURCE.lost }};;
+  }
+  dimension gf {
+    label: 'Goals For'
+    type: 'number'
+    definition: @sql {{ #SOURCE.gf }};;
+  }
+  dimension ga {
+    label: 'Goals Against'
+    type: 'number'
+    definition: @sql {{ #SOURCE.ga }};;
+  }
+  dimension gd {
+    label: 'Goal Difference'
+    type: 'number'
+    definition: @sql {{ #SOURCE.gd }};;
+  }
+  dimension pts {
+    label: 'Points'
+    type: 'number'
+    definition: @sql {{ #SOURCE.pts }};;
+  }
+  dimension rank {
+    label: 'Rank'
+    type: 'number'
+    definition: @sql {{ #SOURCE.rank }};;
+  }
+  dimension qual_status {
+    label: 'Qualification Status'
+    type: 'text'
+    definition: @aql case(
+      when: wc_group_standings.rank <= 2, then: 'Advances',
+      when: wc_group_standings.rank == 3, then: 'Best-third playoff',
+      else: 'Eliminated'
+    ) ;;
+  }
+  dimension qual_color {
+    label: 'Qualification Color'
+    type: 'text'
+    description: 'Driver field: standings band color (top-2 green, 3rd amber, else red).'
+    definition: @aql case(
+      when: wc_group_standings.rank <= 2, then: '#1FA36B',
+      when: wc_group_standings.rank == 3, then: '#E0A23B',
+      else: '#E5362B'
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_group_standings"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_group_standings.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_group_standings.model.aml
@@ -2,7 +2,7 @@ Model wc_group_standings {
   type: 'table'
   label: 'Group Standings'
   description: 'Live group table A–L (3 pts/win, 1/draw; ranked by Pts, GD, GF). All 48 teams always present.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension group_code {
     label: 'Group'
     type: 'text'
@@ -84,5 +84,5 @@ Model wc_group_standings {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_group_standings"'
+  table_name: '"public"."wc_group_standings"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_groups.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_groups.model.aml
@@ -1,0 +1,25 @@
+Model wc_groups {
+  type: 'table'
+  label: 'Groups'
+  description: 'World Cup 2026 groups A–L.'
+  data_source_name: 'demodb'
+  dimension code {
+    label: 'Group'
+    type: 'text'
+    definition: @sql {{ #SOURCE.code }};;
+    primary_key: true
+  }
+  dimension name {
+    label: 'Group Name'
+    type: 'text'
+    definition: @sql {{ #SOURCE.name }};;
+  }
+  dimension fifa_group_id {
+    label: 'FIFA Group Id'
+    type: 'text'
+    hidden: true
+    definition: @sql {{ #SOURCE.fifa_group_id }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_groups"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_groups.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_groups.model.aml
@@ -2,7 +2,7 @@ Model wc_groups {
   type: 'table'
   label: 'Groups'
   description: 'World Cup 2026 groups A–L.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension code {
     label: 'Group'
     type: 'text'
@@ -21,5 +21,5 @@ Model wc_groups {
     definition: @sql {{ #SOURCE.fifa_group_id }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_groups"'
+  table_name: '"public"."wc_groups"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_editions.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_editions.model.aml
@@ -1,0 +1,30 @@
+Model wc_history_editions {
+  type: 'table'
+  label: 'WC History Editions'
+  description: 'One row per finished World Cup edition 1930–2022 (name, hosts).'
+  data_source_name: 'demodb'
+  dimension year {
+    label: 'Edition'
+    type: 'number'
+    definition: @sql {{ #SOURCE.year }};;
+    primary_key: true
+  }
+  dimension season_id {
+    label: 'FIFA Season ID'
+    type: 'text'
+    definition: @sql {{ #SOURCE.season_id }};;
+  }
+  dimension name {
+    label: 'Edition Name'
+    type: 'text'
+    definition: @sql {{ #SOURCE.name }};;
+  }
+  dimension host_codes {
+    label: 'Host Codes'
+    type: 'text'
+    description: 'Comma-separated host nation codes (2002 = KOR,JPN).'
+    definition: @sql {{ #SOURCE.host_codes }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_history_editions"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_editions.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_editions.model.aml
@@ -2,7 +2,7 @@ Model wc_history_editions {
   type: 'table'
   label: 'WC History Editions'
   description: 'One row per finished World Cup edition 1930–2022 (name, hosts).'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension year {
     label: 'Edition'
     type: 'number'
@@ -26,5 +26,5 @@ Model wc_history_editions {
     definition: @sql {{ #SOURCE.host_codes }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_history_editions"'
+  table_name: '"public"."wc_history_editions"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_finals.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_finals.model.aml
@@ -2,7 +2,7 @@ Model wc_history_finals {
   type: 'query'
   label: 'WC History Finals'
   description: 'One row per edition 1930–2022: the final resolved into champion vs runner-up (codes, names, flags, scoreline). 21 editions come from stage=final; 1950 (a round-robin with no final) uses the decisive Uruguay–Brazil Maracanazo. Exists because resolving both finalist names + crests from historical codes (defunct nations + non-2026 finalists) plus the scoreline cannot be expressed through the dataset filter graph.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_history_matches, wc_history_editions, wc_team_aliases, wc_teams]
   query: @sql
     with fin as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_finals.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_finals.model.aml
@@ -1,0 +1,130 @@
+Model wc_history_finals {
+  type: 'query'
+  label: 'WC History Finals'
+  description: 'One row per edition 1930–2022: the final resolved into champion vs runner-up (codes, names, flags, scoreline). 21 editions come from stage=final; 1950 (a round-robin with no final) uses the decisive Uruguay–Brazil Maracanazo. Exists because resolving both finalist names + crests from historical codes (defunct nations + non-2026 finalists) plus the scoreline cannot be expressed through the dataset filter graph.'
+  data_source_name: 'demodb'
+  models: [wc_history_matches, wc_history_editions, wc_team_aliases, wc_teams]
+  query: @sql
+    with fin as (
+      select {{ #h.year }} as year, {{ #h.home_code }} as home_code, {{ #h.away_code }} as away_code,
+             {{ #h.home_score }} as home_score, {{ #h.away_score }} as away_score,
+             {{ #h.home_pen }} as home_pen, {{ #h.away_pen }} as away_pen, {{ #h.winner_code }} as winner_code
+      from {{ #wc_history_matches as h }}
+      where {{ #h.stage }} = 'final'
+      union all
+      -- 1950 was decided by a final round-robin; the deciding match (Uruguay 2–1 Brazil) is the de-facto final.
+      select {{ #h2.year }}, {{ #h2.home_code }}, {{ #h2.away_code }},
+             {{ #h2.home_score }}, {{ #h2.away_score }}, {{ #h2.home_pen }}, {{ #h2.away_pen }}, {{ #h2.winner_code }}
+      from {{ #wc_history_matches as h2 }}
+      where {{ #h2.year }} = 1950 and {{ #h2.stage }} = 'group2'
+        and (({{ #h2.home_code }} = 'URU' and {{ #h2.away_code }} = 'BRA')
+          or ({{ #h2.home_code }} = 'BRA' and {{ #h2.away_code }} = 'URU'))
+    ),
+    sided as (
+      select year,
+        case when winner_code = home_code then home_code else away_code end as champ_code,
+        case when winner_code = home_code then away_code else home_code end as runner_code,
+        case when winner_code = home_code then home_score else away_score end as champ_score,
+        case when winner_code = home_code then away_score else home_score end as runner_score,
+        case when winner_code = home_code then home_pen else away_pen end as champ_pen,
+        case when winner_code = home_code then away_pen else home_pen end as runner_pen
+      from fin
+    )
+    select
+      {{ #e.year }} as year,
+      ({{ #e.year }})::text as year_text,
+      -- the edition name embeds the host ("1954 FIFA World Cup Switzerland"); strip the prefix for a clean host label
+      regexp_replace({{ #e.name }}, '^[0-9]{4} FIFA World Cup ', '') as host_name,
+      s.champ_code,
+      s.runner_code,
+      s.champ_score,
+      s.runner_score,
+      s.champ_pen,
+      s.runner_pen,
+      s.champ_score::text || '–' || s.runner_score::text
+        || case when coalesce(s.champ_pen, 0) + coalesce(s.runner_pen, 0) > 0
+                then ' (' || s.champ_pen::text || '–' || s.runner_pen::text || ' p)'
+                else '' end as score_label,
+      -- name precedence: real historical name for defunct nations (West Germany, Czechoslovakia) →
+      -- official 2026 name → curated marquee nations the dataset has no name for → raw code
+      coalesce(
+        nullif({{ #ca.display_name }}, {{ #ca.alias_code }}),
+        {{ #ct.name }},
+        case s.champ_code when 'ITA' then 'Italy' when 'HUN' then 'Hungary' else null end,
+        s.champ_code
+      ) as champ_name,
+      coalesce({{ #ct.flag_url }}, 'https://api.fifa.com/api/v3/picture/flags-sq-4/' || coalesce({{ #ca.canonical_code }}, s.champ_code)) as champ_flag,
+      coalesce(
+        nullif({{ #ra.display_name }}, {{ #ra.alias_code }}),
+        {{ #rt.name }},
+        case s.runner_code when 'ITA' then 'Italy' when 'HUN' then 'Hungary' else null end,
+        s.runner_code
+      ) as runner_name,
+      coalesce({{ #rt.flag_url }}, 'https://api.fifa.com/api/v3/picture/flags-sq-4/' || coalesce({{ #ra.canonical_code }}, s.runner_code)) as runner_flag
+    from {{ #wc_history_editions as e }}
+    left join sided s on s.year = {{ #e.year }}
+    left join {{ #wc_team_aliases as ca }} on {{ #ca.alias_code }} = s.champ_code
+    left join {{ #wc_teams as ct }} on {{ #ct.code }} = {{ #ca.canonical_code }}
+    left join {{ #wc_team_aliases as ra }} on {{ #ra.alias_code }} = s.runner_code
+    left join {{ #wc_teams as rt }} on {{ #rt.code }} = {{ #ra.canonical_code }};;
+  dimension year {
+    label: 'Edition'
+    type: 'number'
+    primary_key: true
+  }
+  dimension year_text {
+    label: 'Edition Label'
+    type: 'text'
+    description: 'Ungrouped edition year for display ("1998", never "1,998") — cast in SQL because AQL cast() reapplies digit grouping.'
+  }
+  dimension host_name {
+    label: 'Host'
+    type: 'text'
+  }
+  dimension champ_code {
+    label: 'Champion Code'
+    type: 'text'
+  }
+  dimension runner_code {
+    label: 'Runner-up Code'
+    type: 'text'
+  }
+  dimension champ_score {
+    label: 'Champion Score'
+    type: 'number'
+  }
+  dimension runner_score {
+    label: 'Runner-up Score'
+    type: 'number'
+  }
+  dimension champ_pen {
+    label: 'Champion Pens'
+    type: 'number'
+  }
+  dimension runner_pen {
+    label: 'Runner-up Pens'
+    type: 'number'
+  }
+  dimension score_label {
+    label: 'Final Scoreline'
+    type: 'text'
+    description: 'Champion-perspective scoreline, e.g. "3–2" or "0–0 (3–2 p)".'
+  }
+  dimension champ_name {
+    label: 'Champion'
+    type: 'text'
+  }
+  dimension champ_flag {
+    label: 'Champion Flag'
+    type: 'text'
+  }
+  dimension runner_name {
+    label: 'Runner-up'
+    type: 'text'
+  }
+  dimension runner_flag {
+    label: 'Runner-up Flag'
+    type: 'text'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_h2h.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_h2h.model.aml
@@ -1,0 +1,170 @@
+Model wc_history_h2h {
+  type: 'query'
+  label: 'All-time Head-to-Head'
+  description: 'One row per (team, opponent) ordered pair: their all-time World Cup record 1930–2022 from that team\'s perspective (played / W-D-L / goals). Both teams use canonical codes (defunct nations folded into the modern successor) so a 2026 team resolves its full lineage. Built by UNIONing home and away perspectives of wc_history_matches — a cross-row aggregation that is not a single AQL measure. Shootouts count as draws (the 90/120-min score decides W/D/L), matching wc_history_team_editions.'
+  data_source_name: 'demodb'
+  models: [wc_history_matches, wc_teams, wc_team_aliases]
+  query: @sql
+    with persp as (
+      select {{ #h.home_canonical }} as team_code, {{ #h.away_canonical }} as opp_code, {{ #h.year }} as year,
+        case when {{ #h.home_score }} > {{ #h.away_score }} then 1 else 0 end as w,
+        case when {{ #h.home_score }} = {{ #h.away_score }} then 1 else 0 end as d,
+        case when {{ #h.home_score }} < {{ #h.away_score }} then 1 else 0 end as l,
+        {{ #h.home_score }} as gf, {{ #h.away_score }} as ga
+      from {{ #wc_history_matches as h }}
+      where {{ #h.home_score }} is not null and {{ #h.away_score }} is not null
+      union all
+      select {{ #h2.away_canonical }}, {{ #h2.home_canonical }}, {{ #h2.year }},
+        case when {{ #h2.away_score }} > {{ #h2.home_score }} then 1 else 0 end,
+        case when {{ #h2.away_score }} = {{ #h2.home_score }} then 1 else 0 end,
+        case when {{ #h2.away_score }} < {{ #h2.home_score }} then 1 else 0 end,
+        {{ #h2.away_score }}, {{ #h2.home_score }}
+      from {{ #wc_history_matches as h2 }}
+      where {{ #h2.home_score }} is not null and {{ #h2.away_score }} is not null
+    ),
+    agg as (
+      select
+        team_code, opp_code,
+        count(*) as played,
+        sum(w) as wins, sum(d) as draws, sum(l) as losses,
+        sum(gf) as gf, sum(ga) as ga,
+        sum(gf) - sum(ga) as gd,
+        min(year) as first_year, max(year) as last_year,
+        sum(w)::text || '-' || sum(d)::text || '-' || sum(l)::text as record_label,
+        round(sum(w)::numeric / nullif(count(*), 0) * 100, 0) as win_pct
+      from persp
+      group by team_code, opp_code
+    )
+    select
+      agg.team_code || '-' || agg.opp_code as h2h_key,
+      agg.team_code, agg.opp_code,
+      agg.played, agg.wins, agg.draws, agg.losses,
+      agg.gf, agg.ga, agg.gd,
+      agg.first_year, agg.last_year,
+      agg.record_label, agg.win_pct,
+      -- Opponent display name resolved for EVERY historical nation (wc_opponent_teams covers only the 48
+      -- nations in the 2026 field, so non-qualifiers like Italy/Poland/Serbia would render blank). Precedence
+      -- mirrors wc_team_aliases.entity_name: official 2026 name → curated marquee nations the dataset has only
+      -- a code for → the alias's real historical name → the bare code.
+      coalesce(
+        {{ #ot.name }},
+        case agg.opp_code
+          when 'ITA' then 'Italy' when 'RUS' then 'Russia' when 'SRB' then 'Serbia'
+          when 'HUN' then 'Hungary' when 'POL' then 'Poland' when 'CHI' then 'Chile'
+          when 'BUL' then 'Bulgaria' when 'PER' then 'Peru' when 'DEN' then 'Denmark'
+          when 'GRE' then 'Greece' when 'CMR' then 'Cameroon' when 'CRC' then 'Costa Rica'
+          when 'IRL' then 'Rep. of Ireland' when 'CHN' then 'China PR' when 'CUB' then 'Cuba'
+          when 'HON' then 'Honduras' when 'BOL' then 'Bolivia' when 'ANG' then 'Angola'
+          when 'JAM' then 'Jamaica' when 'ISR' then 'Israel'
+          -- frequent WC rivals missing from 2026 (so absent from wc_teams) and from the aliases name map;
+          -- the H2H ledger surfaces these as top rivals where the History tab's prestige rollups never did.
+          when 'NGA' then 'Nigeria' when 'ROU' then 'Romania' when 'UKR' then 'Ukraine'
+          when 'WAL' then 'Wales' when 'NIR' then 'Northern Ireland' when 'SVN' then 'Slovenia'
+          when 'SVK' then 'Slovakia' when 'PRK' then 'Korea DPR' when 'IDN' then 'Indonesia'
+          when 'KUW' then 'Kuwait' when 'SLV' then 'El Salvador' when 'TOG' then 'Togo'
+          when 'TRI' then 'Trinidad and Tobago' when 'UAE' then 'United Arab Emirates'
+          else nullif({{ #oa.display_name }}, {{ #oa.alias_code }})
+        end,
+        agg.opp_code
+      ) as opp_name,
+      -- Official crest (2026 sides) → FIFA flag CDN templated on the canonical code (resolves for any current
+      -- federation; truly defunct codes 404 → the img hides). opp_code is already canonical.
+      coalesce({{ #ot.flag_url }}, 'https://api.fifa.com/api/v3/picture/flags-sq-4/' || agg.opp_code) as opp_flag,
+      -- pre-built display strings: number dims re-apply digit grouping in MarkdownViz ("1,950.00"),
+      -- so the year span and the signed GD are cast to text here (same reason wc_history_finals has year_text).
+      agg.first_year::text || '–' || agg.last_year::text as span_label,
+      case when agg.gd > 0 then '+' || agg.gd::text else agg.gd::text end as gd_label,
+      case when agg.gd > 0 then '#1f9a64' when agg.gd < 0 then '#d83a2e' else '#9c8a68' end as gd_color
+    from agg
+    left join {{ #wc_teams as ot }} on {{ #ot.code }} = agg.opp_code
+    left join {{ #wc_team_aliases as oa }} on {{ #oa.alias_code }} = agg.opp_code;;
+  dimension h2h_key {
+    label: 'H2H Key'
+    type: 'text'
+    primary_key: true
+    hidden: true
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    description: 'Canonical (modern-successor) code of the team whose perspective this row takes — join to a wc_teams role.'
+  }
+  dimension opp_code {
+    label: 'Opponent Code'
+    type: 'text'
+    description: 'Canonical code of the opponent — join to wc_opponent_teams for the opponent name/flag.'
+  }
+  dimension played {
+    label: 'Meetings'
+    type: 'number'
+    description: 'All-time World Cup meetings between the pair.'
+  }
+  dimension wins {
+    label: 'Wins'
+    type: 'number'
+  }
+  dimension draws {
+    label: 'Draws'
+    type: 'number'
+  }
+  dimension losses {
+    label: 'Losses'
+    type: 'number'
+  }
+  dimension gf {
+    label: 'Goals For'
+    type: 'number'
+  }
+  dimension ga {
+    label: 'Goals Against'
+    type: 'number'
+  }
+  dimension gd {
+    label: 'Goal Difference'
+    type: 'number'
+  }
+  dimension first_year {
+    label: 'First Meeting'
+    type: 'number'
+  }
+  dimension last_year {
+    label: 'Last Meeting'
+    type: 'number'
+  }
+  dimension record_label {
+    label: 'Record (W-D-L)'
+    type: 'text'
+    description: 'Pre-built "W-D-L" string from this team\'s perspective, e.g. "3-1-2".'
+  }
+  dimension win_pct {
+    label: 'Win %'
+    type: 'number'
+    description: 'Wins as a percentage of meetings (shootouts count as draws).'
+  }
+  dimension opp_name {
+    label: 'Opponent'
+    type: 'text'
+    description: 'Display name of the opponent, resolved for every historical nation (official 2026 name, else a curated marquee-nation map, else the alias name, else the bare code). Use this for display — wc_opponent_teams names only the 48 nations in the 2026 field.'
+  }
+  dimension opp_flag {
+    label: 'Opponent Flag'
+    type: 'text'
+    description: 'Opponent crest URL: official 2026 flag where available, else the FIFA flag CDN on the canonical code.'
+  }
+  dimension span_label {
+    label: 'Years'
+    type: 'text'
+    description: 'First–last meeting years as display text ("1950–2018") — cast in SQL because number formatting re-applies digit grouping in MarkdownViz.'
+  }
+  dimension gd_label {
+    label: 'Goal Difference'
+    type: 'text'
+    description: 'Signed all-time goal difference as text ("+13", "-6", "0").'
+  }
+  dimension gd_color {
+    label: 'GD Color'
+    type: 'text'
+    description: 'Driver: green when GD is positive, red when negative, muted at zero — for conditional formatting of the GD column.'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_h2h.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_h2h.model.aml
@@ -2,7 +2,7 @@ Model wc_history_h2h {
   type: 'query'
   label: 'All-time Head-to-Head'
   description: 'One row per (team, opponent) ordered pair: their all-time World Cup record 1930–2022 from that team\'s perspective (played / W-D-L / goals). Both teams use canonical codes (defunct nations folded into the modern successor) so a 2026 team resolves its full lineage. Built by UNIONing home and away perspectives of wc_history_matches — a cross-row aggregation that is not a single AQL measure. Shootouts count as draws (the 90/120-min score decides W/D/L), matching wc_history_team_editions.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_history_matches, wc_teams, wc_team_aliases]
   query: @sql
     with persp as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_matches.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_matches.model.aml
@@ -2,7 +2,7 @@ Model wc_history_matches {
   type: 'table'
   label: 'WC History Matches'
   description: 'Every World Cup match 1930–2022 (964 rows, FIFA API backfill). home/away_canonical map defunct nations to their modern successors for joins.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension fifa_match_id {
     label: 'FIFA Match ID'
     type: 'text'
@@ -118,5 +118,5 @@ Model wc_history_matches {
     definition: @sql {{ #SOURCE.city }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_history_matches"'
+  table_name: '"public"."wc_history_matches"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_matches.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_matches.model.aml
@@ -1,0 +1,122 @@
+Model wc_history_matches {
+  type: 'table'
+  label: 'WC History Matches'
+  description: 'Every World Cup match 1930–2022 (964 rows, FIFA API backfill). home/away_canonical map defunct nations to their modern successors for joins.'
+  data_source_name: 'demodb'
+  dimension fifa_match_id {
+    label: 'FIFA Match ID'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_match_id }};;
+    primary_key: true
+  }
+  dimension year {
+    label: 'Edition'
+    type: 'number'
+    definition: @sql {{ #SOURCE.year }};;
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+  }
+  dimension match_date {
+    label: 'Match Date'
+    type: 'datetime'
+    definition: @sql {{ #SOURCE.match_date }};;
+  }
+  dimension stage {
+    label: 'Stage'
+    type: 'text'
+    description: 'Normalized: group / group2 / r16 / qf / sf / third_place / final.'
+    definition: @sql {{ #SOURCE.stage }};;
+  }
+  dimension stage_name {
+    label: 'Stage Name'
+    type: 'text'
+    definition: @sql {{ #SOURCE.stage_name }};;
+  }
+  dimension group_name {
+    label: 'Group'
+    type: 'text'
+    definition: @sql {{ #SOURCE.group_name }};;
+  }
+  dimension home_code {
+    label: 'Home Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.home_code }};;
+  }
+  dimension home_name {
+    label: 'Home Team'
+    type: 'text'
+    definition: @sql {{ #SOURCE.home_name }};;
+  }
+  dimension away_code {
+    label: 'Away Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.away_code }};;
+  }
+  dimension away_name {
+    label: 'Away Team'
+    type: 'text'
+    definition: @sql {{ #SOURCE.away_name }};;
+  }
+  dimension home_canonical {
+    label: 'Home Canonical Code'
+    type: 'text'
+    description: 'Defunct nations mapped to FIFA successor (FRG→GER, URS→RUS, …) — join key toward wc_teams roles.'
+    definition: @sql CASE {{ #SOURCE.home_code }}
+      WHEN 'FRG' THEN 'GER' WHEN 'URS' THEN 'RUS' WHEN 'TCH' THEN 'CZE'
+      WHEN 'YUG' THEN 'SRB' WHEN 'SCG' THEN 'SRB' WHEN 'ZAI' THEN 'COD'
+      WHEN 'INH' THEN 'IDN' ELSE {{ #SOURCE.home_code }} END;;
+  }
+  dimension away_canonical {
+    label: 'Away Canonical Code'
+    type: 'text'
+    definition: @sql CASE {{ #SOURCE.away_code }}
+      WHEN 'FRG' THEN 'GER' WHEN 'URS' THEN 'RUS' WHEN 'TCH' THEN 'CZE'
+      WHEN 'YUG' THEN 'SRB' WHEN 'SCG' THEN 'SRB' WHEN 'ZAI' THEN 'COD'
+      WHEN 'INH' THEN 'IDN' ELSE {{ #SOURCE.away_code }} END;;
+  }
+  dimension home_score {
+    label: 'Home Score'
+    type: 'number'
+    definition: @sql {{ #SOURCE.home_score }};;
+  }
+  dimension away_score {
+    label: 'Away Score'
+    type: 'number'
+    definition: @sql {{ #SOURCE.away_score }};;
+  }
+  dimension home_pen {
+    label: 'Home Pens'
+    type: 'number'
+    definition: @sql {{ #SOURCE.home_pen }};;
+  }
+  dimension away_pen {
+    label: 'Away Pens'
+    type: 'number'
+    definition: @sql {{ #SOURCE.away_pen }};;
+  }
+  dimension winner_code {
+    label: 'Winner Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.winner_code }};;
+  }
+  dimension attendance {
+    label: 'Attendance'
+    type: 'number'
+    definition: @sql {{ #SOURCE.attendance }};;
+  }
+  dimension venue {
+    label: 'Venue'
+    type: 'text'
+    definition: @sql {{ #SOURCE.venue }};;
+  }
+  dimension city {
+    label: 'City'
+    type: 'text'
+    definition: @sql {{ #SOURCE.city }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_history_matches"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_team_editions.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_team_editions.model.aml
@@ -2,7 +2,7 @@ Model wc_history_team_editions {
   type: 'table'
   label: 'WC History Team Editions'
   description: 'Per (edition, team) rollup 1930–2022: record, goals, pedigree flags (in_semi/in_final/champion). Shootouts count as draws.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension edition_team {
     label: 'Edition Team Key'
     type: 'text'
@@ -95,5 +95,5 @@ Model wc_history_team_editions {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_history_team_editions"'
+  table_name: '"public"."wc_history_team_editions"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_history_team_editions.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_history_team_editions.model.aml
@@ -1,0 +1,99 @@
+Model wc_history_team_editions {
+  type: 'table'
+  label: 'WC History Team Editions'
+  description: 'Per (edition, team) rollup 1930–2022: record, goals, pedigree flags (in_semi/in_final/champion). Shootouts count as draws.'
+  data_source_name: 'demodb'
+  dimension edition_team {
+    label: 'Edition Team Key'
+    type: 'text'
+    definition: @sql {{ #SOURCE.year }} || '-' || {{ #SOURCE.team_code }};;
+    primary_key: true
+    hidden: true
+  }
+  dimension year {
+    label: 'Edition'
+    type: 'number'
+    definition: @sql {{ #SOURCE.year }};;
+  }
+  dimension year_text {
+    label: 'Edition Label'
+    type: 'text'
+    description: 'Ungrouped edition year for display ("1998", never "1,998") — cast in SQL because AQL cast() reapplies digit grouping.'
+    definition: @sql ({{ #SOURCE.year }})::text;;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    description: 'Historical code — join via wc_team_aliases for the modern successor.'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension played {
+    label: 'Played'
+    type: 'number'
+    definition: @sql {{ #SOURCE.played }};;
+  }
+  dimension won {
+    label: 'Won'
+    type: 'number'
+    definition: @sql {{ #SOURCE.won }};;
+  }
+  dimension drawn {
+    label: 'Drawn'
+    type: 'number'
+    definition: @sql {{ #SOURCE.drawn }};;
+  }
+  dimension lost {
+    label: 'Lost'
+    type: 'number'
+    definition: @sql {{ #SOURCE.lost }};;
+  }
+  dimension gf {
+    label: 'Goals For'
+    type: 'number'
+    definition: @sql {{ #SOURCE.gf }};;
+  }
+  dimension ga {
+    label: 'Goals Against'
+    type: 'number'
+    definition: @sql {{ #SOURCE.ga }};;
+  }
+  dimension in_semi {
+    label: 'Reached Semis'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.in_semi }};;
+  }
+  dimension in_final {
+    label: 'Reached Final'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.in_final }};;
+  }
+  dimension champion {
+    label: 'Champion'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.champion }};;
+  }
+  dimension finish_label {
+    label: 'Finish'
+    type: 'text'
+    description: 'Best-stage badge for the campaign ledger (champion ⊃ final ⊃ semi).'
+    definition: @aql case(
+      when: wc_history_team_editions.champion, then: 'Champions',
+      when: wc_history_team_editions.in_final, then: 'Final',
+      when: wc_history_team_editions.in_semi, then: 'Semi-final',
+      else: '—'
+    ) ;;
+  }
+  dimension finish_color {
+    label: 'Finish Color'
+    type: 'text'
+    description: 'Driver field: campaign badge color (champion=gold, final=silver, semi=bronze, else muted).'
+    definition: @aql case(
+      when: wc_history_team_editions.champion, then: '#C8920A',
+      when: wc_history_team_editions.in_final, then: '#8b979d',
+      when: wc_history_team_editions.in_semi, then: '#a9714b',
+      else: '#9AA4B2'
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_history_team_editions"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_home_teams.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_home_teams.model.aml
@@ -1,0 +1,14 @@
+// Role-playing alias of wc_teams for the HOME side of a match.
+// Inherits the wc_teams table + dimensions; relabels for distinct match-card display.
+Model wc_home_teams = wc_teams.extend({
+  label: 'Home Team'
+  dimension name {
+    label: 'Home Team'
+  }
+  dimension flag_url {
+    label: 'Home Flag'
+  }
+  dimension color_hex {
+    label: 'Home Color'
+  }
+})

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_lineup_grid.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_lineup_grid.model.aml
@@ -1,0 +1,127 @@
+Model wc_lineup_grid {
+  type: 'query'
+  label: 'Lineup Grid'
+  description: 'One row per STARTER per match with broadcast-graphic layout baked in: stage_x/y_pct place each token on a dual half-pitch stage (home 0–46%, away 54–100%), reveal_delay staggers the pop-in cascade GK → defence → attack. Rows derive from the FORMATION STRING (4-1-2-3 → bands of 4/1/2/3) because FIFA never sends LineupX/Y: starters are ordered GK→DF→MF→FW then shirt number and dealt into bands, so a winger listed as FW can sit one band off — layout is faithful to the formation, heuristic per player.'
+  data_source_name: 'demodb'
+  models: [wc_lineups, wc_matches, wc_players]
+  query: @sql
+    with starters as (
+      select {{ #l.match_num }} as match_num, {{ #l.team_code }} as team_code,
+             {{ #l.fifa_player_id }} as fifa_player_id, {{ #l.is_captain }} as is_captain,
+             case when {{ #l.team_code }} = {{ #m.home_code }} then 'home' else 'away' end as side,
+             case when {{ #l.team_code }} = {{ #m.home_code }} then {{ #m.home_formation }} else {{ #m.away_formation }} end as formation,
+             {{ #p.shirt_number }} as shirt_number, {{ #p.name }} as name,
+             {{ #p.picture_url }} as picture_url, {{ #p.position }} as position
+      from {{ #wc_lineups as l }}
+      join {{ #wc_matches as m }} on {{ #m.match_num }} = {{ #l.match_num }}
+      join {{ #wc_players as p }} on {{ #p.fifa_player_id }} = {{ #l.fifa_player_id }}
+      where {{ #l.is_starter }}
+    ),
+    seqd as (
+      select *, row_number() over (
+        partition by match_num, team_code
+        order by position asc, shirt_number asc nulls last
+      ) as seq
+      from starters
+      where formation is not null
+    ),
+    bands as (
+      select f.match_num, f.team_code, b.val::int as band_size, b.idx::int as band_idx
+      from (select distinct match_num, team_code, formation from seqd) f
+      cross join lateral unnest(string_to_array(f.formation, '-')) with ordinality as b(val, idx)
+    ),
+    bandc as (
+      select *,
+        sum(band_size) over (partition by match_num, team_code order by band_idx) as cum_end,
+        max(band_idx) over (partition by match_num, team_code) as nbands
+      from bands
+    )
+    select
+      s.match_num || '-' || s.fifa_player_id as grid_key,
+      s.match_num, s.team_code, s.side, s.formation,
+      s.shirt_number, s.name, s.picture_url, s.is_captain,
+      -- per-pitch x (GK centred; band players at odd 2k-ths), then offset into the dual stage
+      round((case when s.side = 'home' then 0 else 54 end)
+        + (case when s.seq = 1 then 50.0
+                else ((s.seq - 1 - (b.cum_end - b.band_size)) * 2 - 1)::numeric / (b.band_size * 2) * 100 end) * 0.46, 1) as stage_x,
+      -- GK at 88%, defence band at 72%, front band at 14%
+      round(case when s.seq = 1 then 88.0
+                 else 72 - (b.band_idx - 1) * (58.0 / greatest(b.nbands - 1, 1)) end, 1) as y_pct,
+      s.seq
+    from seqd s
+    left join bandc b on b.match_num = s.match_num and b.team_code = s.team_code
+      and s.seq - 1 > b.cum_end - b.band_size and s.seq - 1 <= b.cum_end;;
+  dimension grid_key {
+    label: 'Grid Key'
+    type: 'text'
+    primary_key: true
+    hidden: true
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+  }
+  dimension side {
+    label: 'Side'
+    type: 'text'
+  }
+  dimension formation {
+    label: 'Formation'
+    type: 'text'
+  }
+  dimension shirt_number {
+    label: 'Shirt Number'
+    type: 'number'
+  }
+  dimension name {
+    label: 'Player'
+    type: 'text'
+  }
+  dimension picture_url {
+    label: 'Picture URL'
+    type: 'text'
+  }
+  dimension is_captain {
+    label: 'Is Captain'
+    type: 'truefalse'
+    hidden: true
+  }
+  dimension role {
+    label: 'Role'
+    type: 'text'
+    description: 'Driver field: "gk" (gold ring) / "of" — token CSS class.'
+    definition: @aql case(when: wc_lineup_grid.seq == 1, then: 'gk', else: 'of') ;;
+  }
+  dimension cap_tag {
+    label: 'Captain Tag'
+    type: 'text'
+    description: 'Driver field: "C" armband chip, empty otherwise (hides via :empty).'
+    definition: @aql case(when: wc_lineup_grid.is_captain, then: 'C', else: '') ;;
+  }
+  dimension stage_x {
+    label: 'Stage X %'
+    type: 'number'
+    description: 'Driver field: token left% on the dual-pitch stage (home half 0–46, away half 54–100).'
+  }
+  dimension y_pct {
+    label: 'Stage Y %'
+    type: 'number'
+    description: 'Driver field: token top% — GK 88, defence 72, front band 14.'
+  }
+  dimension reveal_delay {
+    label: 'Reveal Delay (s)'
+    type: 'number'
+    description: 'Driver field: animation-delay for the broadcast pop-in cascade, GK first then band by band.'
+    definition: @aql 0.15 + wc_lineup_grid.seq * 0.12 ;;
+  }
+  dimension seq {
+    label: 'Reveal Order'
+    type: 'number'
+    hidden: true
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_lineup_grid.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_lineup_grid.model.aml
@@ -2,7 +2,7 @@ Model wc_lineup_grid {
   type: 'query'
   label: 'Lineup Grid'
   description: 'One row per STARTER per match with broadcast-graphic layout baked in: stage_x/y_pct place each token on a dual half-pitch stage (home 0–46%, away 54–100%), reveal_delay staggers the pop-in cascade GK → defence → attack. Rows derive from the FORMATION STRING (4-1-2-3 → bands of 4/1/2/3) because FIFA never sends LineupX/Y: starters are ordered GK→DF→MF→FW then shirt number and dealt into bands, so a winger listed as FW can sit one band off — layout is faithful to the formation, heuristic per player.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_lineups, wc_matches, wc_players]
   query: @sql
     with starters as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_lineups.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_lineups.model.aml
@@ -1,0 +1,84 @@
+Model wc_lineups {
+  type: 'table'
+  label: 'Lineups'
+  description: 'Per-match per-player lineup with formation pitch coordinates (pitch_x / pitch_y).'
+  data_source_name: 'demodb'
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+  }
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_player_id }};;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension is_starter {
+    label: 'Is Starter'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.is_starter }};;
+  }
+  dimension is_captain {
+    label: 'Is Captain'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.is_captain }};;
+  }
+  dimension pitch_x {
+    label: 'Pitch X'
+    type: 'number'
+    description: 'FIFA LineupX — currently null on every row (not in the live payload); team sheets render as lists, not a positioned pitch plot.'
+    hidden: true
+    definition: @sql {{ #SOURCE.pitch_x }};;
+  }
+  dimension pitch_y {
+    label: 'Pitch Y'
+    type: 'number'
+    description: 'FIFA LineupY — currently null on every row (see pitch_x).'
+    hidden: true
+    definition: @sql {{ #SOURCE.pitch_y }};;
+  }
+  dimension side {
+    label: 'Side'
+    type: 'text'
+    description: 'Driver field: "home"/"away" of the player\'s team within the match — splits the Match Center team sheets. Cross-model ref resolves through the dataset (lineups → matches is many-to-one).'
+    definition: @aql case(
+      when: wc_lineups.team_code == wc_matches.home_code, then: 'home',
+      else: 'away'
+    ) ;;
+  }
+  dimension role {
+    label: 'Role'
+    type: 'text'
+    description: 'Driver field: "xi" (starter) / "bench" — CSS class on the team-sheet row (no template conditionals).'
+    definition: @aql case(
+      when: wc_lineups.is_starter, then: 'xi',
+      else: 'bench'
+    ) ;;
+  }
+  dimension role_sort {
+    label: 'Role Sort'
+    type: 'number'
+    hidden: true
+    description: 'Driver field: starters (0) before bench (1) — lexical sort on role would put bench first.'
+    definition: @aql case(
+      when: wc_lineups.is_starter, then: 0,
+      else: 1
+    ) ;;
+  }
+  dimension captain_tag {
+    label: 'Captain Tag'
+    type: 'text'
+    description: 'Driver field: "C" for the captain, empty otherwise — empty armband chips hide via CSS :empty.'
+    definition: @aql case(
+      when: wc_lineups.is_captain, then: 'C',
+      else: ''
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_lineups"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_lineups.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_lineups.model.aml
@@ -2,7 +2,7 @@ Model wc_lineups {
   type: 'table'
   label: 'Lineups'
   description: 'Per-match per-player lineup with formation pitch coordinates (pitch_x / pitch_y).'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension match_num {
     label: 'Match Number'
     type: 'number'
@@ -80,5 +80,5 @@ Model wc_lineups {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_lineups"'
+  table_name: '"public"."wc_lineups"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_match_odds.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_match_odds.model.aml
@@ -2,7 +2,7 @@ Model wc_match_odds {
   type: 'query'
   label: 'Match Odds (Latest)'
   description: 'One row per MATCH (all 104, from wc_matches): the LATEST Elo→Poisson run probabilities plus the day-over-day delta vs the previous run. Matches with no prediction rows (M1–M2 finished before the first nightly run on 12 Jun 2026) keep their row with null probabilities and a status_note, so the odds board renders a styled empty state instead of the platform "no data" pill. Delta labels/colours are built in SQL — AQL has no signed to_char and cast() re-applies digit grouping.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_match_predictions, wc_matches]
   query: @sql
     with ranked as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_match_odds.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_match_odds.model.aml
@@ -1,0 +1,153 @@
+Model wc_match_odds {
+  type: 'query'
+  label: 'Match Odds (Latest)'
+  description: 'One row per MATCH (all 104, from wc_matches): the LATEST Elo→Poisson run probabilities plus the day-over-day delta vs the previous run. Matches with no prediction rows (M1–M2 finished before the first nightly run on 12 Jun 2026) keep their row with null probabilities and a status_note, so the odds board renders a styled empty state instead of the platform "no data" pill. Delta labels/colours are built in SQL — AQL has no signed to_char and cast() re-applies digit grouping.'
+  data_source_name: 'demodb'
+  models: [wc_match_predictions, wc_matches]
+  query: @sql
+    with ranked as (
+      select
+        {{ #p.match_num }} as match_num,
+        {{ #p.run_date }} as run_date,
+        {{ #p.p_home }} as p_home,
+        {{ #p.p_draw }} as p_draw,
+        {{ #p.p_away }} as p_away,
+        {{ #p.exp_home_goals }} as exp_home_goals,
+        {{ #p.exp_away_goals }} as exp_away_goals,
+        row_number() over (partition by {{ #p.match_num }} order by {{ #p.run_date }} desc) as rn
+      from {{ #wc_match_predictions as p }}
+    )
+    select
+      {{ #m.match_num }} as match_num,
+      c.run_date,
+      c.p_home, c.p_draw, c.p_away,
+      c.exp_home_goals, c.exp_away_goals,
+      case when c.run_date is null then null
+           else to_char(c.exp_home_goals, 'FM990.0') || ' – ' || to_char(c.exp_away_goals, 'FM990.0') end as exp_score_label,
+      case when c.run_date is null then 'no run recorded'
+           else 'run ' || to_char(c.run_date, 'DD Mon') end as run_label,
+      case when c.run_date is not null then null
+           when {{ #m.status }} = 'FT' then 'Played before the model went live on 12 Jun — no pre-match odds were recorded for this fixture.'
+           else 'No sim run for this fixture yet — odds land with the next nightly run.' end as status_note,
+      pr.run_date as prev_run_date,
+      case when c.run_date is null then null
+           when pr.run_date is null then 'first run — deltas from tomorrow'
+           else 'vs run ' || to_char(pr.run_date, 'DD Mon') end as delta_note,
+      case when c.run_date is null or pr.run_date is null then ''
+           when c.p_home - pr.p_home > 0.0005 then '▲ ' || to_char((c.p_home - pr.p_home) * 100, 'FM990.0')
+           when pr.p_home - c.p_home > 0.0005 then '▼ ' || to_char((pr.p_home - c.p_home) * 100, 'FM990.0')
+           else '· 0.0' end as d_home_label,
+      case when c.run_date is null or pr.run_date is null then ''
+           when c.p_draw - pr.p_draw > 0.0005 then '▲ ' || to_char((c.p_draw - pr.p_draw) * 100, 'FM990.0')
+           when pr.p_draw - c.p_draw > 0.0005 then '▼ ' || to_char((pr.p_draw - c.p_draw) * 100, 'FM990.0')
+           else '· 0.0' end as d_draw_label,
+      case when c.run_date is null or pr.run_date is null then ''
+           when c.p_away - pr.p_away > 0.0005 then '▲ ' || to_char((c.p_away - pr.p_away) * 100, 'FM990.0')
+           when pr.p_away - c.p_away > 0.0005 then '▼ ' || to_char((pr.p_away - c.p_away) * 100, 'FM990.0')
+           else '· 0.0' end as d_away_label,
+      case when c.run_date is null or pr.run_date is null or abs(c.p_home - pr.p_home) <= 0.0005 then '#9AA4B2'
+           when c.p_home > pr.p_home then '#1FA36B' else '#E5362B' end as d_home_color,
+      case when c.run_date is null or pr.run_date is null or abs(c.p_draw - pr.p_draw) <= 0.0005 then '#9AA4B2'
+           when c.p_draw > pr.p_draw then '#1FA36B' else '#E5362B' end as d_draw_color,
+      case when c.run_date is null or pr.run_date is null or abs(c.p_away - pr.p_away) <= 0.0005 then '#9AA4B2'
+           when c.p_away > pr.p_away then '#1FA36B' else '#E5362B' end as d_away_color
+    from {{ #wc_matches as m }}
+    left join ranked c on c.match_num = {{ #m.match_num }} and c.rn = 1
+    left join ranked pr on pr.match_num = {{ #m.match_num }} and pr.rn = 2;;
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    primary_key: true
+  }
+  dimension run_date {
+    label: 'Run Date'
+    type: 'date'
+  }
+  dimension run_label {
+    label: 'Run Label'
+    type: 'text'
+    description: 'Header caption: "run 12 Jun", or "no run recorded" for matches without predictions.'
+  }
+  dimension p_home {
+    label: 'P Home Win'
+    type: 'number'
+  }
+  dimension p_draw {
+    label: 'P Draw'
+    type: 'number'
+  }
+  dimension p_away {
+    label: 'P Away Win'
+    type: 'number'
+  }
+  dimension p_home_pct {
+    label: 'P Home Win %'
+    type: 'number'
+    description: 'p_home × 100 — doubles as the probability-bar segment width.'
+    definition: @aql wc_match_odds.p_home * 100 ;;
+  }
+  dimension p_draw_pct {
+    label: 'P Draw %'
+    type: 'number'
+    definition: @aql wc_match_odds.p_draw * 100 ;;
+  }
+  dimension p_away_pct {
+    label: 'P Away Win %'
+    type: 'number'
+    definition: @aql wc_match_odds.p_away * 100 ;;
+  }
+  dimension exp_home_goals {
+    label: 'Expected Home Goals'
+    type: 'number'
+  }
+  dimension exp_away_goals {
+    label: 'Expected Away Goals'
+    type: 'number'
+  }
+  dimension exp_score_label {
+    label: 'Expected Score'
+    type: 'text'
+    description: 'Pre-formatted "2.1 – 0.8" from the Poisson means; null when no run exists.'
+  }
+  dimension status_note {
+    label: 'Status Note'
+    type: 'text'
+    description: 'Styled empty state: why this fixture has no odds (pre-model fixture vs awaiting nightly run); null when odds exist (hides via :empty).'
+  }
+  dimension prev_run_date {
+    label: 'Previous Run Date'
+    type: 'date'
+  }
+  dimension delta_note {
+    label: 'Delta Note'
+    type: 'text'
+    description: 'Footer caption: "vs run 11 Jun", or a first-run notice while only one run exists.'
+  }
+  dimension d_home_label {
+    label: 'Home Delta'
+    type: 'text'
+    description: 'Driver field: signed day-over-day move in percentage points, e.g. "▲ 2.4"; empty on the first run (hides via :empty).'
+  }
+  dimension d_draw_label {
+    label: 'Draw Delta'
+    type: 'text'
+  }
+  dimension d_away_label {
+    label: 'Away Delta'
+    type: 'text'
+  }
+  dimension d_home_color {
+    label: 'Home Delta Color'
+    type: 'text'
+    description: 'Driver field: rising green, falling red, flat/first-run grey.'
+  }
+  dimension d_draw_color {
+    label: 'Draw Delta Color'
+    type: 'text'
+  }
+  dimension d_away_color {
+    label: 'Away Delta Color'
+    type: 'text'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_match_predictions.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_match_predictions.model.aml
@@ -1,0 +1,56 @@
+Model wc_match_predictions {
+  type: 'table'
+  label: 'Match Predictions'
+  description: 'Per-match outcome probabilities + expected goals from the backtested Elo→Poisson model. One row per (match, run_date) — daily history of odds movement.'
+  data_source_name: 'demodb'
+  dimension prediction_key {
+    label: 'Prediction Key'
+    type: 'text'
+    definition: @sql {{ #SOURCE.match_num }} || '-' || {{ #SOURCE.run_date }};;
+    primary_key: true
+    hidden: true
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+  }
+  dimension run_date {
+    label: 'Run Date'
+    type: 'date'
+    definition: @sql {{ #SOURCE.run_date }};;
+  }
+  dimension run_date_label {
+    label: 'Run Date Label'
+    type: 'text'
+    description: 'Pre-formatted prediction run date for trend-axis / picker display, e.g. "13 Jun".'
+    definition: @aql date_format(wc_match_predictions.run_date, '%d %b') ;;
+  }
+  dimension p_home {
+    label: 'P Home Win'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_home }};;
+  }
+  dimension p_draw {
+    label: 'P Draw'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_draw }};;
+  }
+  dimension p_away {
+    label: 'P Away Win'
+    type: 'number'
+    definition: @sql {{ #SOURCE.p_away }};;
+  }
+  dimension exp_home_goals {
+    label: 'Expected Home Goals'
+    type: 'number'
+    definition: @sql {{ #SOURCE.exp_home_goals }};;
+  }
+  dimension exp_away_goals {
+    label: 'Expected Away Goals'
+    type: 'number'
+    definition: @sql {{ #SOURCE.exp_away_goals }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_match_predictions"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_match_predictions.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_match_predictions.model.aml
@@ -2,7 +2,7 @@ Model wc_match_predictions {
   type: 'table'
   label: 'Match Predictions'
   description: 'Per-match outcome probabilities + expected goals from the backtested Elo→Poisson model. One row per (match, run_date) — daily history of odds movement.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension prediction_key {
     label: 'Prediction Key'
     type: 'text'
@@ -52,5 +52,5 @@ Model wc_match_predictions {
     definition: @sql {{ #SOURCE.exp_away_goals }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_match_predictions"'
+  table_name: '"public"."wc_match_predictions"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_matches.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_matches.model.aml
@@ -2,7 +2,7 @@ Model wc_matches {
   type: 'table'
   label: 'Matches'
   description: 'World Cup 2026 fixtures and results (104). Match grain: one row per match.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension match_num {
     label: 'Match Number'
     type: 'number'
@@ -253,7 +253,7 @@ Model wc_matches {
     description: 'Driver: the single featured match — lowest featured_sort (live, else soonest upcoming, else most recent finished) with a match_num tie-break for determinism. The featured hero filters on this and the upcoming-fixtures band excludes it, so the two never show the same match twice.'
     definition: @sql ({{ #SOURCE.match_num }} = (
       select sub.match_num
-      from "demo_world_cup"."wc_matches" sub
+      from "public"."wc_matches" sub
       order by (case when sub.status = 'LIVE' then 0
                      when sub.status = 'NS' then extract(epoch from sub.kickoff_utc)
                      else 100000000000 - extract(epoch from sub.kickoff_utc) end) asc, sub.match_num asc
@@ -341,5 +341,5 @@ Model wc_matches {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_matches"'
+  table_name: '"public"."wc_matches"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_matches.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_matches.model.aml
@@ -1,0 +1,345 @@
+Model wc_matches {
+  type: 'table'
+  label: 'Matches'
+  description: 'World Cup 2026 fixtures and results (104). Match grain: one row per match.'
+  data_source_name: 'demodb'
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+    primary_key: true
+  }
+  dimension fifa_match_id {
+    label: 'FIFA Match Id'
+    type: 'text'
+    hidden: true
+    definition: @sql {{ #SOURCE.fifa_match_id }};;
+  }
+  dimension fifa_stage_id {
+    label: 'FIFA Stage Id'
+    type: 'text'
+    hidden: true
+    definition: @sql {{ #SOURCE.fifa_stage_id }};;
+  }
+  dimension stage {
+    label: 'Stage'
+    type: 'text'
+    definition: @sql {{ #SOURCE.stage }};;
+  }
+  dimension group_code {
+    label: 'Group'
+    type: 'text'
+    definition: @sql {{ #SOURCE.group_code }};;
+  }
+  dimension matchday {
+    label: 'Matchday'
+    type: 'number'
+    definition: @sql {{ #SOURCE.matchday }};;
+  }
+  dimension kickoff_utc {
+    label: 'Kickoff (UTC)'
+    type: 'datetime'
+    definition: @sql {{ #SOURCE.kickoff_utc }};;
+  }
+  dimension home_slot {
+    label: 'Home Slot'
+    type: 'text'
+    definition: @sql {{ #SOURCE.home_slot }};;
+  }
+  dimension away_slot {
+    label: 'Away Slot'
+    type: 'text'
+    definition: @sql {{ #SOURCE.away_slot }};;
+  }
+  dimension home_code {
+    label: 'Home Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.home_code }};;
+  }
+  dimension away_code {
+    label: 'Away Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.away_code }};;
+  }
+  dimension home_score {
+    label: 'Home Score'
+    type: 'number'
+    definition: @sql {{ #SOURCE.home_score }};;
+  }
+  dimension away_score {
+    label: 'Away Score'
+    type: 'number'
+    definition: @sql {{ #SOURCE.away_score }};;
+  }
+  dimension home_pen {
+    label: 'Home Penalties'
+    type: 'number'
+    definition: @sql {{ #SOURCE.home_pen }};;
+  }
+  dimension away_pen {
+    label: 'Away Penalties'
+    type: 'number'
+    definition: @sql {{ #SOURCE.away_pen }};;
+  }
+  dimension status {
+    label: 'Status'
+    type: 'text'
+    definition: @sql {{ #SOURCE.status }};;
+  }
+  dimension fifa_status {
+    label: 'FIFA Status'
+    type: 'number'
+    hidden: true
+    definition: @sql {{ #SOURCE.fifa_status }};;
+  }
+  dimension winner_code {
+    label: 'Winner Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.winner_code }};;
+  }
+  dimension home_formation {
+    label: 'Home Formation'
+    type: 'text'
+    definition: @sql {{ #SOURCE.home_formation }};;
+  }
+  dimension away_formation {
+    label: 'Away Formation'
+    type: 'text'
+    definition: @sql {{ #SOURCE.away_formation }};;
+  }
+  dimension possession_home {
+    label: 'Possession Home'
+    type: 'number'
+    definition: @sql {{ #SOURCE.possession_home }};;
+  }
+  dimension possession_away {
+    label: 'Possession Away'
+    type: 'number'
+    definition: @sql {{ #SOURCE.possession_away }};;
+  }
+  dimension attendance {
+    label: 'Attendance'
+    type: 'number'
+    definition: @sql {{ #SOURCE.attendance }};;
+  }
+  dimension venue {
+    label: 'Venue'
+    type: 'text'
+    definition: @sql {{ #SOURCE.venue }};;
+  }
+  dimension city {
+    label: 'City'
+    type: 'text'
+    definition: @sql {{ #SOURCE.city }};;
+  }
+  dimension updated_at {
+    label: 'Updated At'
+    type: 'datetime'
+    definition: @sql {{ #SOURCE.updated_at }};;
+  }
+  dimension match_label {
+    label: 'Match'
+    type: 'text'
+    description: 'Picker/display key, e.g. "06/12 · 02:00 · KOR vs CZE". Leads with zero-padded month/day + 24h UTC kickoff so the field-filter dropdown sorts CHRONOLOGICALLY (match_num is NOT in kickoff order, and a field filter has no configurable sort — the order must be baked into the value). Undecided knockout teams fall back to slot grammar (1A, W49). Built in SQL because AQL cast() re-applies digit grouping.'
+    definition: @sql to_char({{ #SOURCE.kickoff_utc }}, 'MM/DD · HH24:MI') || ' · ' || coalesce({{ #SOURCE.home_code }}, {{ #SOURCE.home_slot }}) || ' vs ' || coalesce({{ #SOURCE.away_code }}, {{ #SOURCE.away_slot }});;
+  }
+  dimension is_finished {
+    label: 'Is Finished'
+    type: 'truefalse'
+    definition: @aql wc_matches.status == 'FT' ;;
+  }
+  dimension total_match_goals {
+    label: 'Total Match Goals'
+    type: 'number'
+    definition: @aql wc_matches.home_score + wc_matches.away_score ;;
+  }
+  dimension status_label {
+    label: 'Status Label'
+    type: 'text'
+    definition: @aql case(
+      when: wc_matches.status == 'NS', then: 'Upcoming',
+      when: wc_matches.status == 'LIVE', then: 'Live',
+      when: wc_matches.status == 'FT', then: 'Full time',
+      else: wc_matches.status
+    ) ;;
+  }
+  dimension status_color {
+    label: 'Status Color'
+    type: 'text'
+    description: 'Driver field: badge color for the match status (live=red, finished=green, else grey).'
+    definition: @aql case(
+      when: wc_matches.status == 'LIVE', then: '#E5362B',
+      when: wc_matches.status == 'FT', then: '#1FA36B',
+      else: '#9AA4B2'
+    ) ;;
+  }
+  dimension kickoff_label {
+    label: 'Kickoff Label'
+    type: 'text'
+    description: 'Pre-formatted kickoff for card display, e.g. "Sat 13 Jun · 19:00" (UTC).'
+    definition: @aql date_format(wc_matches.kickoff_utc, '%a %d %b · %H:%M') ;;
+  }
+  dimension kickoff_day {
+    label: 'Kickoff Day'
+    type: 'text'
+    description: 'Short kickoff date for compact display, e.g. "13 Jun".'
+    definition: @aql date_format(wc_matches.kickoff_utc, '%d %b') ;;
+  }
+  dimension kickoff_time {
+    label: 'Kickoff Time'
+    type: 'text'
+    description: 'Kickoff time only, 24h UTC, e.g. "19:00".'
+    definition: @aql date_format(wc_matches.kickoff_utc, '%H:%M') ;;
+  }
+  // ---- Time / period drill dimensions (filterable; the dataset's primary date dim is kickoff_date) ----
+  dimension kickoff_date {
+    label: 'Kickoff Date'
+    type: 'date'
+    description: 'Calendar day of kickoff (UTC) — the primary date-drill dimension. Filtering matches (or any per-team fact) to kickoff_date <= D yields an "as of date D" view; a date range drills a window of fixtures.'
+    definition: @aql date_trunc(wc_matches.kickoff_utc, 'day') ;;
+  }
+  dimension phase {
+    label: 'Phase'
+    type: 'text'
+    description: 'Group stage vs Knockout — the coarse split for group-vs-knockout comparison measures.'
+    definition: @aql case(
+      when: wc_matches.stage == 'group', then: 'Group stage',
+      else: 'Knockout'
+    ) ;;
+  }
+  dimension matchday_label {
+    label: 'Matchday / Round'
+    type: 'text'
+    description: 'Filterable round label: "Matchday 1/2/3" for the group stage (from the backfilled matchday column — 2 fixtures per group per matchday), falling back to the knockout stage name ("Round of 32" … "Final"). Use this for the matchday/round drill; matchday itself is NULL for knockouts.'
+    definition: @aql case(
+      when: wc_matches.matchday == 1, then: 'Matchday 1',
+      when: wc_matches.matchday == 2, then: 'Matchday 2',
+      when: wc_matches.matchday == 3, then: 'Matchday 3',
+      else: wc_matches.stage_label
+    ) ;;
+  }
+  dimension matchday_sort {
+    label: 'Matchday Sort'
+    type: 'number'
+    hidden: true
+    description: 'Driver field: chronological sort key for the matchday/round drill — group matchdays 1-3, then knockout rounds in funnel order (R32=4 … Final=9).'
+    definition: @aql case(
+      when: wc_matches.matchday == 1, then: 1,
+      when: wc_matches.matchday == 2, then: 2,
+      when: wc_matches.matchday == 3, then: 3,
+      when: wc_matches.stage == 'r32', then: 4,
+      when: wc_matches.stage == 'r16', then: 5,
+      when: wc_matches.stage == 'qf', then: 6,
+      when: wc_matches.stage == 'sf', then: 7,
+      when: wc_matches.stage == 'third_place', then: 8,
+      when: wc_matches.stage == 'final', then: 9,
+      else: 99
+    ) ;;
+  }
+  dimension featured_sort {
+    label: 'Featured Sort'
+    type: 'number'
+    hidden: true
+    description: 'Driver field: featured-match priority. Live matches sort first (0), then upcoming by soonest kickoff (epoch seconds), then finished by most recent kickoff (inverted epoch keeps the FT bucket after all upcoming values).'
+    definition: @aql case(
+      when: wc_matches.status == 'LIVE', then: 0,
+      when: wc_matches.status == 'NS', then: epoch(wc_matches.kickoff_utc),
+      else: 100000000000 - epoch(wc_matches.kickoff_utc)
+    ) ;;
+  }
+  dimension is_featured {
+    label: 'Is Featured'
+    type: 'truefalse'
+    description: 'Driver: the single featured match — lowest featured_sort (live, else soonest upcoming, else most recent finished) with a match_num tie-break for determinism. The featured hero filters on this and the upcoming-fixtures band excludes it, so the two never show the same match twice.'
+    definition: @sql ({{ #SOURCE.match_num }} = (
+      select sub.match_num
+      from "demo_world_cup"."wc_matches" sub
+      order by (case when sub.status = 'LIVE' then 0
+                     when sub.status = 'NS' then extract(epoch from sub.kickoff_utc)
+                     else 100000000000 - extract(epoch from sub.kickoff_utc) end) asc, sub.match_num asc
+      limit 1
+    )) ;;
+  }
+  dimension in_fixture_band {
+    label: 'In Fixture Band'
+    type: 'truefalse'
+    description: 'Driver: belongs in the Tournament upcoming-fixtures band — not finished AND not the featured match (the featured one is the hero card above, so the band lists the upcoming fixtures after it).'
+    definition: @aql wc_matches.is_finished == false and wc_matches.is_featured == false ;;
+  }
+  dimension stage_label {
+    label: 'Stage Label'
+    type: 'text'
+    description: 'Display name of the match stage, e.g. "Group A", "Round of 32", "Final".'
+    definition: @aql case(
+      when: wc_matches.stage == 'group', then: concat('Group ', wc_matches.group_code),
+      when: wc_matches.stage == 'r32', then: 'Round of 32',
+      when: wc_matches.stage == 'r16', then: 'Round of 16',
+      when: wc_matches.stage == 'qf', then: 'Quarter-final',
+      when: wc_matches.stage == 'sf', then: 'Semi-final',
+      when: wc_matches.stage == 'third_place', then: 'Third place',
+      when: wc_matches.stage == 'final', then: 'Final',
+      else: wc_matches.stage
+    ) ;;
+  }
+  dimension featured_display {
+    label: 'Featured Display'
+    type: 'text'
+    description: 'Driver field: card centre text — score "2 – 1" once the match is live or finished, kickoff time "19:00" while upcoming.'
+    definition: @aql case(
+      when: wc_matches.status == 'NS', then: date_format(wc_matches.kickoff_utc, '%H:%M'),
+      else: concat(cast(wc_matches.home_score, 'text'), ' – ', cast(wc_matches.away_score, 'text'))
+    ) ;;
+  }
+  dimension featured_display_sub {
+    label: 'Featured Display Sub'
+    type: 'text'
+    description: 'Driver field: caption under the card centre text — what the centre value represents per status.'
+    definition: @aql case(
+      when: wc_matches.status == 'NS', then: 'kick-off · UTC',
+      when: wc_matches.status == 'LIVE', then: 'live score',
+      else: 'full time'
+    ) ;;
+  }
+  dimension featured_note {
+    label: 'Featured Note'
+    type: 'text'
+    description: 'Driver field: status-aware footnote for the featured match card.'
+    definition: @aql case(
+      when: wc_matches.status == 'NS', then: 'Possession, xG and scorers go live at kick-off.',
+      when: wc_matches.status == 'LIVE', then: 'Match in progress — score updates with each refresh.',
+      else: 'Full time — final score on the board.'
+    ) ;;
+  }
+  // ---- Header stage-progress ribbon (group on ribbon_short; filter stage to the six funnel stages) ----
+  dimension ribbon_order {
+    label: 'Ribbon Order'
+    type: 'number'
+    hidden: true
+    description: 'Sort key for the header stage-progress ribbon (group=1 → final=6); third place=9 and is filtered out of the ribbon.'
+    definition: @aql case(
+      when: wc_matches.stage == 'group', then: 1,
+      when: wc_matches.stage == 'r32', then: 2,
+      when: wc_matches.stage == 'r16', then: 3,
+      when: wc_matches.stage == 'qf', then: 4,
+      when: wc_matches.stage == 'sf', then: 5,
+      when: wc_matches.stage == 'final', then: 6,
+      else: 9
+    ) ;;
+  }
+  dimension ribbon_short {
+    label: 'Ribbon Stage'
+    type: 'text'
+    description: 'Short stage label for the header ribbon (Group, R32, R16, QF, SF, Final).'
+    definition: @aql case(
+      when: wc_matches.stage == 'group', then: 'Group',
+      when: wc_matches.stage == 'r32', then: 'R32',
+      when: wc_matches.stage == 'r16', then: 'R16',
+      when: wc_matches.stage == 'qf', then: 'QF',
+      when: wc_matches.stage == 'sf', then: 'SF',
+      when: wc_matches.stage == 'final', then: 'Final',
+      else: 'Third place'
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_matches"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_opponent_teams.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_opponent_teams.model.aml
@@ -1,0 +1,13 @@
+// Role-playing alias of wc_teams for the OPPONENT in a per-team match result row.
+Model wc_opponent_teams = wc_teams.extend({
+  label: 'Opponent'
+  dimension name {
+    label: 'Opponent'
+  }
+  dimension flag_url {
+    label: 'Opponent Flag'
+  }
+  dimension color_hex {
+    label: 'Opponent Color'
+  }
+})

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_player_bio.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_player_bio.model.aml
@@ -1,0 +1,73 @@
+Model wc_player_bio {
+  type: 'table'
+  label: 'Player Bio'
+  description: 'Open-data player bio (TheSportsDB), keyed by FIFA player id: age/club/detailed position/cutout image. Matched by name + validated against the squad nationality; matched = false rows are players searched without a confident match (bio hides for them — no fabrication). Tournament stats live in wc_player_stats; this is real-world identity only.'
+  data_source_name: 'demodb'
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_player_id }};;
+    primary_key: true
+  }
+  dimension full_name {
+    label: 'Full Name'
+    type: 'text'
+    definition: @sql {{ #SOURCE.full_name }};;
+  }
+  dimension date_born {
+    label: 'Date of Birth'
+    type: 'date'
+    definition: @sql {{ #SOURCE.date_born }};;
+  }
+  dimension age {
+    label: 'Age'
+    type: 'number'
+    description: 'Whole years from date of birth to today (null when birth date is unknown).'
+    definition: @sql date_part('year', age({{ #SOURCE.date_born }}))::int;;
+  }
+  dimension age_label {
+    label: 'Age Label'
+    type: 'text'
+    description: 'Pre-formatted "26 yrs" (empty when birth date unknown so the chip hides via :empty).'
+    definition: @sql case when {{ #SOURCE.date_born }} is not null then date_part('year', age({{ #SOURCE.date_born }}))::int || ' yrs' else '' end;;
+  }
+  dimension club {
+    label: 'Club'
+    type: 'text'
+    definition: @sql {{ #SOURCE.club }};;
+  }
+  dimension nationality {
+    label: 'Nationality'
+    type: 'text'
+    definition: @sql {{ #SOURCE.nationality }};;
+  }
+  dimension position_detail {
+    label: 'Position (detail)'
+    type: 'text'
+    description: 'Detailed playing position, e.g. "Centre-Forward", "Attacking Midfield".'
+    definition: @sql {{ #SOURCE.position_detail }};;
+  }
+  dimension height {
+    label: 'Height'
+    type: 'text'
+    definition: @sql {{ #SOURCE.height }};;
+  }
+  dimension cutout_url {
+    label: 'Cutout URL'
+    type: 'text'
+    description: 'Transparent player cutout PNG — the FUT card art.'
+    definition: @sql {{ #SOURCE.cutout_url }};;
+  }
+  dimension thumb_url {
+    label: 'Thumb URL'
+    type: 'text'
+    definition: @sql {{ #SOURCE.thumb_url }};;
+  }
+  dimension matched {
+    label: 'Bio Matched'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.matched }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_player_bio"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_player_bio.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_player_bio.model.aml
@@ -2,7 +2,7 @@ Model wc_player_bio {
   type: 'table'
   label: 'Player Bio'
   description: 'Open-data player bio (TheSportsDB), keyed by FIFA player id: age/club/detailed position/cutout image. Matched by name + validated against the squad nationality; matched = false rows are players searched without a confident match (bio hides for them — no fabrication). Tournament stats live in wc_player_stats; this is real-world identity only.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension fifa_player_id {
     label: 'FIFA Player Id'
     type: 'text'
@@ -69,5 +69,5 @@ Model wc_player_bio {
     definition: @sql {{ #SOURCE.matched }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_player_bio"'
+  table_name: '"public"."wc_player_bio"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_player_match_form.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_player_match_form.model.aml
@@ -1,0 +1,135 @@
+Model wc_player_match_form {
+  type: 'query'
+  label: 'Player Match Form'
+  description: 'One row per (player, match) the player appeared in: goals / assists / G+A / cards and whether they started, tagged with the match\'s matchday, stage, kickoff date and opponent. This is the per-matchday breakdown behind the tournament-total wc_player_stats — it lets the dashboard chart a player\'s form across matchdays or filter the Players tab to a single matchday. Appearances are the base (from lineups), so a player who featured without scoring still has a row.'
+  data_source_name: 'demodb'
+  models: [wc_lineups, wc_events, wc_matches, wc_players]
+  query: @sql
+    with apps as (
+      select {{ #l.fifa_player_id }} as fifa_player_id, {{ #l.match_num }} as match_num,
+        max({{ #l.team_code }}) as team_code,
+        bool_or({{ #l.is_starter }}) as started,
+        bool_or({{ #l.is_captain }}) as captain
+      from {{ #wc_lineups as l }}
+      group by {{ #l.fifa_player_id }}, {{ #l.match_num }}
+    ),
+    ev as (
+      select {{ #e.fifa_player_id }} as fifa_player_id, {{ #e.match_num }} as match_num,
+        count(*) filter (where {{ #e.type }} in (0, 41)) as goals,
+        count(*) filter (where {{ #e.type }} = 41) as penalty_goals,
+        count(*) filter (where {{ #e.type }} = 2) as yellows,
+        count(*) filter (where {{ #e.type }} = 3) as reds
+      from {{ #wc_events as e }}
+      where {{ #e.fifa_player_id }} is not null
+      group by {{ #e.fifa_player_id }}, {{ #e.match_num }}
+    ),
+    ast as (
+      select {{ #ea.assist_player_id }} as fifa_player_id, {{ #ea.match_num }} as match_num, count(*) as assists
+      from {{ #wc_events as ea }}
+      where {{ #ea.type }} in (0, 41) and {{ #ea.assist_player_id }} is not null
+      group by {{ #ea.assist_player_id }}, {{ #ea.match_num }}
+    )
+    select
+      a.fifa_player_id || '-' || a.match_num as form_key,
+      a.fifa_player_id,
+      a.match_num,
+      a.team_code,
+      {{ #p.name }} as name,
+      {{ #m.matchday }} as matchday,
+      {{ #m.stage }} as stage,
+      {{ #m.kickoff_utc }}::date as kickoff_date,
+      case when {{ #m.matchday }} in (1, 2, 3) then 'Matchday ' || {{ #m.matchday }}::text
+           else initcap(replace({{ #m.stage }}, '_', ' ')) end as matchday_label,
+      case when a.team_code = {{ #m.home_code }} then {{ #m.away_code }} else {{ #m.home_code }} end as opponent_code,
+      coalesce(ev.goals, 0) as goals,
+      coalesce(ev.penalty_goals, 0) as penalty_goals,
+      coalesce(ast.assists, 0) as assists,
+      coalesce(ev.goals, 0) + coalesce(ast.assists, 0) as goal_contributions,
+      coalesce(ev.yellows, 0) as yellows,
+      coalesce(ev.reds, 0) as reds,
+      a.started,
+      a.captain
+    from apps a
+    join {{ #wc_matches as m }} on {{ #m.match_num }} = a.match_num
+    left join {{ #wc_players as p }} on {{ #p.fifa_player_id }} = a.fifa_player_id
+    left join ev on ev.fifa_player_id = a.fifa_player_id and ev.match_num = a.match_num
+    left join ast on ast.fifa_player_id = a.fifa_player_id and ast.match_num = a.match_num;;
+  dimension form_key {
+    label: 'Form Key'
+    type: 'text'
+    primary_key: true
+    hidden: true
+  }
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+  }
+  dimension name {
+    label: 'Player'
+    type: 'text'
+  }
+  dimension matchday {
+    label: 'Matchday'
+    type: 'number'
+    description: 'Group-stage matchday 1–3; null for knockout rounds (use stage / matchday_label there).'
+  }
+  dimension stage {
+    label: 'Stage'
+    type: 'text'
+  }
+  dimension matchday_label {
+    label: 'Matchday / Round'
+    type: 'text'
+    description: '"Matchday 1/2/3" for the group stage, else the knockout stage name — the per-matchday form axis / filter label.'
+  }
+  dimension kickoff_date {
+    label: 'Kickoff Date'
+    type: 'date'
+  }
+  dimension opponent_code {
+    label: 'Opponent Code'
+    type: 'text'
+  }
+  dimension goals {
+    label: 'Goals'
+    type: 'number'
+  }
+  dimension penalty_goals {
+    label: 'Penalty Goals'
+    type: 'number'
+  }
+  dimension assists {
+    label: 'Assists'
+    type: 'number'
+  }
+  dimension goal_contributions {
+    label: 'Goal Contributions'
+    type: 'number'
+    description: 'Goals + assists in this match.'
+  }
+  dimension yellows {
+    label: 'Yellow Cards'
+    type: 'number'
+  }
+  dimension reds {
+    label: 'Red Cards'
+    type: 'number'
+  }
+  dimension started {
+    label: 'Started'
+    type: 'truefalse'
+  }
+  dimension captain {
+    label: 'Captain'
+    type: 'truefalse'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_player_match_form.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_player_match_form.model.aml
@@ -2,7 +2,7 @@ Model wc_player_match_form {
   type: 'query'
   label: 'Player Match Form'
   description: 'One row per (player, match) the player appeared in: goals / assists / G+A / cards and whether they started, tagged with the match\'s matchday, stage, kickoff date and opponent. This is the per-matchday breakdown behind the tournament-total wc_player_stats — it lets the dashboard chart a player\'s form across matchdays or filter the Players tab to a single matchday. Appearances are the base (from lineups), so a player who featured without scoring still has a row.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_lineups, wc_events, wc_matches, wc_players]
   query: @sql
     with apps as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_player_stats.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_player_stats.model.aml
@@ -2,7 +2,7 @@ Model wc_player_stats {
   type: 'query'
   label: 'Player Stats'
   description: 'One row per squad player with tournament output aggregated from the event stream + lineups: goals (incl. penalties), assists (goal-event assist provider), goal contributions (G+A), appearances, starts, captaincies, and cards. Ranks (goals_rank, ga_rank) are window functions over the whole field — the Golden Boot / playmaker order. Goals come from events (type 0 open play, 41 penalty), the same source wc_scorers is derived from.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_players, wc_events, wc_lineups, wc_matches]
   query: @sql
     with apps as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_player_stats.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_player_stats.model.aml
@@ -1,0 +1,197 @@
+Model wc_player_stats {
+  type: 'query'
+  label: 'Player Stats'
+  description: 'One row per squad player with tournament output aggregated from the event stream + lineups: goals (incl. penalties), assists (goal-event assist provider), goal contributions (G+A), appearances, starts, captaincies, and cards. Ranks (goals_rank, ga_rank) are window functions over the whole field — the Golden Boot / playmaker order. Goals come from events (type 0 open play, 41 penalty), the same source wc_scorers is derived from.'
+  data_source_name: 'demodb'
+  models: [wc_players, wc_events, wc_lineups, wc_matches]
+  query: @sql
+    with apps as (
+      select {{ #l.fifa_player_id }} as fifa_player_id,
+        count(*) as apps,
+        count(*) filter (where {{ #l.is_starter }}) as starts,
+        bool_or({{ #l.is_captain }}) as ever_captain
+      from {{ #wc_lineups as l }}
+      group by {{ #l.fifa_player_id }}
+    ),
+    ev as (
+      select {{ #e.fifa_player_id }} as fifa_player_id,
+        count(*) filter (where {{ #e.type }} in (0, 41)) as goals,
+        count(*) filter (where {{ #e.type }} = 41) as penalty_goals,
+        count(*) filter (where {{ #e.type }} = 2) as yellows,
+        count(*) filter (where {{ #e.type }} = 3) as reds
+      from {{ #wc_events as e }}
+      where {{ #e.fifa_player_id }} is not null
+      group by {{ #e.fifa_player_id }}
+    ),
+    ast as (
+      select {{ #ea.assist_player_id }} as fifa_player_id, count(*) as assists
+      from {{ #wc_events as ea }}
+      where {{ #ea.type }} in (0, 41) and {{ #ea.assist_player_id }} is not null
+      group by {{ #ea.assist_player_id }}
+    ),
+    gd as (
+      select {{ #e3.fifa_player_id }} as fifa_player_id,
+        string_agg(
+          '<li><b>' || {{ #e3.match_minute }} || '</b> vs ' ||
+          (case when {{ #e3.team_code }} = {{ #m.home_code }} then {{ #m.away_code }} else {{ #m.home_code }} end) ||
+          (case when {{ #e3.type }} = 41 then ' &middot; pen' else '' end) || '</li>',
+          '' order by {{ #m.match_num }}
+        ) as goal_log_html,
+        -- goal-mouth placement dots for the popover: only goals that carry FIFA coords contribute,
+        -- so this is NULL for players with no placed goal (the section then hides). Calibration maps
+        -- goal_x [33..69] across the posts and goal_y [0..46] from ground up, inverted into the 120x56
+        -- SVG frame (ground line y=52, crossbar y=8). Tune the four bounds against the render.
+        string_agg(
+          case when {{ #e3.goal_x }} is not null and {{ #e3.goal_y }} is not null then
+            '<circle cx="' || round(10 + (least(greatest({{ #e3.goal_x }}, 33), 69) - 33) / 36.0 * 100, 1)
+            || '" cy="' || round(52 - least(greatest({{ #e3.goal_y }}, 0), 46) / 46.0 * 44, 1)
+            || '" r="3.4" class="gp"/>'
+          end,
+          '' order by {{ #m.match_num }}
+        ) as goal_placement_svg
+      from {{ #wc_events as e3 }} join {{ #wc_matches as m }} on {{ #m.match_num }} = {{ #e3.match_num }}
+      where {{ #e3.type }} in (0, 41)
+      group by {{ #e3.fifa_player_id }}
+    )
+    select
+      {{ #p.fifa_player_id }} as fifa_player_id,
+      {{ #p.name }} as name,
+      {{ #p.team_code }} as team_code,
+      {{ #p.shirt_number }} as shirt_number,
+      {{ #p.position }} as position,
+      {{ #p.picture_url }} as picture_url,
+      case {{ #p.position }} when 0 then 'GK' when 1 then 'DF' when 2 then 'MF' when 3 then 'FW' else '—' end as position_group,
+      coalesce(ev.goals, 0) as goals,
+      coalesce(ev.penalty_goals, 0) as penalty_goals,
+      coalesce(ast.assists, 0) as assists,
+      coalesce(ev.goals, 0) + coalesce(ast.assists, 0) as goal_contributions,
+      coalesce(a.apps, 0) as apps,
+      coalesce(a.starts, 0) as starts,
+      coalesce(a.ever_captain, false) as ever_captain,
+      coalesce(ev.yellows, 0) as yellows,
+      coalesce(ev.reds, 0) as reds,
+      rank() over (order by coalesce(ev.goals, 0) desc) as goals_rank,
+      rank() over (order by coalesce(ast.assists, 0) desc) as assists_rank,
+      rank() over (order by coalesce(ev.goals, 0) + coalesce(ast.assists, 0) desc) as ga_rank,
+      -- bar length relative to the current leader (the race ladder fill); the viz has no
+      -- cross-row max, so the proportion is resolved here. nullif guards an all-zero field.
+      round(coalesce(ev.goals, 0)::numeric / nullif(max(coalesce(ev.goals, 0)) over (), 0) * 100, 1) as goals_bar_pct,
+      round(coalesce(ast.assists, 0)::numeric / nullif(max(coalesce(ast.assists, 0)) over (), 0) * 100, 1) as assists_bar_pct,
+      case when coalesce(ev.goals, 0) + coalesce(ast.assists, 0) >= 3 then 1
+           when coalesce(ev.goals, 0) + coalesce(ast.assists, 0) = 2 then 2
+           else 3 end as card_tier,
+      gd.goal_log_html as goal_log_html,
+      gd.goal_placement_svg as goal_placement_svg
+    from {{ #wc_players as p }}
+    left join ev on ev.fifa_player_id = {{ #p.fifa_player_id }}
+    left join ast on ast.fifa_player_id = {{ #p.fifa_player_id }}
+    left join apps a on a.fifa_player_id = {{ #p.fifa_player_id }}
+    left join gd on gd.fifa_player_id = {{ #p.fifa_player_id }};;
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    primary_key: true
+  }
+  dimension name {
+    label: 'Player'
+    type: 'text'
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+  }
+  dimension shirt_number {
+    label: 'Shirt Number'
+    type: 'number'
+  }
+  dimension position {
+    label: 'Position Code'
+    type: 'number'
+    hidden: true
+  }
+  dimension picture_url {
+    label: 'Picture URL'
+    type: 'text'
+  }
+  dimension position_group {
+    label: 'Position Group'
+    type: 'text'
+  }
+  dimension goals {
+    label: 'Goals'
+    type: 'number'
+  }
+  dimension penalty_goals {
+    label: 'Penalty Goals'
+    type: 'number'
+  }
+  dimension assists {
+    label: 'Assists'
+    type: 'number'
+  }
+  dimension goal_contributions {
+    label: 'Goal Contributions'
+    type: 'number'
+    description: 'Goals + assists (G+A) — the gallery hero metric.'
+  }
+  dimension apps {
+    label: 'Appearances'
+    type: 'number'
+  }
+  dimension starts {
+    label: 'Starts'
+    type: 'number'
+  }
+  dimension ever_captain {
+    label: 'Has Captained'
+    type: 'truefalse'
+  }
+  dimension yellows {
+    label: 'Yellow Cards'
+    type: 'number'
+  }
+  dimension reds {
+    label: 'Red Cards'
+    type: 'number'
+  }
+  dimension goals_rank {
+    label: 'Goals Rank'
+    type: 'number'
+    description: 'Golden Boot rank over the whole field (ties share a rank).'
+  }
+  dimension assists_rank {
+    label: 'Assists Rank'
+    type: 'number'
+    description: 'Playmaker rank over the whole field (ties share a rank).'
+  }
+  dimension ga_rank {
+    label: 'G+A Rank'
+    type: 'number'
+  }
+  dimension goals_bar_pct {
+    label: 'Goals Bar %'
+    type: 'number'
+    description: 'Goals as a percentage of the leader\'s goals — the Golden Boot ladder fill width.'
+  }
+  dimension assists_bar_pct {
+    label: 'Assists Bar %'
+    type: 'number'
+    description: 'Assists as a percentage of the leader\'s assists — the Playmaker ladder fill width.'
+  }
+  dimension card_tier {
+    label: 'Card Tier'
+    type: 'number'
+    description: 'FUT card tier by G+A: 1 = gold (3+), 2 = silver (2), 3 = bronze (1). Drives the t{n} class shared with the boot podium.'
+  }
+  dimension goal_log_html {
+    label: 'Goal Log HTML'
+    type: 'text'
+    description: 'Pre-built <li> list of this player\'s goals (minute vs opponent, pen marker) for the card-back popover; null for non-scorers.'
+  }
+  dimension goal_placement_svg {
+    label: 'Goal Placement SVG'
+    type: 'text'
+    description: 'Pre-built <circle> dots (one per goal that carries FIFA goal-mouth coords) for the popover goal map; null when the player has no placed goal, so the map section hides.'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_players.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_players.model.aml
@@ -2,7 +2,7 @@ Model wc_players {
   type: 'table'
   label: 'Players'
   description: 'World Cup 2026 squad players (populated by live sync from match-detail squads).'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension fifa_player_id {
     label: 'FIFA Player Id'
     type: 'text'
@@ -52,5 +52,5 @@ Model wc_players {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_players"'
+  table_name: '"public"."wc_players"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_players.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_players.model.aml
@@ -1,0 +1,56 @@
+Model wc_players {
+  type: 'table'
+  label: 'Players'
+  description: 'World Cup 2026 squad players (populated by live sync from match-detail squads).'
+  data_source_name: 'demodb'
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_player_id }};;
+    primary_key: true
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension name {
+    label: 'Player'
+    type: 'text'
+    definition: @sql {{ #SOURCE.name }};;
+  }
+  dimension shirt_number {
+    label: 'Shirt Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.shirt_number }};;
+  }
+  dimension position {
+    label: 'Position Code'
+    type: 'number'
+    definition: @sql {{ #SOURCE.position }};;
+  }
+  dimension picture_url {
+    label: 'Picture URL'
+    type: 'text'
+    definition: @sql {{ #SOURCE.picture_url }};;
+  }
+  dimension is_goalkeeper {
+    label: 'Is Goalkeeper'
+    type: 'truefalse'
+    definition: @aql wc_players.position == 0 ;;
+  }
+  dimension position_group {
+    label: 'Position Group'
+    type: 'text'
+    description: 'FIFA position code mapped to squad-sheet groups: 0=GK, 1=DF, 2=MF, 3=FW.'
+    definition: @aql case(
+      when: wc_players.position == 0, then: 'GK',
+      when: wc_players.position == 1, then: 'DF',
+      when: wc_players.position == 2, then: 'MF',
+      when: wc_players.position == 3, then: 'FW',
+      else: '—'
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_players"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_scorers.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_scorers.model.aml
@@ -2,7 +2,7 @@ Model wc_scorers {
   type: 'table'
   label: 'Scorers'
   description: 'Top-scorer leaderboard derived from the goal event stream (Golden Boot race).'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension fifa_player_id {
     label: 'FIFA Player Id'
     type: 'text'
@@ -36,5 +36,5 @@ Model wc_scorers {
     definition: @aql rank(order: wc_scorers.goals | desc()) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_scorers"'
+  table_name: '"public"."wc_scorers"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_scorers.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_scorers.model.aml
@@ -1,0 +1,40 @@
+Model wc_scorers {
+  type: 'table'
+  label: 'Scorers'
+  description: 'Top-scorer leaderboard derived from the goal event stream (Golden Boot race).'
+  data_source_name: 'demodb'
+  dimension fifa_player_id {
+    label: 'FIFA Player Id'
+    type: 'text'
+    definition: @sql {{ #SOURCE.fifa_player_id }};;
+    primary_key: true
+  }
+  dimension player_name {
+    label: 'Scorer'
+    type: 'text'
+    definition: @sql {{ #SOURCE.player_name }};;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension goals {
+    label: 'Goals'
+    type: 'number'
+    definition: @sql {{ #SOURCE.goals }};;
+  }
+  dimension penalty_goals {
+    label: 'Penalty Goals'
+    type: 'number'
+    definition: @sql {{ #SOURCE.penalty_goals }};;
+  }
+  dimension boot_rank {
+    label: 'Boot Rank'
+    type: 'number'
+    description: 'Golden Boot rank by goals across all scorers (ties share a rank; the next rank skips, e.g. 1,2,2,4).'
+    definition: @aql rank(order: wc_scorers.goals | desc()) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_scorers"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_aliases.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_aliases.model.aml
@@ -2,7 +2,7 @@ Model wc_team_aliases {
   type: 'table'
   label: 'Team Aliases'
   description: 'Every team code in WC history → display name + canonical (modern successor) code. Bridge between historical rollups and wc_teams.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension alias_code {
     label: 'Alias Code'
     type: 'text'
@@ -75,5 +75,5 @@ Model wc_team_aliases {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_team_aliases"'
+  table_name: '"public"."wc_team_aliases"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_aliases.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_aliases.model.aml
@@ -1,0 +1,79 @@
+Model wc_team_aliases {
+  type: 'table'
+  label: 'Team Aliases'
+  description: 'Every team code in WC history → display name + canonical (modern successor) code. Bridge between historical rollups and wc_teams.'
+  data_source_name: 'demodb'
+  dimension alias_code {
+    label: 'Alias Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.alias_code }};;
+    primary_key: true
+  }
+  dimension display_name {
+    label: 'Display Name'
+    type: 'text'
+    definition: @sql {{ #SOURCE.display_name }};;
+  }
+  dimension canonical_code {
+    label: 'Canonical Code'
+    type: 'text'
+    description: 'Modern FIFA code (FRG→GER, URS→RUS, …); NULL when no successor (GDR).'
+    definition: @sql {{ #SOURCE.canonical_code }};;
+  }
+  // ---- All-time entity rollup (FIFA / Wikipedia all-time-table convention) ----
+  // The history models are keyed by raw historical code; these dimensions collapse defunct
+  // nations onto their modern successor for all-time aggregation. Group every all-time stat on
+  // entity_code — NEVER on display_name: display_name carries the bare 3-letter code for most
+  // nations and a real name only for ~10 defunct ones, so grouping on it splits West Germany
+  // (3 titles) from Germany (1) and shows codes. canonical_code is the true successor key
+  // (FRG/GER→GER=4, URS/RUS→RUS, TCH/CZE→CZE, YUG/SCG/SRB→SRB); coalescing to alias_code keeps
+  // null-successor sides (East Germany) alive as their own entity instead of dropping to null.
+  dimension entity_code {
+    label: 'All-time Entity'
+    type: 'text'
+    description: 'Successor-rollup key for all-time history: canonical_code where it exists, else the alias code. Group all-time team stats on this.'
+    definition: @aql coalesce(wc_team_aliases.canonical_code, wc_team_aliases.alias_code) ;;
+  }
+  dimension entity_name {
+    label: 'All-time Team'
+    type: 'text'
+    description: 'Readable name for the all-time entity. Prefers the official 2026 name (canonical → wc_teams) so spellings stay canonical; falls back to a curated map of marquee nations the dataset has no name for (only 3-letter codes), then the alias display name. Constant per entity_code so grouping never splits a row.'
+    definition: @aql coalesce(
+      wc_teams.name,
+      case(
+        when: wc_team_aliases.entity_code == 'ITA', then: 'Italy',
+        when: wc_team_aliases.entity_code == 'RUS', then: 'Russia',
+        when: wc_team_aliases.entity_code == 'SRB', then: 'Serbia',
+        when: wc_team_aliases.entity_code == 'HUN', then: 'Hungary',
+        when: wc_team_aliases.entity_code == 'POL', then: 'Poland',
+        when: wc_team_aliases.entity_code == 'CHI', then: 'Chile',
+        when: wc_team_aliases.entity_code == 'BUL', then: 'Bulgaria',
+        when: wc_team_aliases.entity_code == 'PER', then: 'Peru',
+        when: wc_team_aliases.entity_code == 'DEN', then: 'Denmark',
+        when: wc_team_aliases.entity_code == 'GRE', then: 'Greece',
+        when: wc_team_aliases.entity_code == 'CMR', then: 'Cameroon',
+        when: wc_team_aliases.entity_code == 'CRC', then: 'Costa Rica',
+        when: wc_team_aliases.entity_code == 'IRL', then: 'Rep. of Ireland',
+        when: wc_team_aliases.entity_code == 'CHN', then: 'China PR',
+        when: wc_team_aliases.entity_code == 'CUB', then: 'Cuba',
+        when: wc_team_aliases.entity_code == 'HON', then: 'Honduras',
+        when: wc_team_aliases.entity_code == 'BOL', then: 'Bolivia',
+        when: wc_team_aliases.entity_code == 'ANG', then: 'Angola',
+        when: wc_team_aliases.entity_code == 'JAM', then: 'Jamaica',
+        when: wc_team_aliases.entity_code == 'ISR', then: 'Israel',
+        else: wc_team_aliases.display_name
+      )
+    ) ;;
+  }
+  dimension entity_flag {
+    label: 'All-time Flag'
+    type: 'text'
+    description: 'Flag for the all-time entity: official 2026 crest (canonical → wc_teams) where available, else the FIFA flag CDN templated on the entity code (resolves for any current federation; defunct codes 404 → hidden img).'
+    definition: @aql coalesce(
+      wc_teams.flag_url,
+      concat('https://api.fifa.com/api/v3/picture/flags-sq-4/', wc_team_aliases.entity_code)
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_team_aliases"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_match_results.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_match_results.model.aml
@@ -2,7 +2,7 @@ Model wc_team_match_results {
   type: 'table'
   label: 'Team Match Results'
   description: 'Canonical per-team grain: one row per team per finished match. Source for per-team metrics.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension team_code {
     label: 'Team Code'
     type: 'text'
@@ -96,5 +96,5 @@ Model wc_team_match_results {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_team_match_results"'
+  table_name: '"public"."wc_team_match_results"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_match_results.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_match_results.model.aml
@@ -1,0 +1,100 @@
+Model wc_team_match_results {
+  type: 'table'
+  label: 'Team Match Results'
+  description: 'Canonical per-team grain: one row per team per finished match. Source for per-team metrics.'
+  data_source_name: 'demodb'
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+    definition: @sql {{ #SOURCE.match_num }};;
+  }
+  dimension opponent_code {
+    label: 'Opponent Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.opponent_code }};;
+  }
+  dimension gf {
+    label: 'Goals For'
+    type: 'number'
+    definition: @sql {{ #SOURCE.gf }};;
+  }
+  dimension ga {
+    label: 'Goals Against'
+    type: 'number'
+    definition: @sql {{ #SOURCE.ga }};;
+  }
+  dimension result {
+    label: 'Result'
+    type: 'text'
+    definition: @sql {{ #SOURCE.result }};;
+  }
+  dimension clean_sheet {
+    label: 'Clean Sheet'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.clean_sheet }};;
+  }
+  dimension stage {
+    label: 'Stage'
+    type: 'text'
+    definition: @sql {{ #SOURCE.stage }};;
+  }
+  dimension kickoff_utc {
+    label: 'Kickoff (UTC)'
+    type: 'datetime'
+    definition: @sql {{ #SOURCE.kickoff_utc }};;
+  }
+  dimension result_label {
+    label: 'Result Label'
+    type: 'text'
+    definition: @aql case(
+      when: wc_team_match_results.result == 'W', then: 'Win',
+      when: wc_team_match_results.result == 'D', then: 'Draw',
+      when: wc_team_match_results.result == 'L', then: 'Loss',
+      else: '—'
+    ) ;;
+  }
+  dimension result_color {
+    label: 'Result Color'
+    type: 'text'
+    description: 'Driver field: form-chip color (win=green, draw=amber, loss=red).'
+    definition: @aql case(
+      when: wc_team_match_results.result == 'W', then: '#1FA36B',
+      when: wc_team_match_results.result == 'D', then: '#E0A23B',
+      when: wc_team_match_results.result == 'L', then: '#E5362B',
+      else: '#9AA4B2'
+    ) ;;
+  }
+  dimension points_earned {
+    label: 'Points Earned'
+    type: 'number'
+    definition: @aql case(
+      when: wc_team_match_results.result == 'W', then: 3,
+      when: wc_team_match_results.result == 'D', then: 1,
+      else: 0
+    ) ;;
+  }
+  // ---- Time / period drill (mirrors wc_matches): filter kickoff_date <= D for an "as of date D"
+  //      standings/form view; group on phase to split group-stage vs knockout per-team measures. ----
+  dimension kickoff_date {
+    label: 'Kickoff Date'
+    type: 'date'
+    description: 'Calendar day of kickoff (UTC). Filter to kickoff_date <= D and the per-team measures (points, goals, win rate, form) become cumulative "as of date D".'
+    definition: @aql date_trunc(wc_team_match_results.kickoff_utc, 'day') ;;
+  }
+  dimension phase {
+    label: 'Phase'
+    type: 'text'
+    description: 'Group stage vs Knockout — group on this to split per-team measures by phase.'
+    definition: @aql case(
+      when: wc_team_match_results.stage == 'group', then: 'Group stage',
+      else: 'Knockout'
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_team_match_results"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_next_h2h.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_next_h2h.model.aml
@@ -1,0 +1,226 @@
+Model wc_team_next_h2h {
+  type: 'query'
+  label: 'Next Opponent H2H'
+  description: 'Per team: the next unplayed fixture (opponent, kickoff, venue) joined to every historical World Cup meeting against that opponent, scored from the team\'s perspective. One row per past meeting; teams that never met their next opponent keep a single row with null meeting columns. Exists because "home OR away" cannot be expressed through the dataset filter graph.'
+  data_source_name: 'demodb'
+  models: [wc_matches, wc_history_matches, wc_teams]
+  query: @sql
+    with sides as (
+      select {{ #m.match_num }} as match_num, {{ #m.home_code }} as team_code, {{ #m.away_code }} as opponent_code,
+             {{ #m.kickoff_utc }} as kickoff_utc, {{ #m.status }} as status, {{ #m.stage }} as stage,
+             {{ #m.group_code }} as group_code, {{ #m.venue }} as venue, {{ #m.city }} as city
+      from {{ #wc_matches as m }}
+      union all
+      select {{ #m2.match_num }}, {{ #m2.away_code }}, {{ #m2.home_code }},
+             {{ #m2.kickoff_utc }}, {{ #m2.status }}, {{ #m2.stage }},
+             {{ #m2.group_code }}, {{ #m2.venue }}, {{ #m2.city }}
+      from {{ #wc_matches as m2 }}
+    ),
+    next_fixture as (
+      select distinct on (team_code) *
+      from sides
+      where status <> 'FT' and team_code is not null and opponent_code is not null
+      order by team_code, kickoff_utc
+    ),
+    hist as (
+      select {{ #h.fifa_match_id }} as h2h_match_id,
+             {{ #h.home_canonical }} as h_home, {{ #h.away_canonical }} as h_away,
+             {{ #h.year }} as year, {{ #h.stage_name }} as stage_name, {{ #h.match_date }} as match_date,
+             {{ #h.home_score }} as home_score, {{ #h.away_score }} as away_score,
+             {{ #h.home_pen }} as home_pen, {{ #h.away_pen }} as away_pen
+      from {{ #wc_history_matches as h }}
+    )
+    select
+      nf.team_code || '-' || coalesce(hh.h2h_match_id, 'none') as h2h_key,
+      nf.team_code,
+      nf.opponent_code,
+      {{ #opp.name }} as opponent_name,
+      {{ #opp.flag_url }} as opponent_flag,
+      {{ #opp.color_hex }} as opponent_color,
+      nf.match_num as next_match_num,
+      nf.kickoff_utc as next_kickoff,
+      nf.stage as next_stage,
+      nf.group_code as next_group,
+      nf.venue as next_venue,
+      nf.city as next_city,
+      hh.h2h_match_id,
+      hh.year,
+      (hh.year)::text as year_text,
+      hh.stage_name,
+      hh.match_date,
+      case when hh.h_home = nf.team_code then hh.home_score else hh.away_score end as team_score,
+      case when hh.h_home = nf.team_code then hh.away_score else hh.home_score end as opp_score,
+      case when hh.h_home = nf.team_code then hh.home_pen else hh.away_pen end as team_pen,
+      case when hh.h_home = nf.team_code then hh.away_pen else hh.home_pen end as opp_pen,
+      case when hh.h2h_match_id is null then null
+           when (case when hh.h_home = nf.team_code then hh.home_score else hh.away_score end)
+              > (case when hh.h_home = nf.team_code then hh.away_score else hh.home_score end) then 'W'
+           when (case when hh.h_home = nf.team_code then hh.home_score else hh.away_score end)
+              < (case when hh.h_home = nf.team_code then hh.away_score else hh.home_score end) then 'L'
+           else 'D' end as result,
+      case when hh.h2h_match_id is null then null
+           else (case when hh.h_home = nf.team_code then hh.home_score else hh.away_score end)::text
+                || '–'
+                || (case when hh.h_home = nf.team_code then hh.away_score else hh.home_score end)::text
+                || case when coalesce(hh.home_pen, 0) + coalesce(hh.away_pen, 0) > 0
+                        then ' (' || (case when hh.h_home = nf.team_code then hh.home_pen else hh.away_pen end)::text
+                             || '–'
+                             || (case when hh.h_home = nf.team_code then hh.away_pen else hh.home_pen end)::text
+                             || ' p)'
+                        else '' end
+           end as score_label
+    from next_fixture nf
+    left join {{ #wc_teams as opp }} on {{ #opp.code }} = nf.opponent_code
+    left join hist hh on (hh.h_home = nf.team_code and hh.h_away = nf.opponent_code)
+                      or (hh.h_home = nf.opponent_code and hh.h_away = nf.team_code);;
+  dimension h2h_key {
+    label: 'H2H Key'
+    type: 'text'
+    primary_key: true
+    hidden: true
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+  }
+  dimension opponent_code {
+    label: 'Opponent Code'
+    type: 'text'
+  }
+  dimension opponent_name {
+    label: 'Opponent'
+    type: 'text'
+  }
+  dimension opponent_flag {
+    label: 'Opponent Flag URL'
+    type: 'text'
+  }
+  dimension opponent_color {
+    label: 'Opponent Color'
+    type: 'text'
+  }
+  dimension next_match_num {
+    label: 'Next Match Number'
+    type: 'number'
+  }
+  dimension next_kickoff {
+    label: 'Next Kickoff (UTC)'
+    type: 'datetime'
+  }
+  dimension next_stage {
+    label: 'Next Stage'
+    type: 'text'
+  }
+  dimension next_group {
+    label: 'Next Group'
+    type: 'text'
+  }
+  dimension next_venue {
+    label: 'Next Venue'
+    type: 'text'
+  }
+  dimension next_city {
+    label: 'Next City'
+    type: 'text'
+  }
+  dimension h2h_match_id {
+    label: 'H2H Match Id'
+    type: 'text'
+    hidden: true
+  }
+  dimension year {
+    label: 'Edition'
+    type: 'number'
+  }
+  dimension year_text {
+    label: 'Edition Label'
+    type: 'text'
+    description: 'Ungrouped edition year for display ("1998", never "1,998") — cast in SQL because AQL cast() reapplies digit grouping.'
+  }
+  dimension stage_name {
+    label: 'Stage'
+    type: 'text'
+  }
+  dimension match_date {
+    label: 'Meeting Date'
+    type: 'datetime'
+  }
+  dimension team_score {
+    label: 'Team Score'
+    type: 'number'
+  }
+  dimension opp_score {
+    label: 'Opponent Score'
+    type: 'number'
+  }
+  dimension team_pen {
+    label: 'Team Pens'
+    type: 'number'
+  }
+  dimension opp_pen {
+    label: 'Opponent Pens'
+    type: 'number'
+  }
+  dimension result {
+    label: 'Result'
+    type: 'text'
+  }
+  dimension score_label {
+    label: 'Scoreline'
+    type: 'text'
+    description: 'Team-perspective scoreline, e.g. "2–1" or "1–1 (4–3 p)".'
+  }
+  dimension result_color {
+    label: 'Result Color'
+    type: 'text'
+    description: 'Driver field: meeting chip color (win=green, draw=amber, loss=red, never-met=grey).'
+    definition: @aql case(
+      when: wc_team_next_h2h.result == 'W', then: '#1FA36B',
+      when: wc_team_next_h2h.result == 'D', then: '#E0A23B',
+      when: wc_team_next_h2h.result == 'L', then: '#E5362B',
+      else: '#9AA4B2'
+    ) ;;
+  }
+  dimension next_ko_label {
+    label: 'Next Kickoff Label'
+    type: 'text'
+    description: 'Pre-formatted kickoff for card display, e.g. "Sat 13 Jun · 19:00" (UTC).'
+    definition: @aql date_format(wc_team_next_h2h.next_kickoff, '%a %d %b · %H:%M') ;;
+  }
+  dimension next_stage_label {
+    label: 'Next Stage Label'
+    type: 'text'
+    definition: @aql case(
+      when: wc_team_next_h2h.next_stage == 'group', then: concat('Group ', wc_team_next_h2h.next_group),
+      when: wc_team_next_h2h.next_stage == 'r32', then: 'Round of 32',
+      when: wc_team_next_h2h.next_stage == 'r16', then: 'Round of 16',
+      when: wc_team_next_h2h.next_stage == 'qf', then: 'Quarter-final',
+      when: wc_team_next_h2h.next_stage == 'sf', then: 'Semi-final',
+      when: wc_team_next_h2h.next_stage == 'third_place', then: 'Third place',
+      when: wc_team_next_h2h.next_stage == 'final', then: 'Final',
+      else: wc_team_next_h2h.next_stage
+    ) ;;
+  }
+  measure meetings {
+    label: 'Previous Meetings'
+    type: 'number'
+    description: 'Historical World Cup meetings vs the next opponent (null meeting rows do not count).'
+    definition: @aql count(wc_team_next_h2h.h2h_match_id) ;;
+  }
+  measure h2h_wins {
+    label: 'H2H Wins'
+    type: 'number'
+    definition: @aql count_if(wc_team_next_h2h.result == 'W') ;;
+  }
+  measure h2h_draws {
+    label: 'H2H Draws'
+    type: 'number'
+    definition: @aql count_if(wc_team_next_h2h.result == 'D') ;;
+  }
+  measure h2h_losses {
+    label: 'H2H Losses'
+    type: 'number'
+    definition: @aql count_if(wc_team_next_h2h.result == 'L') ;;
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_next_h2h.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_next_h2h.model.aml
@@ -2,7 +2,7 @@ Model wc_team_next_h2h {
   type: 'query'
   label: 'Next Opponent H2H'
   description: 'Per team: the next unplayed fixture (opponent, kickoff, venue) joined to every historical World Cup meeting against that opponent, scored from the team\'s perspective. One row per past meeting; teams that never met their next opponent keep a single row with null meeting columns. Exists because "home OR away" cannot be expressed through the dataset filter graph.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_matches, wc_history_matches, wc_teams]
   query: @sql
     with sides as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_rating_movement.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_rating_movement.model.aml
@@ -1,0 +1,119 @@
+Model wc_team_rating_movement {
+  type: 'query'
+  label: 'Team Rating Movement'
+  description: 'One row per team comparing the LATEST Elo snapshot against the previous snapshot and the nearest snapshot ~30 days earlier, with rank movement. Period comparison cannot be expressed as an AQL dimension (it needs a row-offset lag over snapshot dates), so it is materialised here. Signed delta labels/colours are built in SQL (AQL has no signed to_char). Snapshots are monthly since 2024-07 then daily during the tournament, so "previous" tightens to day-over-day once play starts.'
+  data_source_name: 'demodb'
+  models: [wc_team_ratings]
+  query: @sql
+    with snaps as (
+      select {{ #r.team_code }} as team_code, {{ #r.snapshot_date }} as snapshot_date, {{ #r.elo }} as elo,
+        row_number() over (partition by {{ #r.team_code }} order by {{ #r.snapshot_date }} desc) as rn
+      from {{ #wc_team_ratings as r }}
+    ),
+    latest as (select team_code, elo, snapshot_date from snaps where rn = 1),
+    prev as (select team_code, elo, snapshot_date from snaps where rn = 2),
+    d30 as (
+      select distinct on (s.team_code) s.team_code, s.elo, s.snapshot_date
+      from snaps s
+      join latest l on l.team_code = s.team_code
+      where s.snapshot_date <= l.snapshot_date - interval '30 days'
+      order by s.team_code, s.snapshot_date desc
+    ),
+    joined as (
+      select
+        l.team_code,
+        l.elo, l.snapshot_date as rating_date,
+        p.elo as elo_prev, p.snapshot_date as prev_date,
+        d.elo as elo_30d, d.snapshot_date as date_30d,
+        round(l.elo - p.elo, 1) as delta_prev,
+        round(l.elo - coalesce(d.elo, p.elo), 1) as delta_30d,
+        rank() over (order by l.elo desc) as elo_rank,
+        rank() over (order by p.elo desc nulls last) as elo_rank_prev
+      from latest l
+      left join prev p on p.team_code = l.team_code
+      left join d30 d on d.team_code = l.team_code
+    )
+    select
+      team_code, elo, rating_date, elo_prev, prev_date, elo_30d, date_30d,
+      delta_prev, delta_30d, elo_rank, elo_rank_prev,
+      (elo_rank_prev - elo_rank) as rank_delta,
+      case when delta_30d > 0.05 then '▲ ' || to_char(delta_30d, 'FM990.0')
+           when delta_30d < -0.05 then '▼ ' || to_char(abs(delta_30d), 'FM990.0')
+           else '· 0' end as delta_30d_label,
+      case when delta_30d > 0.05 then '#1FA36B'
+           when delta_30d < -0.05 then '#E5362B'
+           else '#9AA4B2' end as delta_30d_color,
+      case when (elo_rank_prev - elo_rank) > 0 then '▲ ' || (elo_rank_prev - elo_rank)::text
+           when (elo_rank_prev - elo_rank) < 0 then '▼ ' || abs(elo_rank_prev - elo_rank)::text
+           else '·' end as rank_delta_label
+    from joined;;
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    primary_key: true
+  }
+  dimension elo {
+    label: 'Elo (latest)'
+    type: 'number'
+  }
+  dimension rating_date {
+    label: 'Rating As Of'
+    type: 'date'
+  }
+  dimension elo_prev {
+    label: 'Elo (previous snapshot)'
+    type: 'number'
+  }
+  dimension prev_date {
+    label: 'Previous Snapshot Date'
+    type: 'date'
+  }
+  dimension elo_30d {
+    label: 'Elo (~30d ago)'
+    type: 'number'
+    description: 'Elo at the nearest snapshot at least 30 days before the latest; null very early in the backfill (falls back to the previous snapshot in delta_30d).'
+  }
+  dimension date_30d {
+    label: '~30d-ago Snapshot Date'
+    type: 'date'
+  }
+  dimension delta_prev {
+    label: 'Elo Δ vs previous'
+    type: 'number'
+  }
+  dimension delta_30d {
+    label: 'Elo Δ vs ~30d'
+    type: 'number'
+    description: 'Latest Elo minus the ~30-days-ago Elo (or the previous snapshot when no 30-day-old one exists yet).'
+  }
+  dimension elo_rank {
+    label: 'Elo Rank (latest)'
+    type: 'number'
+    description: 'Rank among the 48 teams by latest Elo (1 = strongest).'
+  }
+  dimension elo_rank_prev {
+    label: 'Elo Rank (previous)'
+    type: 'number'
+  }
+  dimension rank_delta {
+    label: 'Rank Movement'
+    type: 'number'
+    description: 'Positions climbed since the previous snapshot (positive = moved up the table).'
+  }
+  dimension delta_30d_label {
+    label: 'Elo Δ Label'
+    type: 'text'
+    description: 'Driver field: signed 30-day Elo move, e.g. "▲ 12.4" / "▼ 5.0" / "· 0".'
+  }
+  dimension delta_30d_color {
+    label: 'Elo Δ Color'
+    type: 'text'
+    description: 'Driver field: rising green / falling red / flat grey.'
+  }
+  dimension rank_delta_label {
+    label: 'Rank Movement Label'
+    type: 'text'
+    description: 'Driver field: signed rank move vs previous snapshot, e.g. "▲ 2" / "▼ 1" / "·".'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_rating_movement.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_rating_movement.model.aml
@@ -2,7 +2,7 @@ Model wc_team_rating_movement {
   type: 'query'
   label: 'Team Rating Movement'
   description: 'One row per team comparing the LATEST Elo snapshot against the previous snapshot and the nearest snapshot ~30 days earlier, with rank movement. Period comparison cannot be expressed as an AQL dimension (it needs a row-offset lag over snapshot dates), so it is materialised here. Signed delta labels/colours are built in SQL (AQL has no signed to_char). Snapshots are monthly since 2024-07 then daily during the tournament, so "previous" tightens to day-over-day once play starts.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_team_ratings]
   query: @sql
     with snaps as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_ratings.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_ratings.model.aml
@@ -1,0 +1,43 @@
+Model wc_team_ratings {
+  type: 'table'
+  label: 'Team Ratings'
+  description: 'Elo snapshots for the 48 teams (monthly since 2024-07, daily during the tournament). Computed by the worldcup-sync nightly job.'
+  data_source_name: 'demodb'
+  dimension rating_key {
+    label: 'Rating Key'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }} || '-' || {{ #SOURCE.snapshot_date }};;
+    primary_key: true
+    hidden: true
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+  }
+  dimension snapshot_date {
+    label: 'Snapshot Date'
+    type: 'date'
+    definition: @sql {{ #SOURCE.snapshot_date }};;
+  }
+  dimension snapshot_label {
+    label: 'Snapshot Label'
+    type: 'text'
+    description: 'Pre-formatted snapshot date for trend-axis / picker display, e.g. "Jun 2026".'
+    definition: @aql date_format(wc_team_ratings.snapshot_date, '%b %Y') ;;
+  }
+  dimension elo {
+    label: 'Elo'
+    type: 'number'
+    definition: @sql {{ #SOURCE.elo }};;
+  }
+  dimension fifa_rank {
+    label: 'FIFA Rank'
+    type: 'number'
+    description: 'Currently 100% NULL in the source (ETL placeholder, never populated) — hidden until a FIFA-rank feed exists. Use wc_team_snapshot.elo_rank for a live ranking instead.'
+    hidden: true
+    definition: @sql {{ #SOURCE.fifa_rank }};;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_team_ratings"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_ratings.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_ratings.model.aml
@@ -2,7 +2,7 @@ Model wc_team_ratings {
   type: 'table'
   label: 'Team Ratings'
   description: 'Elo snapshots for the 48 teams (monthly since 2024-07, daily during the tournament). Computed by the worldcup-sync nightly job.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension rating_key {
     label: 'Rating Key'
     type: 'text'
@@ -39,5 +39,5 @@ Model wc_team_ratings {
     definition: @sql {{ #SOURCE.fifa_rank }};;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_team_ratings"'
+  table_name: '"public"."wc_team_ratings"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_running_standings.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_running_standings.model.aml
@@ -2,7 +2,7 @@ Model wc_team_running_standings {
   type: 'query'
   label: 'Running Standings'
   description: 'One row per (team, finished match) carrying the team\'s running totals AFTER that match — cumulative points, goals for/against, goal difference and games played — ordered by kickoff. This is the matchday-over-matchday movement series behind the current-only wc_group_standings: chart cum_points against matchday to show how a group table built up. Running totals are a window over ordered rows, not an AQL dimension, so they are materialised here.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_team_match_results, wc_matches]
   query: @sql
     with base as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_running_standings.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_running_standings.model.aml
@@ -1,0 +1,93 @@
+Model wc_team_running_standings {
+  type: 'query'
+  label: 'Running Standings'
+  description: 'One row per (team, finished match) carrying the team\'s running totals AFTER that match — cumulative points, goals for/against, goal difference and games played — ordered by kickoff. This is the matchday-over-matchday movement series behind the current-only wc_group_standings: chart cum_points against matchday to show how a group table built up. Running totals are a window over ordered rows, not an AQL dimension, so they are materialised here.'
+  data_source_name: 'demodb'
+  models: [wc_team_match_results, wc_matches]
+  query: @sql
+    with base as (
+      select {{ #t.team_code }} as team_code, {{ #t.match_num }} as match_num,
+        {{ #t.gf }} as gf, {{ #t.ga }} as ga, {{ #t.result }} as result, {{ #t.kickoff_utc }} as kickoff_utc,
+        case {{ #t.result }} when 'W' then 3 when 'D' then 1 else 0 end as pts,
+        {{ #m.group_code }} as group_code, {{ #m.matchday }} as matchday, {{ #m.stage }} as stage
+      from {{ #wc_team_match_results as t }}
+      join {{ #wc_matches as m }} on {{ #m.match_num }} = {{ #t.match_num }}
+    )
+    select
+      team_code || '-' || match_num as standing_key,
+      team_code, match_num, group_code, matchday, stage,
+      kickoff_utc::date as kickoff_date,
+      pts as match_points, gf as match_gf, ga as match_ga,
+      sum(pts) over w as cum_points,
+      sum(gf) over w as cum_gf,
+      sum(ga) over w as cum_ga,
+      sum(gf - ga) over w as cum_gd,
+      row_number() over w as games_played
+    from base
+    window w as (partition by team_code order by kickoff_utc, match_num rows between unbounded preceding and current row);;
+  dimension standing_key {
+    label: 'Standing Key'
+    type: 'text'
+    primary_key: true
+    hidden: true
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+  }
+  dimension match_num {
+    label: 'Match Number'
+    type: 'number'
+  }
+  dimension group_code {
+    label: 'Group'
+    type: 'text'
+  }
+  dimension matchday {
+    label: 'Matchday'
+    type: 'number'
+    description: 'Group-stage matchday 1–3 (null for knockouts) — the x-axis for the cumulative points line.'
+  }
+  dimension stage {
+    label: 'Stage'
+    type: 'text'
+  }
+  dimension kickoff_date {
+    label: 'Kickoff Date'
+    type: 'date'
+  }
+  dimension match_points {
+    label: 'Points (this match)'
+    type: 'number'
+  }
+  dimension match_gf {
+    label: 'Goals For (this match)'
+    type: 'number'
+  }
+  dimension match_ga {
+    label: 'Goals Against (this match)'
+    type: 'number'
+  }
+  dimension cum_points {
+    label: 'Cumulative Points'
+    type: 'number'
+    description: 'Running points after this match — the standings-movement line value.'
+  }
+  dimension cum_gf {
+    label: 'Cumulative Goals For'
+    type: 'number'
+  }
+  dimension cum_ga {
+    label: 'Cumulative Goals Against'
+    type: 'number'
+  }
+  dimension cum_gd {
+    label: 'Cumulative Goal Difference'
+    type: 'number'
+  }
+  dimension games_played {
+    label: 'Games Played'
+    type: 'number'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_snapshot.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_snapshot.model.aml
@@ -2,7 +2,7 @@ Model wc_team_snapshot {
   type: 'query'
   label: 'Team Snapshot'
   description: 'One row per team: the LATEST Elo + FIFA rank snapshot and the LATEST Monte Carlo run probabilities. Exists because max()-style metrics over wc_team_ratings/wc_advance_probs mix dates; this pins every value to its most recent date.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_team_ratings, wc_advance_probs]
   query: @sql
     with latest_rating as (

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_team_snapshot.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_team_snapshot.model.aml
@@ -1,0 +1,136 @@
+Model wc_team_snapshot {
+  type: 'query'
+  label: 'Team Snapshot'
+  description: 'One row per team: the LATEST Elo + FIFA rank snapshot and the LATEST Monte Carlo run probabilities. Exists because max()-style metrics over wc_team_ratings/wc_advance_probs mix dates; this pins every value to its most recent date.'
+  data_source_name: 'demodb'
+  models: [wc_team_ratings, wc_advance_probs]
+  query: @sql
+    with latest_rating as (
+      select distinct on ({{ #r.team_code }})
+        {{ #r.team_code }} as team_code,
+        {{ #r.elo }} as elo,
+        {{ #r.snapshot_date }} as rating_date
+      from {{ #wc_team_ratings as r }}
+      order by {{ #r.team_code }}, {{ #r.snapshot_date }} desc
+    ),
+    latest_rank as (
+      -- fifa_rank only rides on some snapshots (monthly publish), so take the freshest non-null one
+      select distinct on ({{ #r2.team_code }})
+        {{ #r2.team_code }} as team_code,
+        {{ #r2.fifa_rank }} as fifa_rank
+      from {{ #wc_team_ratings as r2 }}
+      where {{ #r2.fifa_rank }} is not null
+      order by {{ #r2.team_code }}, {{ #r2.snapshot_date }} desc
+    ),
+    latest_prob as (
+      select distinct on ({{ #p.team_code }})
+        {{ #p.team_code }} as team_code,
+        {{ #p.run_date }} as run_date,
+        {{ #p.p_champion }} as p_champion,
+        {{ #p.p_final }} as p_final,
+        {{ #p.p_sf }} as p_sf,
+        {{ #p.p_qf }} as p_qf,
+        {{ #p.p_r16 }} as p_r16,
+        {{ #p.p_r32 }} as p_r32
+      from {{ #wc_advance_probs as p }}
+      order by {{ #p.team_code }}, {{ #p.run_date }} desc
+    )
+    select
+      coalesce(lr.team_code, lp.team_code) as team_code,
+      lr.elo, lk.fifa_rank, lr.rating_date,
+      rank() over (order by lr.elo desc nulls last) as elo_rank,
+      lp.run_date, lp.p_champion, lp.p_final, lp.p_sf, lp.p_qf, lp.p_r16, lp.p_r32
+    from latest_rating lr
+    full outer join latest_prob lp on lp.team_code = lr.team_code
+    left join latest_rank lk on lk.team_code = coalesce(lr.team_code, lp.team_code);;
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    primary_key: true
+  }
+  dimension elo {
+    label: 'Elo (latest)'
+    type: 'number'
+  }
+  dimension fifa_rank {
+    label: 'FIFA Rank (latest)'
+    type: 'number'
+    description: 'Currently all-null in the source table (ETL placeholder) — do not display until populated.'
+    hidden: true
+  }
+  dimension elo_rank {
+    label: 'Elo Rank'
+    type: 'number'
+    description: 'Rank among the 48 qualified teams by latest Elo (1 = strongest).'
+  }
+  dimension rating_date {
+    label: 'Rating As Of'
+    type: 'date'
+  }
+  dimension run_date {
+    label: 'Sim Run Date'
+    type: 'date'
+  }
+  dimension p_champion {
+    label: 'P Champion (latest)'
+    type: 'number'
+  }
+  dimension p_champion_pct {
+    label: 'Title Odds %'
+    type: 'number'
+    description: 'p_champion × 100 for display — render with pattern #,##0.0 and append % in the template.'
+    definition: @aql wc_team_snapshot.p_champion * 100 ;;
+  }
+  dimension run_date_label {
+    label: 'Sim Run Date Label'
+    type: 'text'
+    definition: @aql date_format(wc_team_snapshot.run_date, '%d %b %Y') ;;
+  }
+  dimension p_final {
+    label: 'P Reach Final (latest)'
+    type: 'number'
+  }
+  dimension p_sf {
+    label: 'P Reach SF (latest)'
+    type: 'number'
+  }
+  dimension p_qf {
+    label: 'P Reach QF (latest)'
+    type: 'number'
+  }
+  dimension p_r16 {
+    label: 'P Reach R16 (latest)'
+    type: 'number'
+  }
+  dimension p_r32 {
+    label: 'P Reach R32 (latest)'
+    type: 'number'
+  }
+  dimension p_r32_pct {
+    label: 'Reach R32 Odds %'
+    type: 'number'
+    description: 'p_r32 × 100 for display — render with pattern #,##0 and append % in the template (a %-format pattern does not ×100 here).'
+    definition: @aql wc_team_snapshot.p_r32 * 100 ;;
+  }
+  dimension p_r16_pct {
+    label: 'Reach R16 Odds %'
+    type: 'number'
+    definition: @aql wc_team_snapshot.p_r16 * 100 ;;
+  }
+  dimension p_qf_pct {
+    label: 'Reach QF Odds %'
+    type: 'number'
+    definition: @aql wc_team_snapshot.p_qf * 100 ;;
+  }
+  dimension p_sf_pct {
+    label: 'Reach SF Odds %'
+    type: 'number'
+    definition: @aql wc_team_snapshot.p_sf * 100 ;;
+  }
+  dimension p_final_pct {
+    label: 'Reach Final Odds %'
+    type: 'number'
+    definition: @aql wc_team_snapshot.p_final * 100 ;;
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_teams.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_teams.model.aml
@@ -2,7 +2,7 @@ Model wc_teams {
   type: 'table'
   label: 'Teams'
   description: 'World Cup 2026 national teams (48). Dimension spine for flags, kit colors, names.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension code {
     label: 'Team Code'
     type: 'text'
@@ -49,5 +49,5 @@ Model wc_teams {
     definition: @sql case when {{ #SOURCE.code }} in ('MEX', 'USA', 'CAN') then 'Co-host' else '' end;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_teams"'
+  table_name: '"public"."wc_teams"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_teams.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_teams.model.aml
@@ -1,0 +1,53 @@
+Model wc_teams {
+  type: 'table'
+  label: 'Teams'
+  description: 'World Cup 2026 national teams (48). Dimension spine for flags, kit colors, names.'
+  data_source_name: 'demodb'
+  dimension code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.code }};;
+    primary_key: true
+  }
+  dimension name {
+    label: 'Team'
+    type: 'text'
+    definition: @sql {{ #SOURCE.name }};;
+  }
+  dimension group_code {
+    label: 'Group'
+    type: 'text'
+    definition: @sql {{ #SOURCE.group_code }};;
+  }
+  dimension group_order {
+    label: 'Group Order'
+    type: 'number'
+    hidden: true
+    description: 'Numeric lane index for the group A–L (A=1 … L=12). Drives small-multiple/lane positioning where a CSS template needs a number rather than the letter.'
+    definition: @sql ascii({{ #SOURCE.group_code }}) - 64;;
+  }
+  dimension flag_url {
+    label: 'Flag URL'
+    type: 'text'
+    definition: @sql {{ #SOURCE.flag_url }};;
+  }
+  dimension color_hex {
+    label: 'Team Color'
+    type: 'text'
+    definition: @sql {{ #SOURCE.color_hex }};;
+  }
+  dimension fifa_team_id {
+    label: 'FIFA Team Id'
+    type: 'number'
+    hidden: true
+    definition: @sql {{ #SOURCE.fifa_team_id }};;
+  }
+  dimension cohost_tag {
+    label: 'Co-host Tag'
+    type: 'text'
+    description: 'Driver field: "Co-host" pill for the three 2026 host nations, empty otherwise (hides via :empty). SQL (not AQL) so the wc_home/away/opponent_teams extends inherit it without a fan-out — a qualified wc_teams.code ref breaks inside the aliases.'
+    definition: @sql case when {{ #SOURCE.code }} in ('MEX', 'USA', 'CAN') then 'Co-host' else '' end;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_teams"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_third_place_ranking.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_third_place_ranking.model.aml
@@ -1,0 +1,71 @@
+Model wc_third_place_ranking {
+  type: 'table'
+  label: 'Third Place Ranking'
+  description: '2026 format: the 8 best third-placed teams (of 12 groups) advance to the Round of 32.'
+  data_source_name: 'demodb'
+  dimension group_code {
+    label: 'Group'
+    type: 'text'
+    definition: @sql {{ #SOURCE.group_code }};;
+  }
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_code }};;
+    primary_key: true
+  }
+  dimension team_name {
+    label: 'Team'
+    type: 'text'
+    definition: @sql {{ #SOURCE.team_name }};;
+  }
+  dimension played {
+    label: 'Played'
+    type: 'number'
+    definition: @sql {{ #SOURCE.played }};;
+  }
+  dimension pts {
+    label: 'Points'
+    type: 'number'
+    definition: @sql {{ #SOURCE.pts }};;
+  }
+  dimension gd {
+    label: 'Goal Difference'
+    type: 'number'
+    definition: @sql {{ #SOURCE.gd }};;
+  }
+  dimension gf {
+    label: 'Goals For'
+    type: 'number'
+    definition: @sql {{ #SOURCE.gf }};;
+  }
+  dimension overall_rank {
+    label: 'Overall Rank'
+    type: 'number'
+    definition: @sql {{ #SOURCE.overall_rank }};;
+  }
+  dimension advances {
+    label: 'Advances'
+    type: 'truefalse'
+    definition: @sql {{ #SOURCE.advances }};;
+  }
+  dimension qual_status {
+    label: 'Qualification Status'
+    type: 'text'
+    definition: @aql case(
+      when: wc_third_place_ranking.overall_rank <= 8, then: 'In the 8',
+      else: 'Below the line'
+    ) ;;
+  }
+  dimension qual_color {
+    label: 'Qualification Color'
+    type: 'text'
+    description: 'Driver field: best-thirds band color (top-8 green, else red).'
+    definition: @aql case(
+      when: wc_third_place_ranking.overall_rank <= 8, then: '#1FA36B',
+      else: '#E5362B'
+    ) ;;
+  }
+  owner: 'hung.dd@holistics.io'
+  table_name: '"demo_world_cup"."wc_third_place_ranking"'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_third_place_ranking.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_third_place_ranking.model.aml
@@ -2,7 +2,7 @@ Model wc_third_place_ranking {
   type: 'table'
   label: 'Third Place Ranking'
   description: '2026 format: the 8 best third-placed teams (of 12 groups) advance to the Round of 32.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   dimension group_code {
     label: 'Group'
     type: 'text'
@@ -67,5 +67,5 @@ Model wc_third_place_ranking {
     ) ;;
   }
   owner: 'hung.dd@holistics.io'
-  table_name: '"demo_world_cup"."wc_third_place_ranking"'
+  table_name: '"public"."wc_third_place_ranking"'
 }

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_title_odds_movement.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_title_odds_movement.model.aml
@@ -1,0 +1,72 @@
+Model wc_title_odds_movement {
+  type: 'query'
+  label: 'Title Odds Movement'
+  description: 'One row per team: latest Monte-Carlo championship odds vs the previous nightly run, with the day-over-day shift. Materialised for the same reason as wc_match_odds — a run-over-run lag and signed delta label are not AQL dimensions. NOTE: only a few nightly runs exist this early (first run 12 Jun 2026), so deltas are sparse until runs accumulate; the full title-odds *trend* line is wc_advance_probs (long format, one point per run_date).'
+  data_source_name: 'demodb'
+  models: [wc_advance_probs]
+  query: @sql
+    with ranked as (
+      select {{ #a.team_code }} as team_code, {{ #a.run_date }} as run_date, {{ #a.p_champion }} as p_champion,
+        row_number() over (partition by {{ #a.team_code }} order by {{ #a.run_date }} desc) as rn
+      from {{ #wc_advance_probs as a }}
+    )
+    select
+      c.team_code,
+      c.run_date,
+      c.p_champion,
+      round(c.p_champion * 100, 1) as p_champion_pct,
+      p.run_date as prev_run_date,
+      p.p_champion as p_champion_prev,
+      round((c.p_champion - p.p_champion) * 100, 1) as delta_pct,
+      case when p.run_date is null then ''
+           when c.p_champion - p.p_champion > 0.0005 then '▲ ' || to_char((c.p_champion - p.p_champion) * 100, 'FM990.0')
+           when p.p_champion - c.p_champion > 0.0005 then '▼ ' || to_char((p.p_champion - c.p_champion) * 100, 'FM990.0')
+           else '· 0.0' end as delta_label,
+      case when p.run_date is null or abs(c.p_champion - p.p_champion) <= 0.0005 then '#9AA4B2'
+           when c.p_champion > p.p_champion then '#1FA36B' else '#E5362B' end as delta_color
+    from ranked c
+    left join ranked p on p.team_code = c.team_code and p.rn = 2
+    where c.rn = 1;;
+  dimension team_code {
+    label: 'Team Code'
+    type: 'text'
+    primary_key: true
+  }
+  dimension run_date {
+    label: 'Run Date'
+    type: 'date'
+  }
+  dimension p_champion {
+    label: 'P Champion (latest)'
+    type: 'number'
+  }
+  dimension p_champion_pct {
+    label: 'Title Odds %'
+    type: 'number'
+    description: 'p_champion × 100 for display.'
+  }
+  dimension prev_run_date {
+    label: 'Previous Run Date'
+    type: 'date'
+  }
+  dimension p_champion_prev {
+    label: 'P Champion (previous)'
+    type: 'number'
+  }
+  dimension delta_pct {
+    label: 'Title Odds Δ (pts)'
+    type: 'number'
+    description: 'Percentage-point shift in championship odds vs the previous run.'
+  }
+  dimension delta_label {
+    label: 'Title Odds Δ Label'
+    type: 'text'
+    description: 'Driver field: signed move, e.g. "▲ 2.4" / "▼ 1.1"; empty when only one run exists (hides via :empty).'
+  }
+  dimension delta_color {
+    label: 'Title Odds Δ Color'
+    type: 'text'
+    description: 'Driver field: rising green / falling red / flat grey.'
+  }
+  owner: 'hung.dd@holistics.io'
+}

--- a/04 demo dashboards 2026/World Cup 2026/models/wc_title_odds_movement.model.aml
+++ b/04 demo dashboards 2026/World Cup 2026/models/wc_title_odds_movement.model.aml
@@ -2,7 +2,7 @@ Model wc_title_odds_movement {
   type: 'query'
   label: 'Title Odds Movement'
   description: 'One row per team: latest Monte-Carlo championship odds vs the previous nightly run, with the day-over-day shift. Materialised for the same reason as wc_match_odds — a run-over-run lag and signed delta label are not AQL dimensions. NOTE: only a few nightly runs exist this early (first run 12 Jun 2026), so deltas are sparse until runs accumulate; the full title-odds *trend* line is wc_advance_probs (long format, one point per run_date).'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [wc_advance_probs]
   query: @sql
     with ranked as (

--- a/04 demo dashboards 2026/World Cup 2026/themes/wc_pitch_day.theme.aml
+++ b/04 demo dashboards 2026/World Cup 2026/themes/wc_pitch_day.theme.aml
@@ -1,0 +1,337 @@
+// =============================================================================
+// WORLD CUP 2026 — "ON THE PITCH" · DAY
+// Shared values = flat AML consts (wc_pd_*) feeding every native PageTheme prop
+// (object-dict accessors aren't supported in this AML version). custom_css holds
+// only the --wc tokens + helpers the MarkdownViz blocks read (no dict in @css).
+// Night mode = sibling file wc_pitch_night (no runtime toggle — swap page `theme:`).
+// =============================================================================
+
+// surfaces — turf-edge is the stadium SURROUND (page bg). The mown-stripe pitch itself
+// is the `pitch` block, not the canvas, so the jumbotron/header can sit on the surround
+// ABOVE it. Pitch turf reads the --grass-* / --line / --vignette vars in custom_css below.
+const wc_pd_turf_edge   = "#2d7d47"
+// page background = stadium-surround floodlight bloom from the top
+const wc_pd_sky_bloom   = "radial-gradient(120% 65% at 50% -10%, #cfeeff 0%, rgba(207,238,255,.18) 34%, transparent 60%)"
+// ink
+const wc_pd_ink         = "#0c2418"
+const wc_pd_ink_2       = "#1c3a2a"
+const wc_pd_muted       = "#2f5a42"
+// panels / tables
+const wc_pd_panel       = "#f4faf6"
+const wc_pd_panel_line  = "rgba(12,36,24,.14)"
+const wc_pd_panel_ink   = "#11241a"
+const wc_pd_table_header= "#e7f1ea"
+const wc_pd_table_hover = "rgba(12,36,24,.06)"
+const wc_pd_table_band  = "rgba(12,36,24,.035)"
+// type
+const wc_pd_font_disp   = "Saira Condensed, Sora, system-ui, sans-serif"
+const wc_pd_font_body   = "Sora, system-ui, sans-serif"
+
+ColorPalette wc_pitch_day_palette {
+  title: "WC Pitch — Day"
+  categorical {
+    colors: [
+      "#1f9d52", "#C8920A", "#1D3F8E", "#E61D25",
+      "#00853F", "#d99412", "#0c2418", "#2f5a42"
+    ]
+  }
+}
+
+PageTheme wc_pitch_day {
+  title: "World Cup — On the Pitch (Day)"
+
+  color {
+    data: wc_pitch_day_palette
+  }
+
+  // LAYER 1 — PAGE = the stadium surround: dark turf-edge + sky/floodlight bloom from above.
+  background {
+    bg_color: wc_pd_turf_edge
+    bg_image: wc_pd_sky_bloom
+    bg_repeat: false
+    bg_size: "cover"
+  }
+
+  // CANVAS = transparent, so the page surround shows through. The pitch is its own `pitch`
+  // block (lowest layer); jumbotron + header sit on the surround ABOVE it, content stacks on it.
+  canvas {
+    border { border_width: 0  border_style: "none"  border_radius: 0 }
+    background { bg_color: "transparent" }
+    shadow: "none"
+    opacity: 1
+  }
+
+  // Transparent blocks → each MarkdownViz/TextBlock owns its surface (no fighting).
+  block {
+    label {
+      font_family: wc_pd_font_disp
+      font_size: 12
+      font_color: wc_pd_ink
+      font_weight: "bold"
+      letter_spacing: "0.04em"
+      text_transform: "uppercase"
+    }
+    text {
+      font_family: wc_pd_font_body
+      font_size: 13
+      font_color: wc_pd_ink_2
+      font_weight: "normal"
+    }
+    border { border_width: 0  border_style: "none"  border_radius: 12 }
+    background { bg_color: "transparent" }
+    padding: 0
+    shadow: "none"
+    opacity: 1
+  }
+
+  viz {
+    table {
+      general {
+        bg_color:      wc_pd_panel
+        hover_color:   wc_pd_table_hover
+        banding_color: wc_pd_table_band
+        cell_padding:  DetailedSpacing { top: 8, right: 12, bottom: 8, left: 12 }
+        font_size: 12
+        font_color:    wc_pd_panel_ink
+        font_family:   wc_pd_font_body
+        border_color:  wc_pd_panel_line
+        grid_color:    wc_pd_panel_line
+        border_width: 1
+        borders { outer: true, vertical: false, horizontal: true, header: true, row_header: false }
+      }
+      header {
+        bg_color:    wc_pd_table_header
+        font_size: 12
+        font_color:  wc_pd_ink
+        font_weight: "bold"
+      }
+      sub_header {
+        bg_color:    wc_pd_table_band
+        font_size: 11
+        font_color:  wc_pd_muted
+        font_weight: "semibold"
+      }
+      sub_title {
+        font_size: 11
+        font_color:  wc_pd_muted
+        font_weight: "semibold"
+      }
+    }
+  }
+
+  // custom_css = design tokens + helpers the MarkdownViz HTML reads (literal — no .dac-* overrides)
+  custom_css: @css
+    @import url('https://fonts.googleapis.com/css2?family=Saira+Condensed:wght@500;600;700;800&family=Sora:wght@400;500;600;700&display=swap');
+
+    :root {
+      --grass-a:#3DA35D; --grass-b:#4FB069; --sky-ambient:#cfeeff; --turf-edge:#2d7d47;
+      --line:rgba(255,255,255,.88); --line-soft:rgba(255,255,255,.55);
+      --ink:#0c2418; --ink-2:#1c3a2a; --muted:#2f5a42;
+      --panel:rgba(255,255,255,.94); --panel-2:rgba(255,255,255,.86);
+      --panel-line:rgba(12,36,24,.14); --panel-ink:#11241a; --panel-muted:#5b7567;
+      --gold:#C8920A; --gold-2:#f2c84b; --live:#E61D25;
+      --board-bg:#07140d; --board-ink:#eafff2; --board-glow:rgba(120,255,180,.55);
+      --board-bezel-a:#cdd6da; --board-bezel-b:#8b979d;
+      --zone-q:rgba(38,166,91,.22); --zone-q-bar:#1f9d52;
+      --zone-p:rgba(232,168,30,.26); --zone-p-bar:#d99412;
+      --win:#1FA36B; --draw:#E0A23B; --loss:#E5362B;
+      --qual-adv:#1FA36B; --qual-po:#E0A23B; --qual-out:#E5362B;
+      --shadow-dir:rgba(7,30,18,.30); --flag-shadow:0 8px 18px rgba(8,28,18,.28);
+      --vignette:rgba(6,28,16,.30);
+      --font-disp:"Saira Condensed", Sora, sans-serif; --font-body:"Sora", system-ui, sans-serif;
+    }
+
+    .wc-num { font-variant-numeric: tabular-nums; font-feature-settings:"tnum" 1; }
+    .wc-disp { font-family: var(--font-disp); }
+    .wc-pulse { display:inline-block; width:8px; height:8px; border-radius:50%;
+      background: var(--live); animation: wc-pulse 1.8s infinite; vertical-align:middle; }
+    @keyframes wc-pulse { 0%{box-shadow:0 0 0 0 rgba(230,29,37,.5);} 70%{box-shadow:0 0 0 8px rgba(230,29,37,0);} 100%{box-shadow:0 0 0 0 rgba(230,29,37,0);} }
+
+    /* motion @keyframes live in the header_rail page <style> — theme @keyframes are inert
+       (a page rule referencing a theme keyframe animates nothing; static theme styles DO apply) */
+
+    /* ---- The pitch surface (shared, reusable on any tab): mown turf + frame. Size comes from the block's
+       layout position (height:100%), so the same block can be placed at different sizes per tab. The white
+       markings are an SVG inside the block (see the `pitch` block) drawn in REAL pitch units — 1 unit = 10cm
+       of a FIFA 68m x 105m pitch — so features are placed from published measurements, never recomputed. */
+    .wc-pitch { position:relative; width:100%; height:100%; border-radius:14px; overflow:hidden;
+      background:
+        radial-gradient(140% 34% at 50% -2%, transparent 57%, var(--vignette) 100%),
+        repeating-linear-gradient(90deg, var(--grass-a) 0, var(--grass-a) 66px, var(--grass-b) 66px, var(--grass-b) 132px);
+      box-shadow: inset 0 0 0 2px var(--turf-edge), 0 34px 64px -30px rgba(4,18,11,.6); }
+    /* Markings anchored by the BOX MODEL, not coordinates — boundary = inset border box, halfway line and
+       centre circle = 50% anchors, corner arcs = quarter-circles pinned to the corners. Resizing the pitch
+       block (any tab, any height) repositions everything automatically; nothing here is ever re-derived.
+       Only the penalty-box detail is an SVG with fixed internal coords, pinned to the top edge. */
+    .wc-pitch .pl { position:absolute; display:block; border:0 solid #e6f0ea; box-sizing:border-box; }
+    .wc-pitch .pl-bound { inset:32px; border-width:4px; }
+    .wc-pitch .pl-half { left:32px; right:32px; top:50%; height:4px; margin-top:-2px; background:#e6f0ea; }
+    .wc-pitch .pl-circle { left:50%; top:50%; width:280px; height:280px; margin:-140px 0 0 -140px;
+      border-width:4px; border-radius:50%; }
+    .wc-pitch .pl-spot { left:50%; top:50%; width:14px; height:14px; margin:-7px 0 0 -7px; border-radius:50%;
+      background:#e6f0ea; }
+    .wc-pitch .pl-corner { width:26px; height:26px; }
+    .wc-pitch .pl-corner.tl { left:32px; top:32px; border-radius:0 0 100% 0;
+      border-right:4px solid #e6f0ea; border-bottom:4px solid #e6f0ea; }
+    .wc-pitch .pl-corner.tr { right:32px; top:32px; border-radius:0 0 0 100%;
+      border-left:4px solid #e6f0ea; border-bottom:4px solid #e6f0ea; }
+    .wc-pitch .pl-corner.bl { left:32px; bottom:32px; border-radius:0 100% 0 0;
+      border-right:4px solid #e6f0ea; border-top:4px solid #e6f0ea; }
+    .wc-pitch .pl-corner.br { right:32px; bottom:32px; border-radius:100% 0 0 0;
+      border-left:4px solid #e6f0ea; border-top:4px solid #e6f0ea; }
+    .wc-pitch .pl-endtop { position:absolute; top:0; left:0; width:100%; display:block; }
+
+    /* ---- Standings clipboard: a coach's tactical board laid on the turf (shared by the per-group blocks) ----
+       Form chips = pre-built HTML from the worldcup.team_form_html metric (one .cb-chip <span> per finished
+       match, coloured by result), rendered via a field format of type html. Paired with the points measure so
+       the multi-fact join keeps every team; empty until a team plays, when :empty shows a dim placeholder. */
+    .cb-wrap { width:100%; height:100%; box-sizing:border-box; display:flex; align-items:flex-start;
+      justify-content:center; padding:20px 8px 12px; }
+    .clipboard { position:relative; width:100%; border-radius:11px 11px 13px 13px; color:var(--panel-ink);
+      background:linear-gradient(180deg,#fbfdfb,#ecf3ee); border:1px solid var(--panel-line); padding:24px 13px 11px;
+      box-shadow:0 18px 30px -16px var(--shadow-dir), 0 2px 0 rgba(0,0,0,.10), inset 0 1px 0 rgba(255,255,255,.7); }
+    /* chrome spring-clip centred on the top edge */
+    .clipboard::before { content:""; position:absolute; top:-9px; left:50%; transform:translateX(-50%);
+      width:72px; height:17px; border-radius:5px; background:linear-gradient(180deg,#e2e8ea,#9aa6ab 55%,#6f7a7f);
+      box-shadow:0 2px 4px rgba(0,0,0,.30), inset 0 1px 0 rgba(255,255,255,.85); }
+    .clipboard::after { content:""; position:absolute; top:-2px; left:50%; transform:translateX(-50%);
+      width:28px; height:6px; border-radius:3px; background:#586267; box-shadow:inset 0 1px 1px rgba(0,0,0,.55); }
+    .cb-head { display:flex; align-items:baseline; justify-content:space-between; gap:8px;
+      margin-bottom:8px; padding-bottom:7px; border-bottom:1px solid var(--panel-line); }
+    .cb-grp { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.07em;
+      font-size:16px; line-height:1; }
+    .cb-grp b { color:var(--gold); }
+    .cb-sub { font-size:9px; text-transform:uppercase; letter-spacing:.13em; color:var(--panel-muted); white-space:nowrap; }
+    .cb-colhead, .cb-row { display:grid; grid-template-columns:16px 26px 1fr 20px 26px 44px; align-items:center; gap:6px; }
+    .cb-colhead { padding:0 2px 4px; font-family:var(--font-disp); font-weight:700; font-size:8px;
+      text-transform:uppercase; letter-spacing:.07em; color:var(--panel-muted); }
+    .cb-colhead .c { text-align:center; }
+    .cb-colhead .e { text-align:right; }
+    .cb-row { padding:5px 2px 5px 7px; border-left:3px solid transparent; }
+    .cb-row + .cb-row { border-top:1px solid var(--panel-line); }
+    .cb-rank { font-family:var(--font-disp); font-weight:800; font-size:13px; text-align:center; }
+    .clipboard .cb-row img { width:24px !important; height:16px !important; border-radius:2px !important;
+      margin:0 !important; display:block !important; object-fit:cover; box-shadow:0 1px 2px rgba(0,0,0,.3); }
+    .cb-name { font-weight:600; font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .cb-p { font-family:var(--font-disp); font-size:12px; text-align:center; color:var(--panel-muted);
+      font-variant-numeric:tabular-nums; }
+    .cb-pts { font-family:var(--font-disp); font-size:15px; font-weight:800; text-align:center;
+      font-variant-numeric:tabular-nums; }
+    .cb-form { display:flex; gap:3px; justify-content:flex-end; align-items:center; min-height:12px; }
+    .cb-form:empty::after { content:"– – –"; font-size:9px; letter-spacing:1px; color:var(--panel-muted); opacity:.55; }
+    .cb-chip { width:11px; height:11px; border-radius:3px; box-shadow:inset 0 0 0 1px rgba(0,0,0,.14), 0 1px 1px rgba(0,0,0,.12); }
+    .cb-foot { display:flex; align-items:center; gap:9px; flex-wrap:wrap; margin-top:9px; padding-top:7px;
+      border-top:1px solid var(--panel-line); font-size:8px; text-transform:uppercase; letter-spacing:.05em;
+      color:var(--panel-muted); }
+    .cb-foot .lg { display:inline-flex; align-items:center; gap:4px; }
+    .cb-foot .dot { width:8px; height:8px; border-radius:2px; flex:none; }
+    .cb-foot .sp { margin-left:auto; text-transform:none; letter-spacing:.02em; font-style:italic; opacity:.85; }
+
+    /* ---- Groups tab: full-stat clipboard variant (.cb-x) — same chrome, wider ledger:
+       # · flag · team · P W D L GF GA GD · Pts. Number cells are condensed tabular figures;
+       Pts keeps the bold .cb-pts treatment so the ranking column stays the focal point. */
+    .clipboard.cb-x .cb-colhead, .clipboard.cb-x .cb-row {
+      grid-template-columns:16px 26px minmax(0,1fr) repeat(7, 21px) 28px; gap:5px; }
+    .cb-n { font-family:var(--font-disp); font-size:12px; text-align:center; color:var(--panel-muted);
+      font-variant-numeric:tabular-nums; }
+
+    /* ---- Best-thirds board (.cb-tp): one wide clipboard ranking the 12 third-placed teams.
+       2026 format: top 8 cross the line into the Round of 32 — the dashed amber rule under
+       row 8 IS the qualification line; row bands reuse the qual colours (green in, red out). */
+    .clipboard.cb-tp .cb-colhead, .clipboard.cb-tp .cb-row {
+      grid-template-columns:20px 32px 26px minmax(0,1fr) 26px 26px 28px 32px 104px; gap:6px; }
+    .cb-tp .tp-grp { font-family:var(--font-disp); font-weight:700; font-size:11px; text-align:center;
+      color:var(--panel-muted); text-transform:uppercase; letter-spacing:.04em; }
+    .cb-tp .tp-st { font-family:var(--font-disp); font-weight:700; font-size:9px; letter-spacing:.08em;
+      text-transform:uppercase; text-align:right; white-space:nowrap; }
+    .cb-tp .tp-body .cb-row:nth-child(8) { border-bottom:2px dashed var(--qual-po); padding-bottom:7px; }
+
+    /* ---- Knockout bracket: rounds funnel DOWN the pitch toward the goal (shared by the per-round blocks) ----
+       Each round is a full-width row of tie cards; the row narrows as rounds advance. TBD slots (teams not yet
+       decided) show "TBD" via :empty and hide their flag img (empty src) so no broken-image icon appears. */
+    .kbr { display:flex; flex-direction:column; align-items:center; gap:6px; height:100%; }
+    .kbr-h { font-family:var(--font-disp); font-weight:700; text-transform:uppercase; letter-spacing:.14em;
+      font-size:10px; color:var(--line); text-shadow:0 1px 3px rgba(0,0,0,.5); }
+    .kbr-row { display:flex; flex-wrap:wrap; justify-content:center; gap:7px; width:100%; }
+    .tie { width:158px; background:linear-gradient(180deg,var(--panel),var(--panel-2)); border:1px solid var(--panel-line);
+      border-radius:8px; padding:4px 7px; color:var(--panel-ink); box-shadow:0 8px 18px -12px var(--shadow-dir);
+      display:flex; flex-direction:column; gap:2px; }
+    .tie-meta { display:flex; justify-content:space-between; align-items:baseline; gap:6px; width:100%; min-width:0;
+      font-size:8px; text-transform:uppercase; letter-spacing:.05em; color:var(--panel-muted); }
+    .tie-meta span:first-child { flex:none; white-space:nowrap; }
+    .tie-meta span:last-child { flex:1; min-width:0; text-align:right; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .tie-row { display:flex; align-items:center; gap:6px; min-width:0; }
+    .tie .tie-row img { width:16px !important; height:11px !important; border-radius:1px !important; margin:0 !important;
+      display:block !important; object-fit:cover; flex:none; box-shadow:0 1px 2px rgba(0,0,0,.3); }
+    .tie .tie-row img[src=""], .tie .tie-row img:not([src]) { display:none !important; }
+    .tie-row .nm { font-weight:600; font-size:10px; line-height:1.25; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+      flex:1; min-width:0; }
+    .tie-row .nm:empty::after { content:"TBD"; color:var(--panel-muted); font-style:italic; font-weight:500; }
+    .tie-row .g { font-family:var(--font-disp); font-weight:800; font-size:11px; line-height:1.1; flex:none; min-width:9px; text-align:right; }
+    /* the Final reads as the prize: gold-foil face (with a soft sheen) + dark-gold ink, not white paper.
+       Glow kept tight (small blur, negative spread) so the block's overflow:hidden doesn't clip a hard edge. */
+    .tie-final { width:240px; color:#4a3608; border-color:rgba(163,121,32,.6);
+      background:linear-gradient(120deg, transparent 38%, rgba(255,255,255,.4) 47%, transparent 58%), linear-gradient(180deg,#f8ecc0,#ecd592);
+      box-shadow:0 9px 18px -10px rgba(120,85,15,.5), 0 0 9px -1px rgba(242,200,75,.45), inset 0 1px 0 rgba(255,255,255,.55); }
+    .tie-final .kt { display:inline-flex; align-items:center; gap:5px; color:#6e4a14; font-family:var(--font-disp);
+      font-weight:800; text-transform:uppercase; letter-spacing:.06em; font-size:11px; }
+    .tie-final .tie-meta, .tie-final .nm:empty::after { color:rgba(93,67,12,.72); }
+
+    /* THE GOAL — destination at the funnel's mouth: white frame + net mesh + trophy emblem */
+    /* flex-end pins the goal to the block's BOTTOM edge — the page positions that edge on the pitch goal line,
+       so the goal base aligns to the marking without depending on pixel-perfect heights. */
+    .goal-wrap { display:flex; flex-direction:column; align-items:center; width:100%; height:100%; justify-content:flex-end; gap:9px; }
+    .goal-funnel { font-family:var(--font-disp); font-weight:700; text-transform:uppercase; letter-spacing:.2em;
+      font-size:10px; color:var(--line); margin-bottom:10px; text-shadow:0 1px 4px rgba(0,0,0,.5); }
+    .goal-funnel::before, .goal-funnel::after { content:"▾"; margin:0 8px; opacity:.6; }
+    .goal { position:relative; width:min(380px,100%); height:210px; border:5px solid rgba(255,255,255,.94);
+      border-bottom:0; border-radius:6px 6px 0 0; display:flex; align-items:flex-end; justify-content:center;
+      padding-bottom:16px;
+      background:
+        radial-gradient(58% 46% at 50% 66%, rgba(242,200,75,.30), transparent 72%),
+        repeating-linear-gradient(45deg, rgba(255,255,255,.30) 0 1px, transparent 1px 12px),
+        repeating-linear-gradient(-45deg, rgba(255,255,255,.30) 0 1px, transparent 1px 12px),
+        radial-gradient(120% 80% at 50% 100%, rgba(6,28,16,.28), transparent 70%);
+      box-shadow:0 0 40px -6px rgba(242,200,75,.45), inset 0 2px 0 rgba(255,255,255,.45); }
+    .goal img { width:76px !important; height:auto !important; margin:0 !important; display:block !important;
+      filter:drop-shadow(0 0 12px rgba(242,200,75,.65)) drop-shadow(0 0 24px rgba(242,200,75,.32)) drop-shadow(0 6px 12px rgba(0,0,0,.55)); }
+    .goal-line { width:min(420px,82%); height:4px; background:rgba(255,255,255,.88); border-radius:2px;
+      box-shadow:0 0 14px rgba(242,200,75,.35); }
+    .goal-plate { text-align:center; margin-top:11px; }
+    .goal-plate .big { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.04em;
+      font-size:15px; color:#fff; text-shadow:0 2px 10px rgba(0,0,0,.5); }
+    .goal-plate .sub { font-size:11px; color:rgba(234,255,242,.72); margin-top:4px; }
+
+    /* ---- Team HQ squad wall: panini-sticker player cards in four position rails. Stickers sit
+       straight on the turf (no clipboard chrome) with alternating tilt via :nth-child — the album
+       look. Number badge + bottom ribbon take the kit colour inline from wc_teams.color_hex. ---- */
+    .stk-band { display:flex; flex-direction:column; gap:14px; height:100%; padding:0 2px; }
+    .stk-head { display:flex; align-items:center; gap:10px; }
+    .stk-dot { width:10px; height:10px; border-radius:3px; flex:none; box-shadow:0 1px 2px rgba(0,0,0,.35); }
+    .stk-title { font-family:var(--font-disp); font-weight:800; text-transform:uppercase; letter-spacing:.16em;
+      font-size:12px; color:var(--line); text-shadow:0 1px 3px rgba(0,0,0,.5); }
+    .stk-rule { flex:1; height:2px; background:rgba(255,255,255,.26); border-radius:1px; }
+    .stk-rail { display:flex; flex-wrap:wrap; gap:18px 16px; align-items:flex-start; }
+    .stk { position:relative; width:122px; background:#fdfefd; border-radius:5px; padding:6px 6px 0;
+      box-shadow:0 16px 26px -14px var(--shadow-dir), 0 2px 0 rgba(0,0,0,.14), inset 0 1px 0 #fff;
+      --rest:translateY(0) rotate(-1deg) scale(1); transform:var(--rest); }
+    .stk:nth-child(even) { --rest:translateY(0) rotate(1.1deg) scale(1); }
+    .stk-num { position:absolute; top:-8px; right:-8px; z-index:2; min-width:26px; height:26px; padding:0 5px;
+      border-radius:50%; display:inline-flex; align-items:center; justify-content:center;
+      font-family:var(--font-disp); font-weight:800; font-size:12px; color:#fff;
+      box-shadow:0 2px 5px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.35), inset 0 0 0 2px rgba(255,255,255,.5); }
+    /* photo frame carries a baked-in player silhouette: when picture_url is empty the img is
+       hidden and the silhouette sticker shows instead of a bare frame */
+    .stk-ph { position:relative; height:104px; border-radius:3px 3px 0 0; overflow:hidden;
+      background:
+        url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100' preserveAspectRatio='xMidYMax meet'><g fill='%23a7bfae'><circle cx='50' cy='36' r='15'/><path d='M20 100c1-24 14-36 30-36s29 12 30 36z'/></g></svg>") center bottom / 64% no-repeat,
+        radial-gradient(120% 90% at 50% 0%, #e8f1ea, #c9d8cd); }
+    .stk-ph img { position:relative; z-index:1; width:100% !important; height:100% !important; object-fit:cover;
+      object-position:top center; display:block !important; margin:0 !important; }
+    .stk-ph img[src=""], .stk-ph img:not([src]) { display:none !important; }
+    .stk-kit { height:4px; }
+    .stk-name { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+      font-size:10.5px; letter-spacing:.02em; color:var(--panel-ink); padding:5px 2px 7px; line-height:1.15;
+      white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  ;;
+}

--- a/04 demo dashboards 2026/World Cup 2026/worldcup.dataset.aml
+++ b/04 demo dashboards 2026/World Cup 2026/worldcup.dataset.aml
@@ -1,0 +1,468 @@
+Dataset worldcup {
+  __engine__: 'aql'
+  label: 'World Cup 2026'
+  description: 'Live World Cup 2026 semantic layer: fixtures, results, standings, scorers, squads, lineups and events.'
+  data_source_name: 'demodb'
+  models: [
+    wc_teams,
+    wc_home_teams,
+    wc_away_teams,
+    wc_opponent_teams,
+    wc_groups,
+    wc_matches,
+    wc_players,
+    wc_lineups,
+    wc_events,
+    wc_goals,
+    wc_scorers,
+    wc_team_match_results,
+    wc_group_standings,
+    wc_third_place_ranking,
+    wc_history_matches,
+    wc_history_editions,
+    wc_history_team_editions,
+    wc_team_aliases,
+    wc_team_ratings,
+    wc_match_predictions,
+    wc_advance_probs,
+    wc_team_snapshot,
+    wc_team_next_h2h,
+    wc_match_odds,
+    wc_contender_board,
+    wc_lineup_grid,
+    wc_history_finals,
+    wc_player_stats,
+    wc_player_bio,
+    wc_team_rating_movement,
+    wc_edition_compare,
+    wc_title_odds_movement,
+    wc_history_h2h,
+    wc_player_match_form,
+    wc_team_running_standings
+  ]
+  relationships: [
+    relationship(wc_matches.home_code > wc_home_teams.code, true),
+    relationship(wc_matches.away_code > wc_away_teams.code, true),
+    relationship(wc_matches.group_code > wc_groups.code, true),
+    relationship(wc_goals.match_num > wc_matches.match_num, true),
+    relationship(wc_goals.team_code > wc_teams.code, true),
+    relationship(wc_team_match_results.team_code > wc_teams.code, true),
+    relationship(wc_team_match_results.opponent_code > wc_opponent_teams.code, true),
+    relationship(wc_group_standings.team_code > wc_teams.code, true),
+    relationship(wc_group_standings.group_code > wc_groups.code, true),
+    relationship(wc_players.team_code > wc_teams.code, true),
+    relationship(wc_lineups.match_num > wc_matches.match_num, true),
+    relationship(wc_lineups.fifa_player_id > wc_players.fifa_player_id, true),
+    relationship(wc_lineups.fifa_player_id > wc_player_stats.fifa_player_id, true),
+    relationship(wc_lineups.team_code > wc_teams.code, true),
+    relationship(wc_events.match_num > wc_matches.match_num, true),
+    relationship(wc_events.team_code > wc_teams.code, true),
+    relationship(wc_events.fifa_player_id > wc_players.fifa_player_id, true),
+    relationship(wc_scorers.fifa_player_id > wc_players.fifa_player_id, true),
+    relationship(wc_scorers.team_code > wc_teams.code, true),
+    relationship(wc_third_place_ranking.team_code > wc_teams.code, true),
+    relationship(wc_third_place_ranking.group_code > wc_groups.code, true),
+    relationship(wc_history_matches.year > wc_history_editions.year, true),
+    relationship(wc_history_matches.home_canonical > wc_home_teams.code, true),
+    relationship(wc_history_matches.away_canonical > wc_away_teams.code, true),
+    relationship(wc_history_team_editions.team_code > wc_team_aliases.alias_code, true),
+    relationship(wc_team_aliases.canonical_code > wc_teams.code, true),
+    relationship(wc_team_ratings.team_code > wc_teams.code, true),
+    relationship(wc_match_predictions.match_num > wc_matches.match_num, true),
+    relationship(wc_advance_probs.team_code > wc_teams.code, true),
+    relationship(wc_team_snapshot.team_code > wc_teams.code, true),
+    relationship(wc_team_next_h2h.team_code > wc_teams.code, true),
+    relationship(wc_match_odds.match_num > wc_matches.match_num, true),
+    relationship(wc_contender_board.team_code > wc_teams.code, true),
+    relationship(wc_lineup_grid.match_num > wc_matches.match_num, true),
+    relationship(wc_lineup_grid.team_code > wc_teams.code, true),
+    relationship(wc_player_stats.team_code > wc_teams.code, true),
+    relationship(wc_player_stats.fifa_player_id > wc_player_bio.fifa_player_id, true),
+    relationship(wc_team_rating_movement.team_code > wc_teams.code, true),
+    relationship(wc_title_odds_movement.team_code > wc_teams.code, true),
+    relationship(wc_edition_compare.edition > wc_history_editions.year, true),
+    relationship(wc_history_h2h.team_code > wc_teams.code, true),
+    relationship(wc_history_h2h.opp_code > wc_opponent_teams.code, true),
+    relationship(wc_player_match_form.fifa_player_id > wc_players.fifa_player_id, true),
+    relationship(wc_player_match_form.team_code > wc_teams.code, true),
+    relationship(wc_player_match_form.match_num > wc_matches.match_num, true),
+    relationship(wc_player_match_form.opponent_code > wc_opponent_teams.code, true),
+    relationship(wc_team_running_standings.team_code > wc_teams.code, true),
+    relationship(wc_team_running_standings.group_code > wc_groups.code, true),
+    relationship(wc_team_running_standings.match_num > wc_matches.match_num, true)
+  ]
+
+  metric total_goals {
+    label: 'Total Goals'
+    type: 'number'
+    description: 'All goals scored in finished matches (each goal counted once as the scoring team).'
+    definition: @aql sum(wc_team_match_results.gf) ;;
+  }
+  metric matches_played {
+    label: 'Matches Played'
+    type: 'number'
+    description: 'Count of finished (FT) matches in context.'
+    definition: @aql count_if(wc_matches.status == 'FT') ;;
+  }
+  metric total_matches {
+    label: 'Total Matches'
+    type: 'number'
+    description: 'All scheduled matches in context regardless of status (104 tournament-wide).'
+    definition: @aql count(wc_matches.match_num) ;;
+  }
+  metric scorer_bar_pct {
+    label: 'Scorer Bar Pct'
+    type: 'number'
+    description: 'Driver field: a scorer\'s goals as a percentage of the current Golden Boot leader\'s goals — drives leaderboard bar widths (leader = 100).'
+    definition: @aql 100 * safe_divide(sum(wc_scorers.goals), window_max(sum(wc_scorers.goals))) ;;
+  }
+  metric goals_per_match {
+    label: 'Goals per Match'
+    type: 'number'
+    description: 'Average goals across finished matches.'
+    definition: @aql safe_divide(sum(wc_team_match_results.gf), count_if(wc_matches.status == 'FT')) ;;
+  }
+  metric win_rate {
+    label: 'Win Rate'
+    type: 'number'
+    description: 'Share of a team\'s finished matches that ended in a win (per-team grain).'
+    definition: @aql safe_divide(count_if(wc_team_match_results.result == 'W'), count(wc_team_match_results.match_num)) ;;
+  }
+  metric clean_sheets {
+    label: 'Clean Sheets'
+    type: 'number'
+    description: 'Finished matches in which the team conceded zero (per-team grain).'
+    definition: @aql count_if(wc_team_match_results.clean_sheet) ;;
+  }
+  metric points {
+    label: 'Points'
+    type: 'number'
+    description: 'Group-stage points (3 per win, 1 per draw) from the standings view.'
+    definition: @aql sum(wc_group_standings.pts) ;;
+  }
+  metric team_form_html {
+    label: 'Form'
+    type: 'text'
+    description: 'Pre-built HTML: one form-chip <span> per finished match, coloured by result (win/draw/loss), in kickoff order (oldest→newest). Render with a field format of type html. Null until a team has played; pair with a standings measure so all teams stay in the result (multi-fact left join). Chronological order is achieved by leading each chip with a constant prefix + the ISO kickoff in data-ko, so string_agg order:asc sorts lexically == by time.'
+    definition: @aql string_agg(
+      concat('<span class="cb-chip" data-ko="', cast(wc_team_match_results.kickoff_utc, 'text'), '" style="background:', wc_team_match_results.result_color, '"></span>'),
+      sep: '',
+      order: 'asc'
+    ) ;;
+  }
+  metric goals_for {
+    label: 'Goals For'
+    type: 'number'
+    description: 'Goals scored by the team(s) in context (per-team grain).'
+    definition: @aql sum(wc_team_match_results.gf) ;;
+  }
+  metric goals_against {
+    label: 'Goals Against'
+    type: 'number'
+    description: 'Goals conceded by the team(s) in context (per-team grain).'
+    definition: @aql sum(wc_team_match_results.ga) ;;
+  }
+  metric goal_difference {
+    label: 'Goal Difference'
+    type: 'number'
+    description: 'Goals for minus goals against (per-team grain).'
+    definition: @aql sum(wc_team_match_results.gf) - sum(wc_team_match_results.ga) ;;
+  }
+  metric team_matches_played {
+    label: 'Team Matches Played'
+    type: 'number'
+    description: 'Finished matches for the team(s) in context (per-team grain, from the team-match fact).'
+    definition: @aql count(wc_team_match_results.match_num) ;;
+  }
+  metric matches_won {
+    label: 'Matches Won'
+    type: 'number'
+    definition: @aql count_if(wc_team_match_results.result == 'W') ;;
+  }
+  metric matches_drawn {
+    label: 'Matches Drawn'
+    type: 'number'
+    definition: @aql count_if(wc_team_match_results.result == 'D') ;;
+  }
+  metric matches_lost {
+    label: 'Matches Lost'
+    type: 'number'
+    definition: @aql count_if(wc_team_match_results.result == 'L') ;;
+  }
+  metric avg_attendance {
+    label: 'Average Attendance'
+    type: 'number'
+    description: 'Mean attendance across matches with attendance recorded.'
+    definition: @aql average(wc_matches.attendance) ;;
+  }
+  metric total_attendance {
+    label: 'Total Attendance'
+    type: 'number'
+    definition: @aql sum(wc_matches.attendance) ;;
+  }
+  metric teams_count {
+    label: 'Teams'
+    type: 'number'
+    description: 'Number of participating nations (48).'
+    definition: @aql count(wc_teams.code) ;;
+  }
+  metric wc_titles {
+    label: 'WC Titles'
+    type: 'number'
+    description: 'World Cup titles 1930–2022. Grouped by wc_teams via aliases, defunct-nation titles roll up to the successor (FRG → GER).'
+    definition: @aql count_if(wc_history_team_editions.champion) ;;
+  }
+  metric wc_finals_reached {
+    label: 'WC Finals Reached'
+    type: 'number'
+    definition: @aql count_if(wc_history_team_editions.in_final) ;;
+  }
+  metric wc_semis_reached {
+    label: 'WC Semis Reached'
+    type: 'number'
+    definition: @aql count_if(wc_history_team_editions.in_semi) ;;
+  }
+  metric wc_appearances {
+    label: 'WC Appearances'
+    type: 'number'
+    description: 'Editions played 1930–2022 (one row per edition per team).'
+    definition: @aql count(wc_history_team_editions.year) ;;
+  }
+  metric hist_wins {
+    label: 'All-time WC Wins'
+    type: 'number'
+    definition: @aql sum(wc_history_team_editions.won) ;;
+  }
+  metric hist_draws {
+    label: 'All-time WC Draws'
+    type: 'number'
+    description: 'Shootout results count as draws.'
+    definition: @aql sum(wc_history_team_editions.drawn) ;;
+  }
+  metric hist_losses {
+    label: 'All-time WC Losses'
+    type: 'number'
+    definition: @aql sum(wc_history_team_editions.lost) ;;
+  }
+  metric hist_gf {
+    label: 'All-time WC Goals For'
+    type: 'number'
+    definition: @aql sum(wc_history_team_editions.gf) ;;
+  }
+  metric hist_ga {
+    label: 'All-time WC Goals Against'
+    type: 'number'
+    definition: @aql sum(wc_history_team_editions.ga) ;;
+  }
+  metric hist_win_rate {
+    label: 'All-time WC Win Rate'
+    type: 'number'
+    description: 'Wins / matches across all editions in context (shootouts count as draws).'
+    definition: @aql safe_divide(sum(wc_history_team_editions.won), sum(wc_history_team_editions.played)) ;;
+  }
+  metric hist_goals_per_match {
+    label: 'Historical Goals per Match'
+    type: 'number'
+    description: 'Baseline: goals per match across the editions in context (filter year for an era).'
+    definition: @aql safe_divide(sum(wc_history_matches.home_score) + sum(wc_history_matches.away_score), count(wc_history_matches.fifa_match_id)) ;;
+  }
+  metric hist_goals_per_match_modern {
+    label: 'Goals per Match Since 1998'
+    type: 'number'
+    description: 'Baseline for the jumbotron: goals/match across the 64-match-era editions (1998–2022).'
+    definition: @aql safe_divide(
+      sum(case(when: wc_history_matches.year >= 1998, then: wc_history_matches.home_score + wc_history_matches.away_score, else: 0)),
+      count_if(wc_history_matches.year >= 1998)
+    ) ;;
+  }
+  metric hist_title_years {
+    label: 'Title Years'
+    type: 'text'
+    description: 'Comma-separated editions the team(s) in context won, oldest→newest. Built on year_text (cast in SQL) so years render without digit grouping; empty for non-champions.'
+    definition: @aql string_agg(wc_history_team_editions.year_text, sep: ', ', order: 'asc') | where(wc_history_team_editions.champion) ;;
+  }
+  metric hist_first_title_year {
+    label: 'First Title Year'
+    type: 'text'
+    description: 'Earliest edition the team(s) in context won, as text (champion editions only). Built on year_text (cast in SQL) so it renders "1958" — a numeric year metric reapplies digit grouping ("1,958.00").'
+    definition: @aql min(wc_history_team_editions.year_text) | where(wc_history_team_editions.champion) ;;
+  }
+  metric hist_last_title_year {
+    label: 'Last Title Year'
+    type: 'text'
+    description: 'Most recent edition the team(s) in context won, as text. Built on year_text to avoid digit grouping.'
+    definition: @aql max(wc_history_team_editions.year_text) | where(wc_history_team_editions.champion) ;;
+  }
+  metric title_odds {
+    label: 'Title Odds'
+    type: 'number'
+    description: 'P(champion) from the Monte Carlo sim. Per (team, run_date) grain — filter run_date (e.g. latest) when displaying a single board.'
+    definition: @aql average(wc_advance_probs.p_champion) ;;
+  }
+  metric latest_run_date {
+    label: 'Latest Prediction Run'
+    type: 'date'
+    definition: @aql max(wc_advance_probs.run_date) ;;
+  }
+  metric current_elo {
+    label: 'Current Elo'
+    type: 'number'
+    description: 'Latest Elo snapshot in context (max over snapshot dates in filter range).'
+    definition: @aql max(wc_team_ratings.elo) ;;
+  }
+  // ---- All-time pedigree index (group on wc_team_aliases.entity_code) ----
+  // Weighted prestige score across all editions 1930–2022: every title, final, semi and appearance
+  // compounds (a title contributes at all four tiers), so sustained tournament excellence rises to the
+  // top. Defunct nations roll into their successor via entity_code (West Germany → Germany, etc.).
+  metric pedigree_score {
+    label: 'Pedigree Score'
+    type: 'number'
+    description: 'Weighted all-time prestige: 8·titles + 4·finals reached + 2·semis reached + appearances. Tiers are nested (a champion also reached the final and semi), so titles compound. Group on wc_team_aliases.entity_code.'
+    definition: @aql 8 * count_if(wc_history_team_editions.champion)
+      + 4 * count_if(wc_history_team_editions.in_final)
+      + 2 * count_if(wc_history_team_editions.in_semi)
+      + count(wc_history_team_editions.year) ;;
+  }
+  metric pedigree_bar_pct {
+    label: 'Pedigree Bar Pct'
+    type: 'number'
+    description: 'Driver field: a nation\'s pedigree score as a percentage of the highest score in context — drives leaderboard bar widths (leader = 100).'
+    definition: @aql 100 * safe_divide(
+      8 * count_if(wc_history_team_editions.champion) + 4 * count_if(wc_history_team_editions.in_final) + 2 * count_if(wc_history_team_editions.in_semi) + count(wc_history_team_editions.year),
+      window_max(8 * count_if(wc_history_team_editions.champion) + 4 * count_if(wc_history_team_editions.in_final) + 2 * count_if(wc_history_team_editions.in_semi) + count(wc_history_team_editions.year))
+    ) ;;
+  }
+  metric pedigree_field_avg {
+    label: 'Pedigree Field Average'
+    type: 'number'
+    description: 'Baseline: the average pedigree score across the nations in context (window average). Pairs every leaderboard score with a comparison.'
+    definition: @aql window_avg(8 * count_if(wc_history_team_editions.champion) + 4 * count_if(wc_history_team_editions.in_final) + 2 * count_if(wc_history_team_editions.in_semi) + count(wc_history_team_editions.year)) ;;
+  }
+  metric pedigree_avg_pct {
+    label: 'Pedigree Average Pct'
+    type: 'number'
+    description: 'Driver field: the field-average pedigree as a percentage of the leader — positions the baseline marker on the leaderboard bars.'
+    definition: @aql 100 * safe_divide(
+      window_avg(8 * count_if(wc_history_team_editions.champion) + 4 * count_if(wc_history_team_editions.in_final) + 2 * count_if(wc_history_team_editions.in_semi) + count(wc_history_team_editions.year)),
+      window_max(8 * count_if(wc_history_team_editions.champion) + 4 * count_if(wc_history_team_editions.in_final) + 2 * count_if(wc_history_team_editions.in_semi) + count(wc_history_team_editions.year))
+    ) ;;
+  }
+  // ---- Header stage-progress ribbon + live meta (used by the header fascia, grouped on wc_matches.ribbon_short,
+  // filtered to the six funnel stages). stage_state is per-stage; the tourn_* metrics window over the stage rows
+  // to broadcast tournament-wide totals onto every row (read via rows[0] in the header template). ----
+  metric stage_state {
+    label: 'Stage State'
+    type: 'text'
+    description: 'Driver field for the header ribbon: done (all matches FT) / now (earliest stage not yet complete, via window_min over the stage rows) / upcoming. Done stages contribute a 999 sentinel so window_min lands on the current stage.'
+    definition: @aql case(
+      when: count_if(wc_matches.status == 'FT') >= count(wc_matches.match_num), then: 'done',
+      when: min(wc_matches.ribbon_order) == window_min(case(when: count_if(wc_matches.status == 'FT') < count(wc_matches.match_num), then: min(wc_matches.ribbon_order), else: 999)), then: 'now',
+      else: 'upcoming'
+    ) ;;
+  }
+  metric tourn_played {
+    label: 'Tournament Matches Played'
+    type: 'number'
+    description: 'Window total of finished matches across the stage rows in context — the tournament-wide played count broadcast onto every ribbon row.'
+    definition: @aql window_sum(count_if(wc_matches.status == 'FT')) ;;
+  }
+  metric tourn_as_of {
+    label: 'Tournament As Of'
+    type: 'text'
+    description: 'Latest finished-match kickoff across the stage rows, formatted "DD Mon"; "pre-tournament" before any result.'
+    definition: @aql coalesce(date_format(window_max(max(wc_matches.kickoff_utc) | where(wc_matches.status == 'FT')), '%d %b'), 'pre-tournament') ;;
+  }
+  metric live_headline {
+    label: 'Live Headline'
+    type: 'text'
+    description: 'Header meta line: "N live now" when any match is live (window total), else "No live matches".'
+    definition: @aql case(
+      when: window_sum(count_if(wc_matches.status == 'LIVE')) > 0,
+        then: concat(cast(window_sum(count_if(wc_matches.status == 'LIVE')), 'text'), ' live now'),
+      else: 'No live matches'
+    ) ;;
+  }
+  metric live_class {
+    label: 'Live Class'
+    type: 'text'
+    description: 'Driver field: live / idle — drives the header status-dot (pulsing red when any match is live).'
+    definition: @aql case(when: window_sum(count_if(wc_matches.status == 'LIVE')) > 0, then: 'live', else: 'idle') ;;
+  }
+  // ---- Team HQ scouting report (deterministic verdict; AQL-first). Numbers stay as formatted viz
+  //      fields; every qualitative tag is a case() over real aggregates with thresholds calibrated
+  //      to tournament norms (~1.3 goals/team/game). No fabricated prose — the words are a direct,
+  //      reproducible function of the figures shown beside them. ----
+  metric goals_for_per_game {
+    label: 'Goals For per Game'
+    type: 'number'
+    description: 'Team goals scored per finished match (per-team grain) — the scouting attack rate.'
+    definition: @aql safe_divide(sum(wc_team_match_results.gf), count(wc_team_match_results.match_num)) ;;
+  }
+  metric goals_against_per_game {
+    label: 'Goals Against per Game'
+    type: 'number'
+    description: 'Team goals conceded per finished match (per-team grain) — the scouting defensive rate.'
+    definition: @aql safe_divide(sum(wc_team_match_results.ga), count(wc_team_match_results.match_num)) ;;
+  }
+  metric scout_form_verdict {
+    label: 'Scouting Verdict'
+    type: 'text'
+    description: 'Headline read from results so far: Maximum points (won all) / On the front foot (more wins than losses) / Holding steady (level) / Under pressure; "Awaiting kick-off" before a team has played.'
+    definition: @aql case(
+      when: coalesce(count(wc_team_match_results.match_num), 0) == 0, then: 'Awaiting kick-off',
+      when: count_if(wc_team_match_results.result == 'W') == count(wc_team_match_results.match_num), then: 'Maximum points',
+      when: count_if(wc_team_match_results.result == 'W') > count_if(wc_team_match_results.result == 'L'), then: 'On the front foot',
+      when: count_if(wc_team_match_results.result == 'W') == count_if(wc_team_match_results.result == 'L'), then: 'Holding steady',
+      else: 'Under pressure'
+    ) ;;
+  }
+  metric scout_attack {
+    label: 'Scouting Attack Tag'
+    type: 'text'
+    description: 'Calibrated read of goals/game (norm ~1.3): Free-scoring ≥2.0, Potent ≥1.4, Steady ≥0.9, Goal-shy >0; "Yet to score"/"Awaiting debut" otherwise.'
+    definition: @aql case(
+      when: coalesce(count(wc_team_match_results.match_num), 0) == 0, then: 'Awaiting debut',
+      when: safe_divide(sum(wc_team_match_results.gf), count(wc_team_match_results.match_num)) >= 2.0, then: 'Free-scoring',
+      when: safe_divide(sum(wc_team_match_results.gf), count(wc_team_match_results.match_num)) >= 1.4, then: 'Potent',
+      when: safe_divide(sum(wc_team_match_results.gf), count(wc_team_match_results.match_num)) >= 0.9, then: 'Steady',
+      when: sum(wc_team_match_results.gf) > 0, then: 'Goal-shy',
+      else: 'Yet to score'
+    ) ;;
+  }
+  metric scout_defence {
+    label: 'Scouting Defence Tag'
+    type: 'text'
+    description: 'Calibrated read of goals conceded/game (norm ~1.3): Miserly ≤0.5, Resolute ≤1.0, Leaky ≤1.6, else Porous; "Awaiting debut" before a team has played.'
+    definition: @aql case(
+      when: coalesce(count(wc_team_match_results.match_num), 0) == 0, then: 'Awaiting debut',
+      when: safe_divide(sum(wc_team_match_results.ga), count(wc_team_match_results.match_num)) <= 0.5, then: 'Miserly',
+      when: safe_divide(sum(wc_team_match_results.ga), count(wc_team_match_results.match_num)) <= 1.0, then: 'Resolute',
+      when: safe_divide(sum(wc_team_match_results.ga), count(wc_team_match_results.match_num)) <= 1.6, then: 'Leaky',
+      else: 'Porous'
+    ) ;;
+  }
+  metric scout_class {
+    label: 'Scouting Class Tag'
+    type: 'text'
+    description: 'Standing among the 48 qualified teams by latest Elo: Elite ≤8, Strong ≤16, Solid ≤24, Mid-tier ≤36, else Outsider.'
+    definition: @aql case(
+      when: max(wc_team_snapshot.elo_rank) <= 8, then: 'Elite tier',
+      when: max(wc_team_snapshot.elo_rank) <= 16, then: 'Strong side',
+      when: max(wc_team_snapshot.elo_rank) <= 24, then: 'Solid outfit',
+      when: max(wc_team_snapshot.elo_rank) <= 36, then: 'Mid-tier',
+      else: 'Outsider'
+    ) ;;
+  }
+  metric scout_outlook {
+    label: 'Scouting Outlook Tag'
+    type: 'text'
+    description: 'Model read on reaching the knockouts from P(reach R32): Strong favourite ≥0.75, Likely ≥0.5, In the hunt ≥0.3, Long odds >0; "Awaiting sim" otherwise.'
+    definition: @aql case(
+      when: max(wc_team_snapshot.p_r32) >= 0.75, then: 'Strong favourite to advance',
+      when: max(wc_team_snapshot.p_r32) >= 0.5, then: 'Likely to progress',
+      when: max(wc_team_snapshot.p_r32) >= 0.3, then: 'In the hunt',
+      when: max(wc_team_snapshot.p_r32) > 0, then: 'Long odds to progress',
+      else: 'Awaiting sim'
+    ) ;;
+  }
+}

--- a/04 demo dashboards 2026/World Cup 2026/worldcup.dataset.aml
+++ b/04 demo dashboards 2026/World Cup 2026/worldcup.dataset.aml
@@ -2,7 +2,7 @@ Dataset worldcup {
   __engine__: 'aql'
   label: 'World Cup 2026'
   description: 'Live World Cup 2026 semantic layer: fixtures, results, standings, scorers, squads, lineups and events.'
-  data_source_name: 'demodb'
+  data_source_name: 'demo_worldcup'
   models: [
     wc_teams,
     wc_home_teams,

--- a/04 demo dashboards 2026/World Cup 2026/worldcup_the_pitch.page.aml
+++ b/04 demo dashboards 2026/World Cup 2026/worldcup_the_pitch.page.aml
@@ -1,0 +1,976 @@
+Dashboard worldcup_the_pitch {
+  title: 'World Cup 2026 — On the Pitch'
+  description: 'Live World Cup 2026 — the dashboard is the pitch.'
+  theme: wc_pitch_day
+
+  // ---- Jumbotron: stadium big-screen scoreboard (tournament KPIs) ----
+  block jumbotron: wc_jumbotron()
+  block match_cards: wc_match_cards()
+  block featured_match: wc_featured_match()
+
+  // ---- Golden Boot — race leaders as game-style (FUT) cards: clipped shield silhouette with a gold rim,
+  //      big photo region beside the rating column (goals = the "rating"), faded team flag as the card
+  //      background texture. Grid places the leader alone on top (spans both columns), #2 and #3 side by
+  //      side beneath — reads as a podium for 1, 2 or 3 scorers without empty slots. Top 3 by goals (ties
+  //      beyond 3 cut until the race spreads). The rank-4+ rack returns once it would be non-empty —
+  //      Holistics renders a built-in unstylable "no data" pill for empty results, so no empty blocks. ----
+  block boot_podium: wc_boot_podium()
+
+  // ---- Golden Boot — chasing pack: ranks 4+ beside the podium cards, mockup rack style (rank, flag, name,
+  //      gold bar relative to the best of the pack, goals). Shows the platform's empty-result state until
+  //      the race has a rank-4+ tail — accepted while data is thin. ----
+  block boot_rack: wc_boot_rack()
+
+  // ---- Header rail: a seated stadium-broadcast fascia on the dark surround. Reworks the (un-stylable)
+  //      Holistics tab material into a premium header: glass bar + a full-width gold broadcast underline,
+  //      WC26 brand, a DATA-DRIVEN stage-progress ribbon (Group → … → Final; the gold "now" chip is the
+  //      earliest stage not yet complete, from the stage_state metric), faint dividers, and a live meta
+  //      (live count + played/104 + as-of, all window aggregates). VizBlock on worldcup, grouped on
+  //      ribbon_short, filtered to the six funnel stages (ribbon_order < 9 drops the third-place match);
+  //      tournament constants (48 teams, 104 matches) stay inline. Disabled in both page-filter interactions.
+  //      Band is 78px so the content breathes. ----
+  block header_rail: wc_header_rail()
+
+  // ---- The pitch: mown-turf panel + white field markings. Lowest layer; content stacks on top.
+  //      REUSABLE: surface styles (.wc-pitch) live in the theme with height:100%, so this one block can be
+  //      placed at ANY size on any tab with zero edits here: the boundary, halfway line, centre circle/spot
+  //      and corner arcs are theme classes anchored by the box model (insets + 50%), so they reposition
+  //      themselves when the block resizes. The only fixed coordinates are inside the top penalty-box SVG,
+  //      which is pinned to the top edge and scales with the block's width — its numbers never change:
+  //        penalty area x 410..1070 depth 212 · six-yard x 580..900 depth 112 · spot (740,152) · arc r=100
+  //      (All markings share the 32px boundary inset and the #e6f0ea 4px stroke, defined in the theme.)
+  block pitch: wc_pitch()
+
+  // ---- The goal + trophy: same content as before (funnel label + goal), now its own block so the pitch
+  //      stays a pure reusable surface. Theme .goal-wrap pins the goal base to the block's bottom edge,
+  //      which the layout places at the same spot the goal previously rendered (bottom of the turf). ----
+  block goal_prize: wc_goal_prize()
+
+  // ---- Standings clipboards: one coach's board per group (A–C), laid on the turf in the upper midfield.
+  // ---- Standings clipboards: one coach's board per group (A–C), laid on the turf in the upper midfield.
+  //      Core grain = wc_group_standings (one row/team) + wc_teams flag/kit (many-to-one, no fan-out).
+  //      qual_color paints each row's left band (top-2 green, 3rd amber, else red). Form chips come from the
+  //      worldcup.team_form_html metric (html format); the points measure anchors the multi-fact join so every
+  //      team stays in the result. Shared .cb-* / .clipboard styles live in the theme. ----
+  block standings_a: wc_group_standings_card('A')
+
+  block standings_b: wc_group_standings_card('B')
+
+  block standings_c: wc_group_standings_card('C')
+
+  // ---- Knockout bracket: "Road to the final" funnelling down the pitch toward the goal. One VizBlock per
+  //      round (wc_matches filtered by stage), ties rendered as cards that wrap and narrow each round. Teams are
+  //      TBD until the groups finish (home/away null → "TBD", flags hidden); venue + date show today. Shared
+  //      .kbr / .tie / .goal styles live in the theme. ----
+  block knockout_label: wc_knockout_label()
+  block ko_r32: wc_knockout_r32()
+
+  block ko_r16: wc_knockout_round('r16', 'Round of 16', '.28s', 8)
+
+  block ko_qf: wc_knockout_round('qf', 'Quarter-finals', '.41s', 4)
+
+  block ko_sf: wc_knockout_round('sf', 'Semi-finals', '.54s', 2)
+
+  block ko_final: wc_knockout_final()
+
+
+  // ---- Groups tab: full-stat clipboards, one per group A–L (theme .cb-x ledger grid).
+  //      All columns are wc_group_standings dimensions (no measures needed) + wc_teams flag. ----
+  block groups_a: wc_group_card('A')
+
+  block groups_b: wc_group_card('B')
+
+  block groups_c: wc_group_card('C')
+
+  block groups_d: wc_group_card('D')
+
+  block groups_e: wc_group_card('E')
+
+  block groups_f: wc_group_card('F')
+
+  block groups_g: wc_group_card('G')
+
+  block groups_h: wc_group_card('H')
+
+  block groups_i: wc_group_card('I')
+
+  block groups_j: wc_group_card('J')
+
+  block groups_k: wc_group_card('K')
+
+  block groups_l: wc_group_card('L')
+
+  // ---- Groups tab: zone labels (own <style> — block CSS only ships with blocks placed on the tab) ----
+  block groups_zone_label: wc_groups_zone_label()
+  block advance_zone_label: wc_advance_zone_label()
+  block thirds_zone_label: wc_thirds_zone_label()
+
+  // ---- Advancement projector: brushed-steel magnet board, one lane per group A–L. Each team is a
+  //      colour magnet puck positioned by its Monte-Carlo odds to reach the Round of 32 (wc_team_snapshot
+  //      p_r32). Own bespoke material (steel + magnets), not the chalk slate / clipboard. ----
+  block advance_board: wc_advance_board()
+
+  // ---- Best-thirds board: the 12 third-placed teams ranked across groups; top 8 advance to the
+  //      Round of 32 (2026 format). One wide clipboard — the dashed amber rule under row 8 (theme
+  //      .cb-tp) is the qualification line; qual_color/qual_status drive the row bands (no template
+  //      conditionals). All fields are wc_third_place_ranking dimensions + the wc_teams flag. ----
+  block third_place_board: wc_third_place_board()
+  block hq_team_filter: FilterBlock {
+    label: 'Nation'
+    type: 'field'
+    source: FieldFilterSource {
+      dataset: worldcup
+      field: r(wc_teams.name)
+    }
+    default {
+      operator: 'is'
+      value: 'Mexico'
+    }
+    settings {
+      input_type: 'nullable-single'
+    }
+  }
+
+  block hq_filter_hint: wc_hq_filter_hint()
+
+  // ---- LED nameplate: the tab's "dressing room board" on the stadium surround.
+  //      Same bezel/screen language as the jumbotron, scaled down; kit ribbon = team colour.
+  //      Elo baseline = rank among the 48 (honest, computed in wc_team_snapshot);
+  //      title-odds baseline = field average 1/48 ≈ 2.1% (constant by construction). ----
+  block hq_banner: wc_hq_banner()
+
+  block hq_zone_left: wc_hq_zone_left()
+
+  block hq_zone_right: wc_hq_zone_right()
+
+  block hq_zone_squad: wc_hq_zone_squad()
+
+  // ---- Honours board: all-time pedigree counts on one clipboard. Counts roll up through
+  //      wc_team_aliases, so defunct-nation honours land on the successor (FRG → GER). ----
+  block hq_honours: wc_hq_honours()
+
+  // ---- Campaign ledger: one row per edition played, latest first. Finish badge colour is the
+  //      finish_color driver dimension (champion gold / final silver / semi bronze) — no template
+  //      conditionals. row_limit trims long histories; the footer says so. ----
+  block hq_campaigns: wc_hq_campaigns()
+
+  // ---- Next-fixture card: who's next, where, and the all-time tally against them.
+  //      All next_* dims repeat on every H2H row, so grouping collapses to one card;
+  //      the W/D/L tally measures aggregate the same rows the H2H ledger lists. ----
+  block hq_next_match: wc_hq_next_match()
+
+  // ---- H2H ledger: every World Cup meeting vs the next opponent, scored from the selected
+  //      team's side. The result chip colour is the result_color driver dimension. ----
+  block hq_h2h: wc_hq_h2h()
+
+  // ---- Section label (turf wayfinder) above the Record Book. ----
+  block hq_alltime_zone: wc_hq_zone_alltime()
+
+  // ---- The Record Book: all-time World Cup head-to-head vs every nation faced (1930–2022),
+  //      the 12 most-played rivals. Own material (a bound football almanac, NOT the clipboard);
+  //      each row's dominance bar is flex-proportioned to its win/draw/loss share. Opponent name +
+  //      crest are resolved inside the wc_history_h2h model so every historical nation shows (not
+  //      just the 48 in the 2026 field). Scoped to the Nation filter via an explicit wc_teams.name
+  //      mapping (the team side), since wc_opponent_teams.name would otherwise capture the filter. ----
+  block hq_alltime_h2h: wc_hq_alltime_h2h()
+  block hq_squad_gk: wc_squad_gk()
+
+  block hq_squad_df: wc_squad_section('DF', '#1D3F8E', 'Defenders')
+
+  block hq_squad_mf: wc_squad_section('MF', '#1f9d52', 'Midfielders')
+
+  block hq_squad_fw: wc_squad_section('FW', '#E61D25', 'Forwards')
+
+  // ---- Tournament pulse: the selected team's CURRENT campaign — stat chips + a form strip
+  //      with real scorelines ("W 2–0 RSA"), adopted from the concept mockup. Multi-grain:
+  //      rows = one per finished match (form chips), values = team aggregates (multi-fact
+  //      join keeps the row even before the first match). Opponents shown by CODE — the
+  //      nation filter auto-maps by field name, and wc_opponent_teams.name would collide.
+  //      HEIGHT BUDGET (block 320): wrap 32 + clipboard 35 + head 33 + chips 64 + form 38
+  //      + foot 28 + ~40 MarkdownViz overhead ≈ 270. ----
+  block hq_pulse: wc_hq_pulse()
+
+  // ---- Scouting report: a coach's dossier — a stamped verdict + four evidence pillars (attack,
+  //      defence, class, outlook). Every word is a case() metric (scout_*) over live form + the
+  //      Elo/sim model; numbers stay as formatted fields. Distinct material from the LED nameplate,
+  //      painted pulse board, bronze honours and sticker wall. Auto-maps to the nation filter via
+  //      wc_teams.name; disabled for the match filter. ----
+  block hq_scout: wc_hq_scout()
+
+  // ---- Rating trajectory: native Elo LineChart on a crafted dark "rating monitor" chrome, scoped
+  //      to the Nation filter (wc_team_ratings → wc_teams), so it follows the selected team. A
+  //      DateDrillBlock (hq_elo_drill) drives snapshot_date granularity (month/quarter/year) via a
+  //      DateDrillInteraction. Frame + zone label are TextBlocks (no dataset → no filter wiring);
+  //      the chart is disabled on the Match filter. ----
+  block hq_zone_rating: wc_hq_zone_rating()
+  block hq_rating_frame: wc_hq_rating_frame()
+  block hq_rating_chart: wc_hq_rating_chart()
+  block hq_elo_drill: DateDrillBlock {
+    label: 'Granularity'
+    default: 'month'
+  }
+  block hq_rating_move: wc_hq_rating_move()
+
+  // ============================ MATCH CENTER TAB ============================
+  // Per-match detail: pick a match → LED scoreboard, event ticker, team sheets,
+  // odds board. Officials/weather/possession are absent from the source tables
+  // (FIFA live payload gaps) — no blocks fake them.
+  block mc_match_filter: FilterBlock {
+    label: 'Match'
+    type: 'field'
+    source: FieldFilterSource {
+      dataset: worldcup
+      field: r(wc_matches.match_label)
+    }
+    default {
+      operator: 'is'
+      value: '06/12 · 02:00 · KOR vs CZE'
+    }
+    settings {
+      input_type: 'nullable-single'
+    }
+  }
+
+  block mc_filter_hint: wc_mc_filter_hint()
+
+  // ---- Match scoreboard: the jumbotron language scaled to one fixture — kit rails on both
+  //      wings, big LED score (or kickoff time pre-match, via the featured_display drivers). ----
+  block mc_scoreboard: wc_mc_scoreboard()
+
+  block mc_zone_ticker: wc_mc_zone_ticker()
+
+  block mc_zone_odds: wc_mc_zone_odds()
+
+  // ---- Event ticker: goals/cards/subs on a centre spine, home events left, away right
+  //      (side + colours are model driver dims — no template conditionals). Running score
+  //      chips appear on goal events only (score_chip empty otherwise → :empty hides). ----
+  block mc_timeline: wc_mc_timeline()
+
+  // ---- Team sheets: one clipboard per side — starters XI above the dashed cut, bench below
+  //      (role driver dim = row class; the xi→bench transition styles the divider). Captain
+  //      armband from captain_tag (:empty hides). Sorted GK→DF→MF→FW then shirt number. ----
+  block mc_lineup_home: wc_mc_lineup_home()
+
+  block mc_lineup_away: wc_mc_lineup_away()
+
+  // ---- Odds board: latest Elo→Poisson run for the selected match — three-way probability
+  //      bar in kit colours (draw grey), expected score, and day-over-day delta chips
+  //      (labels/colours computed in wc_match_odds SQL; empty on the first run). M1–M2
+  //      pre-date the first run → platform empty-state, called out in the filter hint. ----
+  block mc_odds: wc_mc_odds()
+
+  // ---- Starting line-ups: broadcast formation graphic — two vertical half-pitches, one
+  //      photo token per starter (kit ring, shirt badge, gold GK, captain armband), popping
+  //      in on a GK→defence→attack cascade. All layout (stage_x/y_pct) and stagger
+  //      (reveal_delay) come from wc_lineup_grid; the template only places tokens, so no
+  //      conditionals and no JS — the cascade replays whenever the match filter changes.
+  //      Tokens are %-positioned: the stage scales with the block, no overflow possible. ----
+  block mc_formations: wc_mc_formations()
+
+  // ---- Momentum: a native LineChart (gold step trace of wc_events.score_margin over minute_num)
+  //      layered on a crafted "plotter" chrome — the first native-viz-on-crafted-chrome surface.
+  //      The chart auto-maps to the Match filter (wc_events→wc_matches); disabled on the Nation
+  //      filter. The frame + zone label are TextBlocks (no dataset → no interaction wiring). ----
+  block mc_zone_momentum: wc_mc_zone_momentum()
+  block mc_momentum_frame: wc_mc_momentum_frame()
+  block mc_momentum_chart: wc_mc_momentum_chart()
+
+  // ============================ CONTENDER INDEX TAB ============================
+  // "Who's actually good" — ranked by the nightly sim's title odds (the sim IS the
+  // approved Elo-prior blend: ratings update with results, odds re-run nightly).
+  // Material: the manager's chalkboard — wooden frame, slate, chalk lines. New
+  // object on this page; not clipboard, LED or split-flap.
+  block ci_zone: wc_ci_zone()
+
+  // ---- The big board: top 10 by title odds. Elo spark = 24 months, SQL-built polyline
+  //      (see wc_contender_board). HEIGHT BUDGET (block 860): frame 24 + slate 32 + head 41
+  //      + 10 rows × 53 + foot 21 + ~40 MarkdownViz body overhead ≈ 700. ----
+  block ci_board: wc_ci_board()
+
+  // ---- Road survival: P(reach stage) ladders for the top 6 — six chalk columns per team,
+  //      gold column = lift the trophy. HEIGHT BUDGET (block 860): frame 24 + slate 32 +
+  //      head 41 + 6 sections × 95 + foot 21 + ~40 MarkdownViz body overhead ≈ 730. ----
+  block ci_ladder: wc_ci_ladder()
+
+  // ============================ HISTORY TAB ============================
+  // "Who owns the World Cup" — the all-time archive 1930–2022. All-time stats are grouped on
+  // wc_team_aliases.entity_code (successor rollup: West Germany→Germany=4, Soviet/Yugoslav/
+  // Czechoslovak records into Russia/Serbia/Czechia, East Germany kept as its own entity), with
+  // entity_name/entity_flag giving readable labels + crests for nations the 2026 table never had.
+  // Material: an engraved bronze honours plaque on walnut — the trophy-cabinet wall. New, 8th object;
+  // its signature is DEBOSSED Roman-inscription lettering (Cinzel), not the emissive/printed/raised
+  // text of the LED, split-flap, chalkboard, sticker, glass or enamel-scoreboard materials.
+  // ---- Trophy-hall backdrop (replaces the pitch turf on this tab): a dim honours gallery — deep
+  //      stadium-green-to-charcoal wall, a warm overhead spotlight pooling on the board, faint
+  //      wood-panel seams, a marble floor sheen and a vignette. Lowest layer; the plaque sits on it
+  //      like a trophy cabinet under a museum light. height:100% so it fills whatever the layout gives it. ----
+  block hist_wall: wc_hist_wall()
+
+  block hist_zone: wc_hist_zone()
+
+  // ---- Hall of Champions: every nation that has lifted the trophy, by titles. The hero of the tab.
+  //      Title count is the focal engraving; finals/semis/apps and the first–last span give every
+  //      headline its comparison (a champion's reign in context). Rank via CSS counter (rows arrive
+  //      pre-sorted), so no rank field is needed. Opaque plaque → height:auto so the block's scroll
+  //      headroom renders as turf below (design rule). HEIGHT BUDGET (block 740): walnut 16·2 +
+  //      plate 18·2 + title 60 + colhead 20 + 8 rows·54 + foot 26 + ~40 MarkdownViz ≈ 646 → ~13% turf. ----
+  block hist_champions: wc_hist_champions()
+
+  // ---- Roll of Champions: every final 1930–2022 engraved chronologically on a second bronze plaque —
+  //      EDITION · HOST | champion (gold) | scoreline | runner-up. One row per edition from the
+  //      wc_history_finals query model (21 stage='final' + the 1950 Maracanazo). Same walnut/bronze/Cinzel
+  //      material as the Hall; .roll-* prefix so its denser ledger layout never inherits the Hall's hero rows.
+  //      Opaque plaque → height:auto so the block's scroll headroom renders as wall below (design rule).
+  //      HEIGHT BUDGET (block 1640): walnut 22·2 + plate 18·2 + title 50 + sub 27 + colhead 24 +
+  //      22 rows·53 (stacked year/host cell governs) + foot 40 + ~40 MarkdownViz ≈ 1420 → ~15% wall
+  //      headroom, all 22 rows visible without an inner scroll. ----
+  block hist_roll: wc_hist_roll()
+
+  // ---- All-time pedigree leaderboard: top 12 nations by a weighted prestige index (8·titles + 4·finals +
+  //      2·semis + apps), grouped on wc_team_aliases.entity_code (successor rollup). Every bar is scaled to
+  //      the leader (Brazil) and carries a baseline notch at the field-average pedigree — no score ships
+  //      without its comparison. Third bronze plaque, same material, .ped-* prefix. Opaque → height:auto.
+  //      HEIGHT BUDGET (block 1000): walnut 22·2 + plate 18·2 + title 60 + sub 16 + colhead 22 +
+  //      12 rows·52 + foot 24 + ~40 MarkdownViz ≈ 860 → ~15% wall headroom. ----
+  block hist_pedigree: wc_hist_pedigree()
+
+  // ---- Edition comparison: CRAFTED MarkdownViz (bronze-plaque column timeline, goals/match per
+  //      edition, 2026 gold + dashed average line). Static surface (no filter/drill/pop) → stays on
+  //      the History wall material rather than a native chart. Bar heights from inline window measures.
+  //      In both disable lists for consistency; zone label is a TextBlock. ----
+  block hist_zone_editions: wc_hist_zone_editions()
+  block hist_editions: wc_hist_editions()
+
+  // ============================ PLAYERS TAB ============================
+  // "Stars of the tournament" — a FUT-card wall of every goal contributor, ranked by G+A
+  //   (wc_player_stats). Each card opens the shared player-profile popover (pp-* skin in
+  //   header_rail) with bio (wc_player_bio: age/club/position) + 6-stat grid + goal log.
+  block pack_reveal: wc_pack_reveal()
+  block players_zone_label: wc_players_zone_label()
+  block player_gallery: wc_player_gallery()
+  // "The race" — two timing-board ladders (Golden Boot / Playmaker) below the FUT wall,
+  // seated on their own dark backdrop so they don't float on the green page surround.
+  block race_backdrop: wc_race_backdrop()
+  block race_zone_label: wc_race_zone_label()
+  block boot_ladder: wc_boot_ladder()
+  block playmaker_ladder: wc_playmaker_ladder()
+  view: TabLayout {
+    label: 'View 1'
+    tab tab_tournament: CanvasLayout {
+      label: 'Tournament'
+      width: 1600
+      height: 3280
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block jumbotron {
+        position: pos(60, 96, 1480, 240)
+        layer: 5
+      }
+      block pitch {
+        position: pos(60, 320, 1480, 2940)
+        layer: 1
+      }
+      block match_cards {
+        position: pos(117, 846, 1370, 400)
+        layer: 5
+      }
+      block standings_a {
+        position: pos(115, 1236, 438, 300)
+        layer: 6
+      }
+      block standings_b {
+        position: pos(580, 1236, 440, 300)
+        layer: 6
+      }
+      block standings_c {
+        position: pos(1047, 1236, 438, 300)
+        layer: 6
+      }
+      block featured_match {
+        position: pos(340, 380, 920, 440)
+        layer: 8
+      }
+      block boot_podium {
+        position: pos(120, 1620, 1380, 320)
+        layer: 6
+      }
+      block boot_rack {
+        position: pos(480, 1940, 660, 260)
+        layer: 6
+      }
+      block knockout_label {
+        position: pos(115, 3034, 1370, 32)
+        layer: 5
+      }
+      block ko_r32 {
+        position: pos(115, 2252, 1370, 160)
+        layer: 6
+      }
+      block ko_r16 {
+        position: pos(115, 2420, 1370, 115)
+        layer: 6
+      }
+      block ko_qf {
+        position: pos(115, 2543, 1370, 115)
+        layer: 6
+      }
+      block ko_sf {
+        position: pos(115, 2666, 1370, 115)
+        layer: 6
+      }
+      block ko_final {
+        position: pos(115, 2789, 1370, 125)
+        layer: 6
+      }
+      block goal_prize {
+        position: pos(580, 2940, 440, 280)
+        layer: 7
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.8
+    }
+    tab tab_match_center: CanvasLayout {
+      label: 'Match Center'
+      width: 1600
+      height: 2260
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block mc_scoreboard {
+        position: pos(60, 96, 1140, 240)
+        layer: 5
+      }
+      block mc_match_filter {
+        position: pos(1230, 110, 280, 80)
+        layer: 8
+      }
+      block mc_filter_hint {
+        position: pos(1230, 196, 280, 130)
+        layer: 5
+      }
+      block pitch {
+        position: pos(60, 360, 1480, 1880)
+        layer: 1
+      }
+      block mc_zone_ticker {
+        position: pos(465, 404, 670, 32)
+        layer: 5
+      }
+      block mc_lineup_home {
+        position: pos(115, 432, 330, 1020)
+        layer: 6
+      }
+      block mc_formations {
+        position: pos(465, 452, 670, 500)
+        layer: 6
+      }
+      block mc_timeline {
+        position: pos(465, 972, 670, 500)
+        layer: 6
+      }
+      block mc_lineup_away {
+        position: pos(1155, 432, 330, 1020)
+        layer: 6
+      }
+      block mc_zone_odds {
+        position: pos(115, 1496, 1370, 28)
+        layer: 5
+      }
+      block mc_odds {
+        position: pos(115, 1536, 1370, 260)
+        layer: 6
+      }
+      block mc_zone_momentum {
+        position: pos(115, 1836, 1370, 32)
+        layer: 5
+      }
+      block mc_momentum_frame {
+        position: pos(115, 1876, 1370, 300)
+        layer: 6
+      }
+      block mc_momentum_chart {
+        position: pos(131, 1929, 1340, 216)
+        layer: 7
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.8
+    }
+    tab tab_groups: CanvasLayout {
+      label: 'Groups'
+      width: 1600
+      height: 2920
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block pitch {
+        position: pos(60, 96, 1480, 2810)
+        layer: 1
+      }
+      block groups_zone_label {
+        position: pos(115, 150, 1370, 32)
+        layer: 5
+      }
+      block groups_a {
+        position: pos(115, 200, 438, 300)
+        layer: 6
+      }
+      block groups_b {
+        position: pos(580, 200, 440, 300)
+        layer: 6
+      }
+      block groups_c {
+        position: pos(1047, 200, 438, 300)
+        layer: 6
+      }
+      block groups_d {
+        position: pos(115, 520, 438, 300)
+        layer: 6
+      }
+      block groups_e {
+        position: pos(580, 520, 440, 300)
+        layer: 6
+      }
+      block groups_f {
+        position: pos(1047, 520, 438, 300)
+        layer: 6
+      }
+      block groups_g {
+        position: pos(115, 840, 438, 300)
+        layer: 6
+      }
+      block groups_h {
+        position: pos(580, 840, 440, 300)
+        layer: 6
+      }
+      block groups_i {
+        position: pos(1047, 840, 438, 300)
+        layer: 6
+      }
+      block groups_j {
+        position: pos(115, 1160, 438, 300)
+        layer: 6
+      }
+      block groups_k {
+        position: pos(580, 1160, 440, 300)
+        layer: 6
+      }
+      block groups_l {
+        position: pos(1047, 1160, 438, 300)
+        layer: 6
+      }
+      block advance_zone_label {
+        position: pos(115, 1510, 1370, 32)
+        layer: 5
+      }
+      block advance_board {
+        position: pos(120, 1560, 1380, 600)
+        layer: 6
+      }
+      block thirds_zone_label {
+        position: pos(115, 2210, 1370, 32)
+        layer: 5
+      }
+      block third_place_board {
+        position: pos(420, 2260, 760, 580)
+        layer: 6
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.8
+    }
+    tab tab_team_hq: CanvasLayout {
+      label: 'Team HQ'
+      width: 1600
+      height: 4800
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block hq_banner {
+        position: pos(60, 96, 1140, 200)
+        layer: 5
+      }
+      block hq_team_filter {
+        position: pos(1230, 110, 280, 80)
+        layer: 8
+      }
+      block hq_filter_hint {
+        position: pos(1230, 196, 280, 90)
+        layer: 5
+      }
+      block pitch {
+        position: pos(60, 320, 1480, 4400)
+        layer: 1
+      }
+      block hq_pulse {
+        position: pos(115, 400, 1370, 260)
+        layer: 6
+      }
+      block hq_scout {
+        position: pos(120, 620, 1360, 300)
+        layer: 6
+      }
+      block hq_zone_left {
+        position: pos(115, 1008, 700, 32)
+        layer: 5
+      }
+      block hq_zone_right {
+        position: pos(845, 1008, 640, 32)
+        layer: 5
+      }
+      block hq_honours {
+        position: pos(115, 1060, 700, 320)
+        layer: 6
+      }
+      block hq_next_match {
+        position: pos(845, 1060, 640, 320)
+        layer: 6
+      }
+      block hq_campaigns {
+        position: pos(115, 1400, 700, 700)
+        layer: 6
+      }
+      block hq_h2h {
+        position: pos(845, 1400, 640, 700)
+        layer: 6
+      }
+      block hq_alltime_zone {
+        position: pos(115, 2140, 1370, 32)
+        layer: 5
+      }
+      block hq_alltime_h2h {
+        position: pos(115, 2192, 1370, 620)
+        layer: 6
+      }
+      block hq_zone_rating {
+        position: pos(115, 2840, 1370, 32)
+        layer: 5
+      }
+      block hq_rating_frame {
+        position: pos(115, 2888, 1370, 330)
+        layer: 6
+      }
+      block hq_rating_chart {
+        position: pos(150, 2920, 1300, 250)
+        layer: 7
+      }
+      block hq_rating_move {
+        position: pos(160, 2940, 120, 40)
+        layer: 8
+      }
+      block hq_elo_drill {
+        position: pos(1186, 2875, 280, 40)
+        layer: 8
+      }
+      block hq_zone_squad {
+        position: pos(115, 3260, 1370, 56)
+        layer: 5
+      }
+      block hq_squad_gk {
+        position: pos(120, 3320, 1380, 220)
+        layer: 6
+      }
+      block hq_squad_df {
+        position: pos(120, 3560, 1380, 360)
+        layer: 6
+      }
+      block hq_squad_mf {
+        position: pos(120, 3920, 1380, 360)
+        layer: 6
+      }
+      block hq_squad_fw {
+        position: pos(120, 4300, 1380, 220)
+        layer: 6
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.8
+    }
+    tab tab_players: CanvasLayout {
+      label: 'Players'
+      width: 1600
+      height: 2260
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block pack_reveal {
+        position: pos(60, 100, 1480, 1440)
+        layer: 1
+      }
+      block players_zone_label {
+        position: pos(115, 140, 1370, 32)
+        layer: 5
+      }
+      block player_gallery {
+        position: pos(120, 260, 1380, 1140)
+        layer: 6
+      }
+      block race_backdrop {
+        position: pos(60, 1560, 1480, 680)
+        layer: 1
+      }
+      block race_zone_label {
+        position: pos(115, 1570, 1370, 32)
+        layer: 5
+      }
+      block boot_ladder {
+        position: pos(115, 1620, 675, 560)
+        layer: 6
+      }
+      block playmaker_ladder {
+        position: pos(810, 1620, 675, 560)
+        layer: 6
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.8
+    }
+    tab tab_history: CanvasLayout {
+      label: 'History'
+      width: 1600
+      height: 3990
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block hist_wall {
+        position: pos(60, 100, 1480, 3860)
+        layer: 1
+      }
+      block hist_zone {
+        position: pos(115, 140, 1370, 32)
+        layer: 5
+      }
+      block hist_champions {
+        position: pos(115, 192, 1370, 880)
+        layer: 6
+      }
+      block hist_roll {
+        position: pos(115, 1000, 1370, 1640)
+        layer: 6
+      }
+      block hist_pedigree {
+        position: pos(115, 2408, 1370, 1000)
+        layer: 6
+      }
+      block hist_zone_editions {
+        position: pos(115, 3408, 1370, 32)
+        layer: 5
+      }
+      block hist_editions {
+        position: pos(115, 3456, 1370, 410)
+        layer: 6
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.85
+    }
+    tab tab_contenders: CanvasLayout {
+      label: 'Contender Index'
+      width: 1600
+      height: 1146
+      grid_size: 20
+      auto_expand_vertically: true
+      block header_rail {
+        position: pos(60, 14, 1480, 78)
+        layer: 5
+      }
+      block pitch {
+        position: pos(60, 96, 1480, 1030)
+        layer: 1
+      }
+      block ci_zone {
+        position: pos(115, 140, 1370, 32)
+        layer: 5
+      }
+      block ci_board {
+        position: pos(115, 192, 800, 860)
+        layer: 6
+      }
+      block ci_ladder {
+        position: pos(935, 192, 550, 860)
+        layer: 6
+      }
+      mobile {
+        mode: 'auto'
+      }
+      default_zoom: 0.8
+    }
+  }
+  // Page filters auto-map to every same-dataset viz block on ALL tabs, so each filter
+  // carries an explicit disable list for everything outside its own tab.
+  // - Nation filter: DISABLED outside Team HQ; the squad blocks get an explicit field
+  //   mapping because auto-map matches the filter onto their wc_players.name field
+  //   (player name == 'Mexico' → always empty) instead of wc_teams.name.
+  // - Match filter: wc_matches.match_label collides with nothing, so Match Center blocks
+  //   keep their auto mapping (it propagates through the match_num relationships);
+  //   everything else is disabled.
+  interactions: [
+    FilterInteraction {
+      from: 'hq_team_filter'
+      to: [
+        CustomMapping {
+          block: [
+            'hq_squad_gk',
+            'hq_squad_df',
+            'hq_squad_mf',
+            'hq_squad_fw',
+            'hq_alltime_h2h'
+          ]
+          field: r(wc_teams.name)
+        },
+        CustomMapping {
+          block: [
+            'jumbotron',
+            'match_cards',
+            'featured_match',
+            'boot_podium',
+            'boot_rack',
+            'standings_a',
+            'standings_b',
+            'standings_c',
+            'ko_r32',
+            'ko_r16',
+            'ko_qf',
+            'ko_sf',
+            'ko_final',
+            'groups_a',
+            'groups_b',
+            'groups_c',
+            'groups_d',
+            'groups_e',
+            'groups_f',
+            'groups_g',
+            'groups_h',
+            'groups_i',
+            'groups_j',
+            'groups_k',
+            'groups_l',
+            'advance_board',
+            'third_place_board',
+            'player_gallery',
+            'boot_ladder',
+            'playmaker_ladder',
+            'mc_scoreboard',
+            'mc_timeline',
+            'mc_formations',
+            'mc_lineup_home',
+            'mc_lineup_away',
+            'mc_odds',
+            'ci_board',
+            'ci_ladder',
+            'hist_champions',
+            'hist_roll',
+            'hist_pedigree',
+            'hist_editions',
+            'header_rail',
+            'mc_match_filter',
+            'mc_momentum_chart'
+          ]
+          disabled: true
+        }
+      ]
+    },
+    FilterInteraction {
+      from: 'mc_match_filter'
+      to: [
+        CustomMapping {
+          block: [
+            'jumbotron',
+            'match_cards',
+            'featured_match',
+            'boot_podium',
+            'boot_rack',
+            'standings_a',
+            'standings_b',
+            'standings_c',
+            'ko_r32',
+            'ko_r16',
+            'ko_qf',
+            'ko_sf',
+            'ko_final',
+            'groups_a',
+            'groups_b',
+            'groups_c',
+            'groups_d',
+            'groups_e',
+            'groups_f',
+            'groups_g',
+            'groups_h',
+            'groups_i',
+            'groups_j',
+            'groups_k',
+            'groups_l',
+            'advance_board',
+            'third_place_board',
+            'player_gallery',
+            'boot_ladder',
+            'playmaker_ladder',
+            'hq_banner',
+            'hq_pulse',
+            'hq_scout',
+            'hq_honours',
+            'hq_next_match',
+            'hq_campaigns',
+            'hq_h2h',
+            'hq_alltime_h2h',
+            'hq_squad_gk',
+            'hq_squad_df',
+            'hq_squad_mf',
+            'hq_squad_fw',
+            'ci_board',
+            'ci_ladder',
+            'hist_champions',
+            'hist_roll',
+            'hist_pedigree',
+            'hist_editions',
+            'header_rail',
+            'hq_team_filter',
+            'hq_rating_chart',
+            'hq_rating_move'
+          ]
+          disabled: true
+        }
+      ]
+    },
+    DateDrillInteraction {
+      from: 'hq_elo_drill'
+      to: [
+        CustomMapping {
+          block: 'hq_rating_chart'
+          field: r(wc_team_ratings.snapshot_date)
+        }
+      ]
+    }
+  ]
+  settings {
+    timezone: 'Etc/UTC'
+    cache_duration: 10
+    autorun_on_open: true
+  }
+}


### PR DESCRIPTION
## Overview
This PR corrects the running total metric and label on the `business_users_metric_promotion` dashboard to track Total Users instead of Total Revenue, aligning with the intended business KPI of user growth.

## Changes
- Renamed VizBlock from `v_m825` to `v_pzpr` for clarity
- Updated metric calculation from running total of `revenue` to running total of `total_users` in the dataset `demo_ecommerce_version_2`
- Adjusted label to "Running total of Total Users"
- Fixed number format pattern from inherited/none to explicit 'none' for consistent display

This change ensures the dashboard correctly reflects user growth over time, supporting user retention and engagement monitoring aligned with current business focus.

## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=thuan-hm-dev

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)