### PR TITLE
Remove row_limit from World Cup 2026 dashboard blocks for correct pagination

### DIFF
--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_advance_board.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_advance_board.block.aml
@@ -290,7 +290,6 @@ Func wc_advance_board() {
           }
         ]
         pagination_size: 48
-        row_limit: 48
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_contenders.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_contenders.block.aml
@@ -19,6 +19,13 @@ Func wc_ci_board() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // Top 10 by title odds via a 10th-rank filter — row_limit is dropped on MarkdownViz shareable
+      // links, so the cap lives in the query. odds_rank is a unique 1..N rank (no tie collapse).
+      filter {
+        field: r(wc_contender_board.odds_rank)
+        operator: 'less_than'
+        value: 11
+      }
       rows: [
         VizFieldFull {
           label: 'OddsRank'
@@ -181,7 +188,6 @@ Func wc_ci_board() {
           }
         ]
         pagination_size: 10
-        row_limit: 10
       }
     }
   }
@@ -348,7 +354,6 @@ Func wc_ci_ladder() {
           }
         ]
         pagination_size: 6
-        row_limit: 6
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_group_card.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_group_card.block.aml
@@ -141,7 +141,6 @@ Func wc_group_card(grp: String) {
           }
         ]
         pagination_size: 4
-        row_limit: 4
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_groups.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_groups.block.aml
@@ -143,7 +143,6 @@ Func wc_third_place_board() {
           }
         ]
         pagination_size: 12
-        row_limit: 12
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_header_rail.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_header_rail.block.aml
@@ -425,7 +425,6 @@ button.stk { appearance:none; -webkit-appearance:none; border:none; font:inherit
           }
         ]
         pagination_size: 6
-        row_limit: 6
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hist_editions.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hist_editions.block.aml
@@ -224,7 +224,6 @@ Func wc_hist_editions() {
           }
         ]
         pagination_size: 30
-        row_limit: 30
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_history.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_history.block.aml
@@ -42,6 +42,14 @@ Func wc_hist_champions() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // Hall of champions = the nations that have actually won (exactly 8). Filtering on wc_titles>0
+      // is both the correct definition and shareable-safe; row_limit is dropped on MarkdownViz
+      // shareable links, and without this guard every nation that ever played would render.
+      filter {
+        field: r(worldcup.wc_titles)
+        operator: 'greater_than'
+        value: 0
+      }
       rows: [
         VizFieldFull {
           label: 'Team'
@@ -222,7 +230,6 @@ Func wc_hist_champions() {
           }
         ]
         pagination_size: 8
-        row_limit: 8
       }
     }
   }
@@ -382,7 +389,6 @@ Func wc_hist_roll() {
           }
         ]
         pagination_size: 22
-        row_limit: 22
       }
     }
   }
@@ -395,6 +401,21 @@ Func wc_hist_pedigree() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // Top 12 nations by all-time pedigree. row_limit is dropped on MarkdownViz shareable links, so
+      // the cap lives in the query as a Top-12 rank on the pedigree_score metric (aggregation 'custom'
+      // uses the metric's own definition). Without it every nation that ever played would render.
+      filter {
+        field: r(wc_team_aliases.entity_name)
+        operator: 'top'
+        value: 12
+        options {
+          rank_by {
+            field: r(worldcup.pedigree_score)
+            aggregation: 'custom'
+            logic: 'standard'
+          }
+        }
+      }
       rows: [
         VizFieldFull {
           label: 'Team'
@@ -590,7 +611,6 @@ Func wc_hist_pedigree() {
           }
         ]
         pagination_size: 12
-        row_limit: 12
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_pulse.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_pulse.block.aml
@@ -221,7 +221,6 @@ Func wc_hq_pulse() {
           }
         ]
         pagination_size: 8
