### PR TITLE
Add FanServ Stadium theme and demo dashboard for sports media analytics

### DIFF
--- a/clients/fanserv/design.md
+++ b/clients/fanserv/design.md
@@ -1,0 +1,296 @@
+---
+version: alpha
+name: FanServ Stadium
+description: Visual identity and Holistics dashboard theme for fanserv.com.
+colors:
+  primary: "#009247"
+  primaryDark: "#045C30"
+  accent: "#00E66F"
+  pageDark: "#000000"
+  canvasDark: "#0A0A0A"
+  cardDark: "#111111"
+  cardDarkAlt: "#1A1A1A"
+  borderDark: "#1F1F1F"
+  borderDarkStrong: "#2A2A2A"
+  textOnDark: "#FAFAFA"
+  mutedOnDark: "#A6A6A6"
+  subtleOnDark: "#6F6F6F"
+  pageLight: "#F3F8F5"
+  canvasLight: "#FFFFFF"
+  cardLight: "#FFFFFF"
+  cardLightAlt: "#F7FBF8"
+  borderLight: "#DCEBE3"
+  borderLightStrong: "#BFD8CA"
+  textOnLight: "#06140D"
+  mutedOnLight: "#4B6356"
+  subtleOnLight: "#6C7F74"
+  success: "#00A85A"
+  warning: "#F59E0B"
+  danger: "#EF4444"
+  info: "#38BDF8"
+  neutral: "#A6A6A6"
+typography:
+  display:
+    fontFamily: Inter, Manrope, -apple-system, system-ui, Segoe UI, Roboto, sans-serif
+    fontSize: 30px
+    fontWeight: 800
+    lineHeight: 1.1
+    letterSpacing: -0.04em
+  heading:
+    fontFamily: Inter, Manrope, -apple-system, system-ui, Segoe UI, Roboto, sans-serif
+    fontSize: 24px
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: -0.03em
+  body:
+    fontFamily: Inter, Manrope, -apple-system, system-ui, Segoe UI, Roboto, sans-serif
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.5
+  labelCaps:
+    fontFamily: Inter, Manrope, -apple-system, system-ui, Segoe UI, Roboto, sans-serif
+    fontSize: 12px
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: 0.06em
+  kpiValue:
+    fontFamily: Inter, Manrope, -apple-system, system-ui, Segoe UI, Roboto, sans-serif
+    fontSize: 32px
+    fontWeight: 800
+    lineHeight: 1.1
+rounded:
+  sm: 8px
+  md: 12px
+  pill: 999px
+spacing:
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 32px
+components:
+  canvasDark:
+    backgroundColor: "{colors.canvasDark}"
+    textColor: "{colors.textOnDark}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.lg}"
+  canvasLight:
+    backgroundColor: "{colors.canvasLight}"
+    textColor: "{colors.textOnLight}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.lg}"
+  cardDark:
+    backgroundColor: "{colors.cardDark}"
+    textColor: "{colors.textOnDark}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  cardLight:
+    backgroundColor: "{colors.cardLight}"
+    textColor: "{colors.textOnLight}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  kpiCard:
+    backgroundColor: "{colors.cardLight}"
+    textColor: "{colors.textOnLight}"
+    typography: "{typography.kpiValue}"
+    rounded: "{rounded.md}"
+    padding: "{spacing.md}"
+  liveChip:
+    backgroundColor: "#EAF7F1"
+    textColor: "{colors.primaryDark}"
+    typography: "{typography.labelCaps}"
+    rounded: "{rounded.pill}"
+    padding: "4px 10px"
+---
+
+## Overview
+
+FanServ Stadium is a sports-media analytics identity for Holistics dashboards. It turns FanServ's public landing-page language — “Stadium”, “Scout AI”, “Live”, “The Playbook”, and “game day” — into a production dashboard system that feels operational, confident, and customer-facing.
+
+The source of truth is the public FanServ website rather than a separate brand-guidelines document. Sources used:
+
+- FanServ public landing page: https://fanserv.com/
+- FanServ Stadium launch press page: https://www.fanserv.com/press/fanserv-launches-stadium-platform
+- Browser inspection of `fanserv.com` on 2026-07-08, including computed colors, typography, assets, and the saved screenshot at `.amp/in/artifacts/fanserv-home-viewport-small.png`.
+
+The original brand read is dark, high-contrast, and broadcast-like: black surfaces, white copy, bright stadium green, compact live chips, glassy cards, and sports operations language. The current dashboard applies the light variant for executive readability while preserving FanServ green, live status, and stadium-card structure.
+
+## Colors
+
+FanServ green `#009247` is the primary brand color. `#045C30` is the deep green used for readable text, borders, and restrained emphasis. `#00E66F` is the dark-theme live accent and should be used sparingly for active states, glows, and high-contrast highlights.
+
+### Dark surface system
+
+Use the dark system when the dashboard should feel like a sports control room or broadcast operations surface.
+
+| Role | Token | Value |
+| --- | --- | --- |
+| Page | `pageDark` | `#000000` |
+| Canvas | `canvasDark` | `#0A0A0A` |
+| Card | `cardDark` | `#111111` |
+| Alternate card/table band | `cardDarkAlt` | `#1A1A1A` |
+| Border | `borderDark` | `#1F1F1F` |
+| Strong border/grid | `borderDarkStrong` | `#2A2A2A` |
+| Primary text | `textOnDark` | `#FAFAFA` |
+| Muted text | `mutedOnDark` | `#A6A6A6` |
+
+### Light surface system
+
+Use the light system for executive dashboards and review sessions where readability is more important than immersion.
+
+| Role | Token | Value |
+| --- | --- | --- |
+| Page | `pageLight` | `#F3F8F5` |
+| Canvas | `canvasLight` | `#FFFFFF` |
+| Card | `cardLight` | `#FFFFFF` |
+| Alternate card/table band | `cardLightAlt` | `#F7FBF8` |
+| Border | `borderLight` | `#DCEBE3` |
+| Strong border/grid | `borderLightStrong` | `#BFD8CA` |
+| Primary text | `textOnLight` | `#06140D` |
+| Muted text | `mutedOnLight` | `#4B6356` |
+
+### Semantic colors
+
+| Semantic | Token | Value | Use |
+| --- | --- | --- | --- |
+| Success | `success` | `#00A85A` | Positive KPI movement, success states |
+| Warning | `warning` | `#F59E0B` | Attention, pacing risk, incomplete work |
+| Danger | `danger` | `#EF4444` | Negative KPI movement, errors, missed targets |
+| Info | `info` | `#38BDF8` | Neutral information and links |
+| Neutral | `neutral` | `#A6A6A6` | Secondary annotations and low-emphasis chart marks |
+
+### Chart palettes
+
+Holistics currently documents AML `ColorPalette` support for categorical palettes only. The reusable theme file encodes the categorical palette in AML. Sequential and diverging palettes are design guidance for heatmaps, conditional formatting, custom charts, and future palette-as-code support.
+
+Categorical:
+
+```text
+#009247  FanServ green
+#00E66F  Live accent
+#38BDF8  Broadcast/info blue
+#2563EB  Playbook blue
+#F59E0B  Warning amber
+#F97316  Game-day orange
+#EF4444  Danger red
+#A855F7  Highlight violet
+#14B8A6  Teal
+#A6A6A6  Neutral gray
+```
+
+Sequential:
+
+```text
+#07120C  Lowest / no activity
+#0A2417
+#0B3A24
+#045C30
+#009247  Brand midpoint
+#00B85A
+#00E66F  Highest / live peak
+#C8FFE0  Optional highlight endpoint
+```
+
+Diverging:
+
+```text
+#7F1D1D  Strong negative
+#DC2626
+#F97316  Mild negative / warming
+#2A2A2A  Neutral on dark surfaces
+#0F766E  Mild positive
+#009247
+#00E66F  Strong positive
+```
+
+## Typography
+
+Use the landing-page stack across all dashboard text:
+
+```css
+Inter, Manrope, -apple-system, system-ui, "Segoe UI", Roboto, sans-serif
+```
+
+- Display titles use `display`: 30px, 800 weight, tight tracking.
+- Section headings use `heading`: 24px, 700 weight, tight tracking.
+- Body and helper copy use `body`: 13px, regular weight, 1.5 line height.
+- KPI labels and live chips use `labelCaps`: uppercase, 12px, 600 weight, 0.06em tracking.
+- KPI values use `kpiValue`: 32px, 800 weight, center-aligned in the dashboard theme.
+
+## Layout
+
+The dashboard layout should feel like a stadium control panel: a strong hero band at the top, a row of centered KPI scorecards, then paired analysis panels below.
+
+- Use a 1440px-wide canvas for desktop review.
+- Use generous horizontal spacing so the dashboard feels premium rather than dense.
+- Keep the hero/header short enough that KPIs are visible above the fold.
+- Put global filters in the hero band, right-aligned, so they feel like operational controls.
+- Use paired 50/50 analysis panels for comparable chart groups, such as revenue playbook and cost control.
+- Prefer center alignment for KPI cards and live-status chips.
+
+The current Holistics implementation is standalone AML content in `clients/fanserv/fanserv_demo_dashboard.page.aml`: hero/header blocks, date filter, KPI cards, trend charts, expense mix chart, monthly detail table, layout, interactions, and settings. It uses `theme: fanserv_stadium_light`.
+
+## Elevation & Depth
+
+Depth should be subtle. FanServ should feel polished and operational, not decorative.
+
+- Dark theme: use near-black cards with a low-opacity top highlight and green radial glow in the page/canvas background.
+- Light theme: use white cards, pale green borders, and soft shadows.
+- Use one-pixel borders for most separation; avoid heavy outlines.
+- Reserve glow for live/active elements, not every card.
+- Avoid stacking too many shadows. One card layer plus one canvas layer is enough.
+
+## Shapes
+
+Shapes should be simple and modern.
+
+- Cards: 12px radius.
+- Tables and filter containers: 12px radius when they are card-like, 8px when compact.
+- Live chip: pill radius (`999px`).
+- Avoid sharp-corner hero surfaces; they break the Stadium product feel.
+- Avoid overly rounded cards beyond 16px; they feel playful rather than enterprise-ready.
+
+## Components
+
+### Holistics theme assets
+
+- Reusable AML theme file: `clients/fanserv/fanserv.theme.aml`
+- Dark theme identifier: `fanserv_stadium`
+- Light theme identifier: `fanserv_stadium_light`
+- AML chart palette identifier: `fanserv_categorical_palette`
+- Applied dashboard: `clients/fanserv/fanserv_demo_dashboard.page.aml`
+
+### KPI cards
+
+KPI cards are center-aligned scorecards. Use uppercase muted labels, large values, and semantic trend chips. Do not rely on color alone for direction; preserve signs, arrows, or labels when available.
+
+### Live chip
+
+The live chip communicates real-time Stadium status. It uses the `liveChip` component tokens and embeds a small `data:image/gif` ping indicator that pulses every 5 seconds. This is intentionally embedded in the dashboard block so it remains visible even if dashboard markdown does not render pseudo-elements from theme CSS.
+
+### Tables
+
+Tables are operational detail surfaces. Use low-contrast grid lines, subtle banding, and green hover states. In light mode, table headers should be pale green with deep green text. In dark mode, table headers should use deep green with white text.
+
+### Filters
+
+Filters should look like control inputs, not plain form fields. Use green focus rings, compact labels, and card-level grouping when filters appear in hero/header areas.
+
+## Do's and Don'ts
+
+Do:
+
+- Use `#009247` as the brand anchor and `#045C30` when green needs to be readable on light backgrounds.
+- Use `#00E66F` for dark-theme live accents and active glows.
+- Keep dashboard copy direct and operational.
+- Use sports language sparingly: “Stadium”, “Playbook”, “Live”, and “game day” are useful accents, not a substitute for analytical labels.
+- Keep KPI cards center-aligned.
+- Keep the light theme as the current applied dashboard theme for executive readability.
+
+Don't:
+
+- Do not use `#009247` for small text on dark backgrounds; use `#00E66F` or white text instead.
+- Do not encode KPI direction by color alone.
+- Do not introduce extra brand colors beyond green, blue, amber, red, violet, teal, and neutral unless there is a chart-series need.
+- Do not overuse glow effects outside live/status affordances.
+- Do not duplicate the dashboard just to switch dark/light themes; switch the `theme:` reference unless the content also changes.

