### PR TITLE
Refine ecommerce dashboards and improve visualization clarity

### DIFF
--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_tournament.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_tournament.block.aml
@@ -617,11 +617,11 @@ Func wc_boot_podium() {
       rows: [
         VizFieldFull {
           label: 'Scorer'
-          ref: r(wc_scorers.player_name)
+          ref: r(wc_player_stats.name)
         },
         VizFieldFull {
           label: 'Photo'
-          ref: r(wc_players.picture_url)
+          ref: r(wc_player_stats.picture_url)
         },
         VizFieldFull {
           label: 'Flag'
@@ -633,11 +633,11 @@ Func wc_boot_podium() {
         },
         VizFieldFull {
           label: 'Team'
-          ref: r(wc_scorers.team_code)
+          ref: r(wc_player_stats.team_code)
         },
         VizFieldFull {
           label: 'Rank'
-          ref: r(wc_scorers.boot_rank)
+          ref: r(wc_player_stats.goals_rank)
           format {
             type: 'number'
             pattern: '#,##0'
@@ -645,7 +645,7 @@ Func wc_boot_podium() {
         },
         VizFieldFull {
           label: 'Pens'
-          ref: r(wc_scorers.penalty_goals)
+          ref: r(wc_player_stats.penalty_goals)
           format {
             type: 'number'
             pattern: '#,##0'
@@ -653,7 +653,7 @@ Func wc_boot_podium() {
         },
         VizFieldFull {
           label: 'Goals'
-          ref: r(wc_scorers.goals)
+          ref: r(wc_player_stats.goals)
           uname: 'goals'
           format {
             type: 'number'
@@ -726,14 +726,14 @@ Func wc_boot_rack() {
     viz: MarkdownViz {
       dataset: worldcup
       filter {
-        field: r(wc_scorers.boot_rank)
+        field: r(wc_player_stats.goals_rank)
         operator: 'greater_than'
         value: 3
       }
       rows: [
         VizFieldFull {
           label: 'Scorer'
-          ref: r(wc_scorers.player_name)
+          ref: r(wc_player_stats.name)
         },
         VizFieldFull {
           label: 'Flag'
@@ -741,11 +741,11 @@ Func wc_boot_rack() {
         },
         VizFieldFull {
           label: 'Team'
-          ref: r(wc_scorers.team_code)
+          ref: r(wc_player_stats.team_code)
         },
         VizFieldFull {
           label: 'Rank'
-          ref: r(wc_scorers.boot_rank)
+          ref: r(wc_player_stats.goals_rank)
           format {
             type: 'number'
             pattern: '#,##0'
@@ -753,18 +753,16 @@ Func wc_boot_rack() {
         },
         VizFieldFull {
           label: 'Goals'
-          ref: r(wc_scorers.goals)
+          ref: r(wc_player_stats.goals)
           uname: 'goals'
           format {
             type: 'number'
             pattern: '#,##0'
           }
-        }
-      ]
-      values: [
+        },
         VizFieldFull {
           label: 'BarPct'
-          ref: r(worldcup.scorer_bar_pct)
+          ref: r(wc_player_stats.goals_bar_pct)
           format {
             type: 'number'
             pattern: '#,##0'
@@ -794,7 +792,7 @@ Func wc_boot_rack() {
   <div class="brk-h"><span class="t">Chasing pack</span><span class="s">rank 4+ · goals</span></div>
   <ul class="brk-list wc-num">
 {% map(rows) %}
-  <li><span class="rk">{{ `Rank`.formatted }}</span><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" /><span class="pn">{{ `Scorer`.formatted }} <small>{{ `Team`.formatted }}</small></span><span class="bar"><i style="width:{{ values.`BarPct`.raw }}%"></i></span><span class="gl">{{ `Goals`.formatted }}</span></li>
+  <li><span class="rk">{{ `Rank`.formatted }}</span><img src="{{ `Flag`.raw }}" alt="" style="margin:0 !important" /><span class="pn">{{ `Scorer`.formatted }} <small>{{ `Team`.formatted }}</small></span><span class="bar"><i style="width:{{ `BarPct`.raw }}%"></i></span><span class="gl">{{ `Goals`.formatted }}</span></li>
 {% end %}
   </ul>
 </div> ;;

--- a/testing-claude.page.aml
+++ b/testing-claude.page.aml
@@ -71,6 +71,115 @@ Dashboard testing_claude {
     }
   }
 
+  block v3: VizBlock {
+    settings {
+      hide_label: true
+    }
+    viz: MarkdownViz {
+      dataset: worldcup
+      rows: [
+        VizFieldFull {
+          label: 'Scorer'
+          ref: r(wc_scorers.player_name)
+        },
+        VizFieldFull {
+          label: 'Photo'
+          ref: r(wc_players.picture_url)
+        },
+        VizFieldFull {
+          label: 'Flag'
+          ref: r(wc_teams.flag_url)
+        },
+        VizFieldFull {
+          label: 'TeamColor'
+          ref: r(wc_teams.color_hex)
+        },
+        VizFieldFull {
+          label: 'Team'
+          ref: r(wc_scorers.team_code)
+        },
+        VizFieldFull {
+          label: 'Rank'
+          ref: r(wc_scorers.boot_rank)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Pens'
+          ref: r(wc_scorers.penalty_goals)
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        },
+        VizFieldFull {
+          label: 'Goals'
+          ref: r(wc_scorers.goals)
+          uname: 'goals'
+          format {
+            type: 'number'
+            pattern: '#,##0'
+          }
+        }
+      ]
+      content: @md <style>
+.bp-title { text-align:center; font-family:var(--font-disp); font-weight:700; text-transform:uppercase;
+  letter-spacing:.22em; font-size:11px; color:var(--line); text-shadow:0 1px 4px rgba(0,0,0,.4); opacity:.9;
+  margin:0 0 24px; }
+/* podium order with 3 cards: leader centre (raised + scaled), runner-up left, third right.
+   With exactly 2 (a tie or thin data) both render equal — no false hero. Count-aware via CSS:
+   :first-child:nth-last-child(2) = first of exactly two; :nth-child(2):nth-last-child(2) = middle of three. */
+.bp-row { flex:1; min-height:0; display:flex; justify-content:center; align-items:flex-end; gap:24px; }
+.bp-row .fut:first-child { --rest:perspective(900px) translateY(0) rotateY(0deg) scale(1.12); transform-origin:bottom center; z-index:2;
+  filter:drop-shadow(0 12px 14px rgba(7,30,18,.45)) drop-shadow(0 0 18px rgba(242,200,75,.5)); }
+.bp-row .fut:first-child:nth-last-child(2), .bp-row .fut:first-child:last-child { --rest:perspective(900px) translateY(0) rotateY(0deg) scale(1); }
+.bp-row .fut:nth-child(2):nth-last-child(2) { order:-1; }
+/* The shared .fut card material (shield, foil, tiers t1/t2/t3, deal + foil-hover) lives in
+   header_rail so the podium and the Players gallery are one identical component. Only the
+   podium LAYOUT is here: deal stagger (leader lands last) + the leader's bigger hover. */
+.bp-row .fut:nth-child(1) { animation-delay:.34s; }
+.bp-row .fut:nth-child(2) { animation-delay:.08s; }
+.bp-row .fut:nth-child(3) { animation-delay:.20s; }
+.bp-row .fut:first-child:hover { transform:perspective(900px) translateY(-12px) rotateY(0deg) scale(1.18); }
+</style>
+<p class="bp-title">Golden Boot race</p>
+<div class="bp-row mt-12">
+{% map(rows) %}
+  <article class="fut t{{ `Rank`.formatted }}" style="--teamc:{{ `TeamColor`.raw }};">
+    <svg class="fut-frame" viewBox="0 0 176 232" aria-hidden="true">
+      <path d="M 0 34 C 0 18 10 8 26 7 L 64 7 C 74 7 80 2 88 2 C 96 2 102 7 112 7 L 150 7 C 166 8 176 18 176 34 L 176 168 C 176 192 168 204 146 214 C 124 223 102 230 88 230 C 74 230 52 223 30 214 C 8 204 0 192 0 168 Z" fill="none" stroke="#a37920" stroke-width="5"/>
+    </svg>
+    <span class="fut-medal wc-num">{{ `Rank`.formatted }}</span>
+    <div class="fut-body">
+      <div class="fut-top">
+        <div class="fut-rate"><span class="n wc-num">{{ `Goals`.formatted }}</span><span class="u">Goals</span><img class="fut-flag" src="{{ `Flag`.raw }}" alt="" /></div>
+        <div class="fut-ph"><img src="{{ `Photo`.raw }}" alt="" /></div>
+      </div>
+      <div class="fut-name">{{ `Scorer`.formatted }}</div>
+      <div class="fut-meta">{{ `Team`.formatted }} · <b class="wc-num">{{ `Goals`.formatted }}</b> gls · <b class="wc-num">{{ `Pens`.formatted }}</b> pen</div>
+    </div>
+  </article>
+{% end %}
+</div> ;;
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'goals'
+            direction: 'desc'
+          }
+        ]
+        pagination_size: 3
+        row_limit: 3
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+  }
+
   view: CanvasLayout {
     label: 'View 1'
     width: 1300
@@ -82,6 +191,9 @@ Dashboard testing_claude {
     }
     block v2 {
       position: pos(660, 20, 620, 400)
+    }
+    block v3 {
+      position: pos(60, 440, 620, 420)
     }
   }
 }


### PR DESCRIPTION
## Overview
This PR enhances the ecommerce demo dashboards by improving visualization types, layout arrangements, and styling for better clarity and user experience. The purpose is to present data more intuitively, aiding stakeholders in understanding sales trends, customer demographics, and product performance.

## Changes
- Updated `company_dashboard_v2` to use `LineChart` for revenue trends replacing `CombinationChart` for clearer time series visualization
- Adjusted block positions and canvas layout sizes across multiple tabs for optimized dashboard spacing and readability
- Refined styling of deals component for consistent visual hierarchy and responsiveness
- Improved `age_demographic` filtering in `_3_customer_demographics_demo` to allow finer user segmentation
- Cleaned up color and label settings in charts for better visual distinction
- Fixed field references from shorthand `r()` to explicit `ref()` for consistency and clarity
- Added a new Golden Boot race visualization in `testing_claude` dashboard showcasing player stats with enhanced styling and sorting
- Renamed and corrected metric and visualization blocks to align with displayed data (e.g., running total of users instead of revenue)
- Updated World Cup 2026 blocks to use consistent player stats references improving data accuracy

These refinements support more actionable insights for merchants, users, and operations teams by delivering clearer and better-organized data presentations.

... minor fixes to pagination, formatting, and aggregate awareness settings

## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=thuan-hm-dev

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)