-        row_limit: 8
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_rating.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_hq_rating.block.aml
@@ -145,9 +145,6 @@ Func wc_hq_rating_move() {
 {% end %}
 </div>
 ;;
-      settings {
-        row_limit: 1
-      }
     }
   }
 }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_knockout.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_knockout.block.aml
@@ -86,7 +86,6 @@ Func wc_knockout_round(stage: String, title: String, rd: String, n: Number) {
           }
         ]
         pagination_size: n
-        row_limit: n
       }
     }
   }
@@ -266,7 +265,6 @@ Func wc_knockout_final() {
           }
         ]
         pagination_size: 1
-        row_limit: 1
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_match_center.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_match_center.block.aml
@@ -161,7 +161,6 @@ Func wc_mc_scoreboard() {
           }
         ]
         pagination_size: 1
-        row_limit: 1
       }
     }
   }
@@ -379,7 +378,6 @@ Func wc_mc_timeline() {
           }
         ]
         pagination_size: 40
-        row_limit: 40
       }
     }
   }
@@ -536,7 +534,6 @@ Func wc_mc_lineup_home() {
           }
         ]
         pagination_size: 26
-        row_limit: 26
       }
     }
   }
@@ -693,7 +690,6 @@ Func wc_mc_lineup_away() {
           }
         ]
         pagination_size: 26
-        row_limit: 26
       }
     }
   }
@@ -934,7 +930,6 @@ Func wc_mc_odds() {
           }
         ]
         pagination_size: 1
-        row_limit: 1
       }
     }
   }
@@ -1118,7 +1113,6 @@ Func wc_mc_formations() {
           }
         ]
         pagination_size: 22
-        row_limit: 22
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_player_gallery.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_player_gallery.block.aml
@@ -122,6 +122,14 @@ Func wc_player_gallery() {
         operator: 'greater_than'
         value: 0
       }
+      // Top 24 by goal contributions via a 24th-rank filter — row_limit is dropped on MarkdownViz
+      // shareable links. The goal_contributions>0 guard above stops zero-contribution players
+      // (collapsed into one tie rank) from flooding the wall on ties.
+      filter {
+        field: r(wc_player_stats.ga_rank)
+        operator: 'less_than'
+        value: 25
+      }
       rows: [
         VizFieldFull { label: 'Pid' ref: r(wc_player_stats.fifa_player_id) },
         VizFieldFull { label: 'Name' ref: r(wc_player_stats.name) },
@@ -212,7 +220,6 @@ button.fut { appearance:none; -webkit-appearance:none; border:none; padding:0; f
           SortSetting { key: 'goals' direction: 'desc' }
         ]
         pagination_size: 24
-        row_limit: 24
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_race_ladder.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_race_ladder.block.aml
@@ -60,6 +60,14 @@ Func wc_boot_ladder() {
         operator: 'greater_than'
         value: 0
       }
+      // Top 8 by goals: filter to the 8th rank instead of row_limit (row_limit is dropped on
+      // MarkdownViz shareable links, so the limit must live in the query as a filter). The goals>0
+      // guard above stops zero-goal players (collapsed to one tie rank) from flooding in on ties.
+      filter {
+        field: r(wc_player_stats.goals_rank)
+        operator: 'less_than'
+        value: 9
+      }
       rows: [
         VizFieldFull { label: 'Rank' ref: r(wc_player_stats.goals_rank) format { type: 'number' pattern: '#,##0' } },
         VizFieldFull { label: 'Name' ref: r(wc_player_stats.name) },
@@ -98,7 +106,6 @@ Func wc_boot_ladder() {
           SortSetting { key: 'goals' direction: 'desc' }
         ]
         pagination_size: 8
-        row_limit: 8
       }
     }
   }