--- a/clients/fanserv/fanserv.theme.aml
+++ b/clients/fanserv/fanserv.theme.aml
@@ -1,0 +1,664 @@
+// =====================================================================
+// FanServ — Stadium dashboard theme
+// Source: fanserv.com landing page. Dark stadium UI, FanServ green,
+// live-status accent, Inter/Manrope type, and glassy operational cards.
+// Apply from a dashboard with: theme: fanserv_stadium
+// =====================================================================
+
+const fs_green = "#009247"
+const fs_green_dark = "#045C30"
+const fs_live = "#00E66F"
+const fs_black = "#000000"
+const fs_elevated = "#0A0A0A"
+const fs_card = "#111111"
+const fs_card_alt = "#1A1A1A"
+const fs_border = "#1F1F1F"
+const fs_border_strong = "#2A2A2A"
+const fs_text = "#FAFAFA"
+const fs_text_muted = "#A6A6A6"
+const fs_text_subtle = "#6F6F6F"
+const fs_success = "#00A85A"
+const fs_warning = "#F59E0B"
+const fs_danger = "#EF4444"
+const fs_info = "#38BDF8"
+const fs_font = "Inter, Manrope, -apple-system, system-ui, Segoe UI, Roboto, sans-serif"
+const fs_light_page = "#F3F8F5"
+const fs_light_canvas = "#FFFFFF"
+const fs_light_card = "#FFFFFF"
+const fs_light_card_alt = "#F7FBF8"
+const fs_light_border = "#DCEBE3"
+const fs_light_border_strong = "#BFD8CA"
+const fs_light_text = "#06140D"
+const fs_light_muted = "#4B6356"
+const fs_light_subtle = "#6C7F74"
+
+ColorPalette fanserv_categorical_palette {
+  title: "FanServ Stadium"
+  categorical {
+    colors: [
+      "#009247",
+      "#00E66F",
+      "#38BDF8",
+      "#2563EB",
+      "#F59E0B",
+      "#F97316",
+      "#EF4444",
+      "#A855F7",
+      "#14B8A6",
+      "#A6A6A6"
+    ]
+  }
+}
+
+PageTheme fanserv_stadium {
+  title: "FanServ Stadium"
+
+  color {
+    data: fanserv_categorical_palette
+  }
+
+  background {
+    bg_color: fs_black
+    bg_image: "radial-gradient(circle at 12% 0%, rgba(0, 146, 71, 0.20), transparent 34%), radial-gradient(circle at 88% 8%, rgba(56, 189, 248, 0.12), transparent 30%)"
+    bg_repeat: false
+    bg_size: "cover"
+  }
+
+  canvas {
+    background {
+      bg_color: fs_elevated
+      bg_image: "linear-gradient(180deg, rgba(0, 146, 71, 0.08), rgba(0, 0, 0, 0) 240px)"
+      bg_repeat: false
+      bg_size: "cover"
+    }
+    border {
+      border_width: 1
+      border_radius: 12
+      border_color: fs_border
+      border_style: "solid"
+    }
+    shadow: "md"
+    opacity: 1
+  }
+
+  block {
+    background {
+      bg_color: fs_card
+      bg_image: "linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0))"
+      bg_repeat: false
+      bg_size: "cover"
+    }
+    label {
+      font_family: fs_font
+      font_size: 14
+      font_color: fs_text
+      font_weight: "semibold"
+      letter_spacing: "0.01em"
+    }
+    text {
+      font_family: fs_font
+      font_size: 13
+      font_color: fs_text_muted
+      font_weight: "normal"
+    }
+    border {
+      border_width: 1
+      border_radius: 12
+      border_color: fs_border
+      border_style: "solid"
+    }
+    padding: 18
+    shadow: "sm"
+    opacity: 1
+  }
+
+  viz {
+    table {
+      general {
+        bg_color: fs_card
+        hover_color: "rgba(0, 146, 71, 0.14)"
+        banding_color: fs_card_alt
+        cell_padding: 10
+        font_color: fs_text
+        font_family: fs_font
+        font_size: 13
+        border_color: fs_border
+        border_width: 1
+        grid_color: fs_border_strong
+      }
+      header {
+        bg_color: fs_green_dark
+        font_color: "#FFFFFF"
+        font_size: 12
+        font_weight: "bold"
+      }
+      sub_header {
+        bg_color: fs_card_alt
+        font_color: fs_live
+        font_size: 12
+        font_weight: "semibold"
+      }
+      sub_title {
+        font_color: fs_text_muted
+        font_size: 11
+        font_weight: "medium"
+      }
+      sparkline {
+        line {
+          color: fs_live
+          width: 2
+        }
+        column {
+          color: fs_green
+          width: 4
+        }
+      }
+    }
+
+    metric_kpi {
+      alignment: "center"
+      label {
+        font_family: fs_font
+        font_size: 12
+        font_color: fs_text_muted
+        font_weight: "semibold"
+        letter_spacing: "0.06em"
+        text_transform: "uppercase"
+      }
+      value {
+        font_family: fs_font
+        font_size: 32
+        font_color: fs_text
+        font_weight: "extrabold"
+      }
+      trend {
+        positive {
+          text {
+            font_color: fs_live
+            font_weight: "bold"
+          }
+          background {
+            bg_color: "rgba(0, 168, 90, 0.16)"
+          }
+        }
+        negative {
+          text {
+            font_color: "#FF8A8A"
+            font_weight: "bold"
+          }
+          background {
+            bg_color: "rgba(239, 68, 68, 0.16)"
+          }
+        }
+        neutral {
+          text {
+            font_color: fs_text_muted
+            font_weight: "semibold"
+          }
+          background {
+            bg_color: "rgba(166, 166, 166, 0.14)"
+          }
+        }
+      }
+      progress {
+        text {
+          font_color: fs_text_muted
+          font_size: 12
+        }
+        indicator {
+          bg_color: fs_green
+        }
+        track {
+          bg_color: fs_border_strong
+        }
+      }
+    }
+  }
+
+  custom_css: @css
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap');
+
+    :root {
+      --fanserv-green: #009247;
+      --fanserv-green-dark: #045C30;
+      --fanserv-live: #00E66F;
+      --fanserv-card: #111111;
+      --fanserv-card-alt: #1A1A1A;
+      --fanserv-border: #1F1F1F;
+      --fanserv-text: #FAFAFA;
+      --fanserv-heading: #FAFAFA;
+      --fanserv-muted: #A6A6A6;
+      --fanserv-success: #00A85A;
+      --fanserv-warning: #F59E0B;
+      --fanserv-danger: #EF4444;
+      --fanserv-info: #38BDF8;
+      --fanserv-hero-bg: radial-gradient(circle at 16% 0%, rgba(0,230,111,0.20), transparent 34%), linear-gradient(135deg, rgba(0,146,71,0.22), rgba(17,17,17,0.94) 58%, rgba(0,0,0,0.98));
+      --fanserv-hero-border: rgba(0,146,71,0.30);
+      --fanserv-panel-bg: rgba(17,17,17,0.72);
+      --fanserv-panel-border: rgba(0,146,71,0.20);
+    }
+
+    .h-kpi-metric {
+      letter-spacing: -0.01em;
+    }
+
+    .h-kpi-metric-label {
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .h-kpi-metric-diff .friendly-diff:not(.negative) {
+      background: rgba(0, 168, 90, 0.16);
+      color: var(--fanserv-live);
+      border-color: rgba(0, 230, 111, 0.28);
+    }
+
+    .h-kpi-metric-diff .friendly-diff.negative {
+      background: rgba(239, 68, 68, 0.16);
+      color: #FF8A8A;
+      border-color: rgba(239, 68, 68, 0.28);
+    }
+
+    .h-theme-control-block .h-theme-dm-filter-container .dm-filter-form,
+    .dac-ic-block .hui-select-trigger,
+    .dac-ic-block .h-input {
+      background: rgba(17, 17, 17, 0.88);
+      border-color: rgba(0, 146, 71, 0.32);
+      color: var(--fanserv-text);
+      box-shadow: 0 0 0 1px rgba(0, 146, 71, 0.08);
+    }
+
+    .dac-ic-block .hui-select-trigger:focus,
+    .dac-ic-block .h-input:focus {
+      border-color: var(--fanserv-live);
+      box-shadow: 0 0 0 3px rgba(0, 230, 111, 0.14);
+    }
+
+    .fanserv-live-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid rgba(0, 230, 111, 0.32);
+      border-radius: 999px;
+      padding: 4px 10px;
+      background: rgba(0, 146, 71, 0.16);
+      color: var(--fanserv-live);
+      font: 700 12px Inter, Manrope, sans-serif;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .fanserv-live-chip::before {
+      content: none;
+    }
+
+    .fanserv-live-ping-gif {
+      position: relative;
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      border-radius: 999px;
+      background: var(--fanserv-live);
+      box-shadow: 0 0 12px rgba(0, 230, 111, 0.72);
+      flex: none;
+    }
+
+    .fanserv-live-ping-gif::after {
+      content: '';
+      position: absolute;
+      inset: -5px;
+      border: 1px solid currentColor;
+      border-radius: inherit;
+      opacity: 0;
+      animation: fanserv-live-ping 5s cubic-bezier(0, 0, 0.2, 1) infinite;
+    }
+
+    @keyframes fanserv-live-ping {
+      0% {
+        opacity: 0.72;
+        transform: scale(0.65);
+      }
+      70%, 100% {
+        opacity: 0;
+        transform: scale(1.85);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .fanserv-live-ping-gif::after {
+        animation: none;
+      }
+    }
+
+    .fanserv-hero-title {
+      margin: 0;
+      color: var(--fanserv-text);
+      font: 800 30px/1.1 Inter, Manrope, sans-serif;
+      letter-spacing: -0.04em;
+    }
+
+    .fanserv-muted {
+      color: var(--fanserv-muted);
+    }
+  ;;
+}
+
+PageTheme fanserv_stadium_light {
+  title: "FanServ Stadium Light"
+
+  color {
+    data: fanserv_categorical_palette
+  }
+
+  background {
+    bg_color: fs_light_page
+    bg_image: "radial-gradient(circle at 10% 0%, rgba(0, 146, 71, 0.14), transparent 32%), radial-gradient(circle at 88% 10%, rgba(56, 189, 248, 0.10), transparent 28%)"
+    bg_repeat: false
+    bg_size: "cover"
+  }
+
+  canvas {
+    background {
+      bg_color: fs_light_canvas
+      bg_image: "linear-gradient(180deg, rgba(0, 146, 71, 0.07), rgba(255, 255, 255, 0) 260px)"
+      bg_repeat: false
+      bg_size: "cover"
+    }
+    border {
+      border_width: 1
+      border_radius: 12
+      border_color: fs_light_border
+      border_style: "solid"
+    }
+    shadow: "md"
+    opacity: 1
+  }
+
+  block {
+    background {
+      bg_color: fs_light_card
+      bg_image: "linear-gradient(180deg, rgba(0, 146, 71, 0.035), rgba(255, 255, 255, 0))"
+      bg_repeat: false
+      bg_size: "cover"
+    }
+    label {
+      font_family: fs_font
+      font_size: 14
+      font_color: fs_light_text
+      font_weight: "semibold"
+      letter_spacing: "0.01em"
+    }
+    text {
+      font_family: fs_font
+      font_size: 13
+      font_color: fs_light_muted
+      font_weight: "normal"
+    }
+    border {
+      border_width: 1
+      border_radius: 12
+      border_color: fs_light_border
+      border_style: "solid"
+    }
+    padding: 18
+    shadow: "sm"
+    opacity: 1
+  }
+
+  viz {
+    table {
+      general {
+        bg_color: fs_light_card
+        hover_color: "rgba(0, 146, 71, 0.10)"
+        banding_color: fs_light_card_alt
+        cell_padding: 10
+        font_color: fs_light_text
+        font_family: fs_font
+        font_size: 13
+        border_color: fs_light_border
+        border_width: 1
+        grid_color: fs_light_border
+      }
+      header {
+        bg_color: "#EAF7F1"
+        font_color: fs_green_dark
+        font_size: 12
+        font_weight: "bold"
+      }
+      sub_header {
+        bg_color: fs_light_card_alt
+        font_color: fs_green_dark
+        font_size: 12
+        font_weight: "semibold"
+      }
+      sub_title {
+        font_color: fs_light_muted
+        font_size: 11
+        font_weight: "medium"
+      }
+      sparkline {
+        line {
+          color: fs_green
+          width: 2
+        }
+        column {
+          color: fs_green
+          width: 4
+        }
+      }
+    }
+
+    metric_kpi {
+      alignment: "center"
+      label {
+        font_family: fs_font
+        font_size: 12
+        font_color: fs_light_muted
+        font_weight: "semibold"
+        letter_spacing: "0.06em"
+        text_transform: "uppercase"
+      }
+      value {
+        font_family: fs_font
+        font_size: 32
+        font_color: fs_light_text
+        font_weight: "extrabold"
+      }
+      trend {
+        positive {
+          text {
+            font_color: fs_green_dark
+            font_weight: "bold"
+          }
+          background {
+            bg_color: "rgba(0, 146, 71, 0.12)"
+          }
+        }
+        negative {
+          text {
+            font_color: "#B91C1C"
+            font_weight: "bold"
+          }
+          background {
+            bg_color: "rgba(239, 68, 68, 0.12)"
+          }
+        }
+        neutral {
+          text {
+            font_color: fs_light_muted
+            font_weight: "semibold"
+          }
+          background {
+            bg_color: "rgba(108, 127, 116, 0.12)"
+          }
+        }
+      }
+      progress {
+        text {
+          font_color: fs_light_muted
+          font_size: 12
+        }
+        indicator {
+          bg_color: fs_green
+        }
+        track {
+          bg_color: fs_light_border
+        }
+      }
+    }
+  }
+
+  custom_css: @css
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Manrope:wght@400;500;600;700;800&display=swap');
+
+    :root {
+      --fanserv-green: #009247;
+      --fanserv-green-dark: #045C30;
+      --fanserv-live: #009247;
+      --fanserv-card: #FFFFFF;
+      --fanserv-card-alt: #F7FBF8;
+      --fanserv-border: #DCEBE3;
+      --fanserv-text: #06140D;
+      --fanserv-heading: #06140D;
+      --fanserv-muted: #4B6356;
+      --fanserv-success: #00A85A;
+      --fanserv-warning: #B45309;
+      --fanserv-danger: #B91C1C;
+      --fanserv-info: #0369A1;
+      --fanserv-hero-bg: radial-gradient(circle at 16% 0%, rgba(0,146,71,0.18), transparent 34%), linear-gradient(135deg, rgba(234,247,241,0.98), rgba(255,255,255,0.96) 58%, rgba(246,251,248,0.98));
+      --fanserv-hero-border: rgba(0,146,71,0.24);
+      --fanserv-panel-bg: rgba(255,255,255,0.88);
+      --fanserv-panel-border: rgba(0,146,71,0.18);
+    }
+
+    .h-kpi-metric {
+      letter-spacing: -0.01em;
+    }
+
+    .h-kpi-metric-label {
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+
+    .h-kpi-metric-diff .friendly-diff:not(.negative) {
+      background: rgba(0, 146, 71, 0.12);
+      color: var(--fanserv-green-dark);
+      border-color: rgba(0, 146, 71, 0.22);
+    }
+
+    .h-kpi-metric-diff .friendly-diff.negative {
+      background: rgba(239, 68, 68, 0.12);
+      color: #B91C1C;
+      border-color: rgba(239, 68, 68, 0.22);
+    }
+
+    .h-theme-control-block .h-theme-dm-filter-container .dm-filter-form,
+    .dac-ic-block .hui-select-trigger,
+    .dac-ic-block .h-input {
+      background: rgba(255, 255, 255, 0.92);
+      border-color: rgba(0, 146, 71, 0.24);
+      color: var(--fanserv-text);
+      box-shadow: 0 0 0 1px rgba(0, 146, 71, 0.05);
+    }
+
+    .dac-ic-block .hui-select-trigger:focus,
+    .dac-ic-block .h-input:focus {
+      border-color: var(--fanserv-green);
+      box-shadow: 0 0 0 3px rgba(0, 146, 71, 0.12);
+    }
+
+    .fanserv-live-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      border: 1px solid rgba(0, 146, 71, 0.24);
+      border-radius: 999px;
+      padding: 4px 10px;
+      background: rgba(0, 146, 71, 0.10);
+      color: var(--fanserv-green-dark);
+      font: 700 12px Inter, Manrope, sans-serif;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .fanserv-live-chip::before {
+      content: none;
+    }
+
+    .fanserv-live-ping-gif {
+      position: relative;
+      display: inline-block;
+      width: 7px;
+      height: 7px;
+      border-radius: 999px;
+      background: var(--fanserv-green);
+      box-shadow: 0 0 10px rgba(0, 146, 71, 0.45);
+      flex: none;
+    }
+
+    .fanserv-live-ping-gif::after {
+      content: '';
+      position: absolute;
+      inset: -5px;
+      border: 1px solid currentColor;
+      border-radius: inherit;
+      opacity: 0;
+      animation: fanserv-live-ping 5s cubic-bezier(0, 0, 0.2, 1) infinite;
+    }
+
+    @keyframes fanserv-live-ping {
+      0% {
+        opacity: 0.72;
+        transform: scale(0.65);
+      }
+      70%, 100% {
+        opacity: 0;
+        transform: scale(1.85);
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .fanserv-live-ping-gif::after {
+        animation: none;
+      }
+    }
+
+    .fanserv-hero-title {
+      margin: 0;
+      color: var(--fanserv-heading);
+      font: 800 30px/1.1 Inter, Manrope, sans-serif;
+      letter-spacing: -0.04em;
+    }
+
+    .fanserv-muted {
+      color: var(--fanserv-muted);
+    }
+  ;;
+}
+
+BlockTheme fanserv_transparent_block {
+  background {
+    bg_color: "transparent"
+  }
+  border {
+    border_width: 0
+    border_radius: 0
+    border_style: "none"
+  }
+  padding: 0
+  shadow: "none"
+}
+
+BlockTheme fanserv_glass_block {
+  background {
+    bg_color: "rgba(17, 17, 17, 0.72)"
+  }
+  border {
+    border_width: 1
+    border_radius: 12
+    border_color: "rgba(0, 146, 71, 0.28)"
+    border_style: "solid"
+  }
+  padding: 18
+  shadow: "sm"
+}

--- a/clients/fanserv/fanserv_demo_dashboard.page.aml
+++ b/clients/fanserv/fanserv_demo_dashboard.page.aml
@@ -440,7 +440,7 @@ Dashboard fanserv_demo_dashboard {
     tab view_1: CanvasLayout {
       label: 'Tab 1'
       width: 1440
-      height: 1580
+      height: 1600
       block hero_bg {
         position: pos(20, 20, 1400, 220)
         layer: -1

--- a/clients/fanserv/fanserv_demo_dashboard.page.aml
+++ b/clients/fanserv/fanserv_demo_dashboard.page.aml
@@ -1,0 +1,528 @@
+Dashboard fanserv_demo_dashboard {
+  title: 'FanServ Stadium Demo Dashboard'
+  description: '''FanServ-branded standalone dashboard for validating the reusable Stadium theme with real finance and operating-performance content.'''
+  theme: fanserv_stadium_light
+
+  block hero_bg: TextBlock {
+    content: @md <div style="width:100%;height:100%;border-radius:12px;background:var(--fanserv-hero-bg);border:1px solid var(--fanserv-hero-border);"></div>;;
+    theme: fanserv_transparent_block
+  }
+
+  block hero_copy: TextBlock {
+    content: @md <h1 class="fanserv-hero-title">FanServ Stadium Analytics</h1>
+<p class="fanserv-muted" style="max-width:780px;margin-top:12px;font-size:15px;line-height:1.5;">Campaign, revenue, and audience operating signals for sports media teams that need game-day clarity without spreadsheet handoffs.</p>;;
+    theme: fanserv_transparent_block
+  }
+
+  block live_chip: TextBlock {
+    content: @md <span class="fanserv-live-chip" style="display:inline-flex;align-items:center;gap:8px;border:1px solid rgba(0,146,71,0.24);border-radius:999px;padding:4px 10px;background:rgba(0,146,71,0.10);color:#045C30;font:700 12px Inter, Manrope, sans-serif;letter-spacing:0.08em;text-transform:uppercase;"><img src="data:image/gif;base64,R0lGODlhHAAcAPIFAAAAAACSRwCSRwCSRwCSR////wAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh+QQJMgAAACwAAAAAHAAcAAADOAi63P4wykmrvTjrzbv/WCAQQuANRJoOXKC+pja+qbDR7zbTtubiMQ3qxeqISEGQcslsOp/QKCQBACH5BAkyAAAALAAAAAAcABwAgwAAAACSRwCSRwCSRwCSRwCSRwCSRwCSRwCSR////wAAAAAAAAAAAAAAAAAAAAAAAARPEMhJq7046827/2AojmRpboEwCEFJDIWBGMVAjMOB7PsxiIECb1hogQSy4c4gCA2Uw98xqWSGglBEUZRT+kav2Kx2I6VWxpN6zW673/BSBAAh+QQJMgAAACwAAAAAHAAcAIMAAAAAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkf///8AAAAAAAAAAAAEZRDISau9OOvNu/9gKI5kSQXCQAxCQBbGIctGIRYykiwJItufQEyxKBYVB4PLIzggjFCf4DM47KDFxGHwIRyw0AOBagXztp/mEywNDrFIJQjn3PV+t9gsCRShVCxLJoOEhYaHiIkRACH5BAkyAAAALAAAAAAcABwAgwAAAACSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSR////wAAAAAAAAR7EMhJq7046827/2AojmEgDMQgBGRhvLBRiAN8EAc8gK5BIAlGAkF4zTqBF0HBaDYVRQOLI3ghnFjES9CpHYLYZiK34xQJYey5a/imheRO1XBNaw1cTtLHxEJfUxw9P0FDUUceNS83OS9lPDEwiCUnCyqBJJmam5ydnh4RACH5BAkyAAAALAAAAAAcABwAhAAAAACSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSRwCSR////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAW4ICCOZGmeaKqubOu+8CsMREEMQiwaB+L/iIMBNgAmCgngwFVEKBaBUWCh8C1XBl+CcWIkEUNVT8EFNBwQR0PEqB5UAt9C9IDY7Q/RwpdDNaMNd4JrAVYpBAgJImiCdg4iSQQpBQgFIo2CIpSWKIiKAIyNjwCRKX9mmBCEhihxCHMAdYJ5AHsIfShjZWdpawBtQVhaZSVePmEqTU9RIlNVCFcsTVpISjA8QD9COgAzNTe43OLj5OUuIQAh+QQJMgAAACwAAAAAHAAcAIQAAAAAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkf///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFvSAgjmRpnmiqrmzrvqMwEAUxCPBoHEjvIwfDK1H4KQqKXyHBSix6CkaJkUQsmKoiYpAa9AoqQ4+r8iKEKJ6C1HBAHA1S8oAS9KSiB2S/f4wYPTgmZgEiDXyIcQABYycECGsiboh7DiNJBCdFYCKUiCObjpAjk5SWIpgnhIaeEIqMWyd2CHgAeoh+IoAIgiZqbG5wckApYrFlPWgoWmSqXytOULW6VVdNWlBISlgtOz8+QTkiMjQ2veLo6eotIQAh+QQJMgAAACwAAAAAHAAcAIQAAAAAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkf///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF2CAgjmRpnmiqrmw7BsJAFMQgBO47GEfvH4YBriVA+BKKgiLhQwhYCx+BUWIQfAuVoJd4ogTMg9cUMCYaqwYTMSwNemNtb0DmEUqOR+ThKF0NbSJbB1QjEBGIiBAkDHBuBwkkDomUfSNMdCRXCiR6lIgPJAoHdyQFBwUkn5SmqH4HnCOen6Ejo6Ujb5Ejk6uWIpglg4Uih5SLI41iJQF2eHp8r4Amb8ssg5nMZmgqagdsX1xxwmHjJVE9U1VXPVkrRUdJS03mKAE7Pz5BgS0wMjQ2+OUYSJBFCAAh+QQJMgAAACwAAAAAHAAcAIQAAAAAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkcAkkf///8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF3CAgjmRpnmiqroEwEAUxCMFqGgei7/th2KIET7EoLBS8BIuwG/xIhsGOUEMxEYXnyVDQEVBCxAGYQyhLBl0BKOoitKIyfJUWkwK6gYnReDQYJlIIVQACOnMOD4qKDmg6AiNSCiUMi5aAJEh6IkwLJX2Wig0lCwhfbVgloZYlXWucCJ4koKGjJKWnAJKUqw+YI5ojhm8liZaNUI8jeAibJHx+v5E6hABybAB1Y8mpbG5zAGHbK2VnJldZKVxeKQFXzXNRU9UnYTpERkg75nRlPD3gWLiAIYMGtoMmQgAAIfkECTIAAAAsAAAAABwAHAAAAzgIutz+MMpJq7046827/1ggEELgDUSaDlygvqY2vqmw0e8207bm4jEN6sXqiEhBkHLJbDqf0CgkAQAh+QQJMgAAACwAAAAAHAAcAAADOAi63P4wykmrvTjrzbv/WCAQQuANRJoOXKC+pja+qbDR7zbTtubiMQ3qxeqISEGQcslsOp/QKCQBADs=" alt="" aria-hidden="true" style="width:20px;height:20px;display:block;flex:none;" />Stadium Live</span>;;
+    theme: fanserv_transparent_block
+  }
+
+  block f_date: FilterBlock {
+    label: 'Date Range'
+    type: 'field'
+    source: FieldFilterSource {
+      dataset: demo_finance_extended
+      field: ref('dim_dates', 'date_key')
+    }
+    default {
+      operator: 'matches'
+      value: 'last 12 months'
+    }
+  }
+
+  block kpi_gmv: VizBlock {
+    label: 'Booked Media Value'
+    viz: MetricKpi {
+      dataset: demo_finance_extended
+      value: VizFieldFull {
+        label: 'Booked Media Value'
+        ref: 'gmv'
+        format {
+          type: 'number'
+          pattern: 'inherited'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: ref('dim_dates', 'date_key')
+        duration: 1
+        granularity: 'year'
+      }
+      settings {
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+
+  block kpi_nmv: VizBlock {
+    label: 'Net Media Value'
+    viz: MetricKpi {
+      dataset: demo_finance_extended
+      value: VizFieldFull {
+        label: 'Net Media Value'
+        ref: 'nmv'
+        format {
+          type: 'number'
+          pattern: 'inherited'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: ref('dim_dates', 'date_key')
+        duration: 1
+        granularity: 'year'
+      }
+      settings {
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+
+  block kpi_profit: VizBlock {
+    label: 'Net Profit'
+    viz: MetricKpi {
+      dataset: demo_finance_extended
+      value: VizFieldFull {
+        label: 'Net Profit'
+        ref: 'net_profit'
+        format {
+          type: 'number'
+          pattern: 'inherited'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: ref('dim_dates', 'date_key')
+        duration: 1
+        granularity: 'year'
+      }
+      settings {
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+
+  block kpi_cash: VizBlock {
+    label: 'Cash Balance'
+    viz: MetricKpi {
+      dataset: demo_finance_extended
+      value: VizFieldFull {
+        label: 'Cash Balance'
+        ref: 'total_cash_balance'
+        format {
+          type: 'number'
+          pattern: 'inherited'
+        }
+      }
+      compare_value: VizPopSettings {
+        field: ref('dim_dates', 'date_key')
+        duration: 1
+        granularity: 'year'
+      }
+      settings {
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+    settings {
+      hide_label: true
+    }
+  }
+
+  block revenue_trend_title: TextBlock {
+    content: @md <h2 style="margin:0;color:var(--fanserv-heading);font:700 24px Inter, Manrope, sans-serif;letter-spacing:-0.03em;">Revenue Playbook</h2>;;
+    theme: fanserv_transparent_block
+  }
+
+  block cost_trend_title: TextBlock {
+    content: @md <h2 style="margin:0;color:var(--fanserv-heading);font:700 24px Inter, Manrope, sans-serif;letter-spacing:-0.03em;">Cost Control</h2>;;
+    theme: fanserv_transparent_block
+  }
+
+  block revenue_trend: VizBlock {
+    label: 'Revenue, Cost, and Profit Trend'
+    viz: CombinationChart {
+      dataset: demo_finance_extended
+      filter {
+        field: ref('dim_dates', 'date_key')
+        operator: 'after'
+        value: '2024-01-01'
+      }
+      x_axis: VizFieldFull {
+        ref: ref('dim_dates', 'date_key')
+        transformation: 'datetrunc month'
+        format {
+          type: 'date'
+          pattern: 'LLL yyyy'
+        }
+      }
+      y_axis {
+        settings {
+          show_data_label_by: 'value'
+        }
+        series {
+          field: VizFieldFull {
+            label: 'Net Media Value'
+            ref: 'nmv'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+        }
+        series {
+          field: VizFieldFull {
+            label: 'Total Cost'
+            ref: 'total_cost'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+        }
+        series {
+          mark_type: 'line'
+          field: VizFieldFull {
+            label: 'Net Profit'
+            ref: 'net_profit'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+          settings {
+            color: '#00E66F'
+          }
+        }
+      }
+      settings {
+        row_limit: 5000
+        x_axis_show_null_datetime: false
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+  }
+
+  block cost_budget_trend: VizBlock {
+    label: 'COGS, Operating Cost, and Budget'
+    viz: CombinationChart {
+      dataset: demo_finance_extended
+      x_axis: VizFieldFull {
+        ref: ref('dim_dates', 'date_key')
+        transformation: 'datetrunc month'
+        format {
+          type: 'date'
+          pattern: 'LLL yyyy'
+        }
+      }
+      y_axis {
+        settings {
+          show_data_label_by: 'value'
+          stack_series_by: 'value'
+        }
+        series {
+          field: VizFieldFull {
+            label: 'Cost of Goods Sold'
+            ref: 'cost_of_goods_sold'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+        }
+        series {
+          field: VizFieldFull {
+            label: 'Operating Cost'
+            ref: 'cost_of_operations'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+        }
+        series {
+          mark_type: 'line'
+          field: VizFieldFull {
+            label: 'Expense Budget'
+            ref: 'expense_budgets'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+          settings {
+            color: '#F59E0B'
+          }
+        }
+      }
+      settings {
+        row_limit: 5000
+        x_axis_show_null_datetime: false
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+  }
+
+  block expense_mix: VizBlock {
+    label: 'Operating Expenses by Category'
+    viz: ColumnChart {
+      dataset: demo_finance_extended
+      x_axis: VizFieldFull {
+        ref: ref('dim_dates', 'date_key')
+        transformation: 'datetrunc month'
+        format {
+          type: 'date'
+          pattern: 'LLL yyyy'
+        }
+      }
+      legend: VizFieldFull {
+        ref: ref('ecommerce_operating_expenses', 'category')
+        format {
+          type: 'text'
+        }
+      }
+      y_axis {
+        settings {
+          show_stack_total: true
+          stack_series_by: 'value'
+        }
+        series {
+          field: VizFieldFull {
+            label: 'Operating Cost'
+            ref: 'cost_of_operations'
+            format {
+              type: 'number'
+              pattern: 'inherited'
+            }
+          }
+        }
+      }
+      settings {
+        row_limit: 5000
+        x_axis_show_null_datetime: false
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+      }
+    }
+  }
+  block monthly_table: VizBlock {
+    label: 'Monthly Performance Detail'
+    viz: DataTable {
+      dataset: demo_finance_extended
+      fields: [
+        VizFieldFull {
+          label: 'Month'
+          ref: r(dim_dates.date_key)
+          transformation: 'datetrunc month'
+          format {
+            type: 'date'
+            pattern: 'LLL yyyy'
+          }
+          uname: 'month'
+        },
+        VizFieldFull {
+          label: 'Booked Media Value'
+          ref: r(demo_finance_extended.gmv)
+          format {
+            type: 'number'
+            pattern: 'inherited'
+          }
+          uname: 'custom_gmv'
+        },
+        VizFieldFull {
+          label: 'Net Media Value'
+          ref: r(demo_finance_extended.nmv)
+          format {
+            type: 'number'
+            pattern: 'inherited'
+          }
+          uname: 'custom_nmv'
+        },
+        VizFieldFull {
+          label: 'Total Cost'
+          ref: r(demo_finance_extended.total_cost)
+          format {
+            type: 'number'
+            pattern: 'inherited'
+          }
+          uname: 'custom_total_cost'
+        },
+        VizFieldFull {
+          label: 'Net Profit'
+          ref: r(demo_finance_extended.net_profit)
+          format {
+            type: 'number'
+            pattern: 'inherited'
+          }
+          uname: 'custom_net_profit'
+        },
+        VizFieldFull {
+          label: 'Cash Balance'
+          ref: r(demo_finance_extended.total_cash_balance)
+          format {
+            type: 'number'
+            pattern: 'inherited'
+          }
+          uname: 'custom_total_cash_balance'
+        }
+      ]
+      settings {
+        sorts: [
+          SortSetting {
+            key: 'month'
+            direction: 'desc'
+          }
+        ]
+        row_limit: 5000
+        aggregate_awareness {
+          enabled: true
+          debug_comments: true
+        }
+        column_styles: [
+          ColumnStyle {
+            key: 'month'
+            width: 106
+          },
+          ColumnStyle {
+            key: 'custom_gmv'
+            width: 187
+          },
+          ColumnStyle {
+            key: 'custom_nmv'
+            width: 164
+          },
+          ColumnStyle {
+            key: 'custom_total_cost'
+            width: 127
+          },
+          ColumnStyle {
+            key: 'custom_net_profit'
+            width: 124
+          },
+          ColumnStyle {
+            key: 'custom_total_cash_balance'
+            width: 148
+          }
+        ]
+      }
+    }
+  }
+
+  view: TabLayout {
+    label: 'View 1'
+    tab view_1: CanvasLayout {
+      label: 'Tab 1'
+      width: 1440
+      height: 1580
+      block hero_bg {
+        position: pos(20, 20, 1400, 220)
+        layer: -1
+      }
+      block hero_copy {
+        position: pos(60, 72, 880, 110)
+        layer: 1
+      }
+      block live_chip {
+        position: pos(1258, 36, 220, 60)
+        layer: 1
+      }
+      block f_date {
+        position: pos(1148, 138, 260, 90)
+        layer: 1
+      }
+      block kpi_gmv {
+        position: pos(20, 270, 350, 120)
+      }
+      block kpi_nmv {
+        position: pos(390, 270, 350, 120)
+      }
+      block kpi_profit {
+        position: pos(750, 270, 320, 120)
+      }
+      block kpi_cash {
+        position: pos(1090, 270, 340, 120)
+      }
+      block revenue_trend_title {
+        position: pos(20, 420, 650, 40)
+      }
+      block cost_trend_title {
+        position: pos(740, 420, 650, 40)
+      }
+      block revenue_trend {
+        position: pos(20, 480, 690, 410)
+      }
+      block cost_budget_trend {
+        position: pos(730, 480, 690, 410)
+      }
+      block expense_mix {
+        position: pos(20, 930, 690, 660)
+      }
+      block monthly_table {
+        position: pos(730, 930, 690, 660)
+      }
+      default_zoom: 'fit_to_page'
+    }
+    tab tab_4ehm: CanvasLayout {
+      label: 'Tab 2'
+      width: 1300
+      height: 800
+      grid_size: 20
+      auto_expand_vertically: true
+      mobile {
+        mode: 'auto'
+      }
+    }
+  }
+
+  interactions: [
+    FilterInteraction {
+      from: 'f_date'
+      to: [
+        CustomMapping {
+          block: [
+            'kpi_gmv',
+            'kpi_nmv',
+            'kpi_profit',
+            'kpi_cash',
+            'revenue_trend',
+            'cost_budget_trend',
+            'expense_mix',
+            'monthly_table'
+          ]
+          field: ref('dim_dates', 'date_key')
+        }
+      ]
+    }
+  ]
+
+  settings {
+    autorun_on_open: true
+  }
+}


### PR DESCRIPTION
## Overview

Custom theme for FanServ. Note: this is non-official, demo-purpose only.

<img width="802" height="897" alt="CleanShot 2026-07-08 at 12 01 04" src="https://github.com/user-attachments/assets/d161489b-a282-4ec3-b533-e3f7b8e7e694" />

<img width="791" height="882" alt="CleanShot 2026-07-08 at 12 01 55" src="https://github.com/user-attachments/assets/f7c84a3b-3c86-4335-81ec-d0854f0f43ca" />

## Changes

- Introduced `fanserv_stadium` and `fanserv_stadium_light` page themes with dark and light variants, including colors, typography, layout, and custom CSS matching FanServ’s branding
- Created `fanserv_categorical_palette` color palette consistent with FanServ green and accent colors for categorical charting
- Added reusable block themes `fanserv_transparent_block` and `fanserv_glass_block` for styling dashboard components
- Built `fanserv_demo_dashboard` dashboard showcasing KPIs, trend charts, expense breakdowns, and monthly tables using the new theme
- The demo dashboard uses real finance and operating-performance datasets with date filters and aggregate-aware metrics
- Design documentation added in `clients/fanserv/design.md` describing visual identity principles, color systems, typography, layout, and component usage aligned to FanServ's public website

This work lays the foundation for consistent, operationally-focused dashboards tailored to FanServ’s brand, facilitating better decision-making and communication across sports media teams.

## Holistics

Review this PR in Holistics at: https://demo4.holistics.io/studio/projects/7/explore?branch=poc/custom-theme-fanserv

Holistics will automatically deploy these changes when this PR is merged. For more information about the deployment process, see [PR Deployment](https://docs.holistics.io/docs/continuous-integration/pr-workflow-auto-deploy)