@@ -115,6 +122,13 @@ Func wc_playmaker_ladder() {
         field: r(wc_player_stats.assists)
         operator: 'greater_than'
         value: 0
+      }
+      // Top 8 by assists via 8th-rank filter (see Golden Boot above) — row_limit is not honoured on
+      // MarkdownViz shareable links; the assists>0 guard prevents zero-assist tie flooding.
+      filter {
+        field: r(wc_player_stats.assists_rank)
+        operator: 'less_than'
+        value: 9
       }
       rows: [
         VizFieldFull { label: 'Rank' ref: r(wc_player_stats.assists_rank) format { type: 'number' pattern: '#,##0' } },
@@ -154,7 +168,6 @@ Func wc_playmaker_ladder() {
           SortSetting { key: 'assists' direction: 'desc' }
         ]
         pagination_size: 8
-        row_limit: 8
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_squad.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_squad.block.aml
@@ -146,7 +146,6 @@ Func wc_squad_section(pos: String, color: String, title: String) {
           }
         ]
         pagination_size: 15
-        row_limit: 15
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_standings.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_standings.block.aml
@@ -99,7 +99,6 @@ Func wc_group_standings_card(grp: String) {
           }
         ]
         pagination_size: 4
-        row_limit: 4
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_team_hq.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_team_hq.block.aml
@@ -158,7 +158,6 @@ Func wc_hq_banner() {
 ;;
       settings {
         pagination_size: 1
-        row_limit: 1
       }
     }
   }
@@ -343,6 +342,20 @@ Func wc_hq_campaigns() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // 10 most recent campaigns via a Top-10 rank on the edition year — row_limit is dropped on
+      // MarkdownViz shareable links, so the cap lives in the query. A team can have up to 22 editions.
+      filter {
+        field: r(wc_history_team_editions.year)
+        operator: 'top'
+        value: 10
+        options {
+          rank_by {
+            field: r(wc_history_team_editions.year)
+            aggregation: 'max'
+            logic: 'standard'
+          }
+        }
+      }
       rows: [
         VizFieldFull {
           label: 'Year'
@@ -462,7 +475,6 @@ Func wc_hq_campaigns() {
           }
         ]
         pagination_size: 10
-        row_limit: 10
       }
     }
   }
@@ -612,7 +624,6 @@ Func wc_hq_next_match() {
 ;;
       settings {
         pagination_size: 1
-        row_limit: 1
       }
     }
   }
@@ -702,7 +713,6 @@ Func wc_hq_h2h() {
           }
         ]
         pagination_size: 12
-        row_limit: 12
       }
     }
   }
@@ -715,6 +725,20 @@ Func wc_hq_alltime_h2h() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // 12 most-played rivals via a Top-12 rank on all-time meetings — row_limit is dropped on
+      // MarkdownViz shareable links, so the cap lives in the query. A team can have ~50 opponents.
+      filter {
+        field: r(wc_history_h2h.opp_code)
+        operator: 'top'
+        value: 12
+        options {
+          rank_by {
+            field: r(wc_history_h2h.played)
+            aggregation: 'sum'
+            logic: 'standard'
+          }
+        }
+      }
       rows: [
         VizFieldFull {
           label: 'Opp'
@@ -884,7 +908,6 @@ Func wc_hq_alltime_h2h() {
           }
         ]
         pagination_size: 12
-        row_limit: 12
       }
     }
   }

--- a/04 demo dashboards 2026/World Cup 2026/blocks/wc_tournament.block.aml
+++ b/04 demo dashboards 2026/World Cup 2026/blocks/wc_tournament.block.aml
@@ -120,6 +120,21 @@ Func wc_match_cards() {
         operator: 'is'
         value: true
       }
+      // Soonest 12 upcoming fixtures. row_limit is dropped on MarkdownViz shareable links, so the
+      // cap lives in the query as a Bottom-12 rank on kickoff (earliest 12), matching the kickoff-asc
+      // sort below. The band already excludes finished + featured matches.
+      filter {
+        field: r(wc_matches.match_num)
+        operator: 'bottom'
+        value: 12
+        options {
+          rank_by {
+            field: r(wc_matches.kickoff_utc)
+            aggregation: 'min'
+            logic: 'standard'
+          }
+        }
+      }
       rows: [
         VizFieldFull {
           label: 'MatchNum'
@@ -348,7 +363,6 @@ Func wc_match_cards() {
           }
         ]
         pagination_size: 12
-        row_limit: 12
         aggregate_awareness {
           enabled: true
           debug_comments: true
@@ -594,7 +608,6 @@ Func wc_featured_match() {
             direction: 'asc'
           }
         ]
-        row_limit: 1
         aggregate_awareness {
           enabled: true
           debug_comments: true
@@ -614,6 +627,19 @@ Func wc_boot_podium() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // Top 3 scorers via a 3rd-rank filter (not row_limit — that is dropped on MarkdownViz
+      // shareable links). The goals>0 guard stops zero-goal players (collapsed into one tie rank)
+      // from flooding the podium before anyone has scored.
+      filter {
+        field: r(wc_player_stats.goals)
+        operator: 'greater_than'
+        value: 0
+      }
+      filter {
+        field: r(wc_player_stats.goals_rank)
+        operator: 'less_than'
+        value: 4
+      }
       rows: [
         VizFieldFull {
           label: 'Scorer'
@@ -708,7 +734,6 @@ Func wc_boot_podium() {
           }
         ]
         pagination_size: 3
-        row_limit: 3
         aggregate_awareness {
           enabled: true
           debug_comments: true
@@ -725,10 +750,23 @@ Func wc_boot_rack() {
     }
     viz: MarkdownViz {
       dataset: worldcup
+      // The chasing pack = ranks 4–10. Bound both ends with rank filters (row_limit is dropped on
+      // MarkdownViz shareable links). The goals>0 guard is essential: zero-goal players collapse into
+      // one shared tie rank, which can fall inside 4–10 when few have scored and would flood the rack.
+      filter {
+        field: r(wc_player_stats.goals)
+        operator: 'greater_than'
+        value: 0
+      }
       filter {
         field: r(wc_player_stats.goals_rank)
         operator: 'greater_than'
         value: 3
+      }
+      filter {
+        field: r(wc_player_stats.goals_rank)
+        operator: 'less_than'
+        value: 11
       }
       rows: [
         VizFieldFull {
@@ -804,7 +842,6 @@ Func wc_boot_rack() {
           }
         ]
         pagination_size: 7
-        row_limit: 7
         aggregate_awareness {
           enabled: true
           debug_comments: true


### PR DESCRIPTION
## Overview
Removed `row_limit` settings from multiple World Cup 2026 dashboard blocks to prevent conflicts with pagination and ensure consistent data display on shareable MarkdownViz links. This change improves the accuracy and user experience when viewing top-ranked or filtered lists by relying solely on pagination and AQL filters.

## Changes
- Removed redundant `row_limit` settings from many blocks such as `wc_advance_board`, `wc_contenders`, `wc_group_card`, `wc_groups`, `wc_header_rail`, `wc_hist_editions`, `wc_history`, `wc_hq_pulse`, `wc_hq_rating`, `wc_knockout`, `wc_match_center`, `wc_player_gallery`, `wc_race_ladder`, `wc_squad`, `wc_standings`, `wc_team_hq`, and `wc_tournament`
- Added AQL filters to cap dataset results (e.g. Top-N ranks) where `row_limit` was previously used, ensuring shareable links honor limits despite `row_limit` being ignored in MarkdownViz
- Filters added include limiting top contenders by `odds_rank`, top players by `goal_contributions`, top scorers, assists ranks, upcoming fixtures by kickoff time, and historical team metrics by ranking
- These changes prevent over-fetching data and improve dashboard load performance and accuracy
- Removed deprecated or unnecessary `row_limit` in `settings` blocks that conflicted with pagination

This update aligns World Cup 2026 dashboards with best practices for pagination and filtering in Holistics dashboards and maintains reliable user experience on shareable visualizations.

## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=thuan-hm-dev

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)